### PR TITLE
Fix Next.js build regressions

### DIFF
--- a/app/copilot/page.tsx
+++ b/app/copilot/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";

--- a/app/gap-map/page.tsx
+++ b/app/gap-map/page.tsx
@@ -13,7 +13,7 @@ export default function GapMap() {
           <li key={g.id} className="p-3 text-sm flex items-center justify-between">
             <div>
               <div className="font-medium">{g.title}</div>
-              <div className="text-gray-500">Tier {g.tier} • Impact ${"{:,}".format(g.impact)}</div>
+              <div className="text-gray-500">Tier {g.tier} • Impact ${g.impact.toLocaleString()}</div>
             </div>
             <button className="rounded px-3 py-1 border bg-gray-50 hover:bg-gray-100">Add to Blueprint</button>
           </li>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,1 @@
+@import "../styles/globals.css";

--- a/app/partner/page.tsx
+++ b/app/partner/page.tsx
@@ -14,7 +14,7 @@ export default function Partner() {
               <td className="p-2">{p.name}</td>
               <td className="p-2">{p.overlap}</td>
               <td className="p-2">{p.influence}</td>
-              <td className="p-2">${"{:,}".format(p.pipeline)}</td>
+              <td className="p-2">${p.pipeline.toLocaleString()}</td>
               <td className="p-2"><button className="underline">Draft rev-share</button></td>
             </tr>
           ))}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
@@ -11,10 +15,30 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "allowJs": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- mark the copilot route as a client component so React hooks can be used safely
- add an app-level globals.css shim so the layout can load Tailwind styles
- format currency values with toLocaleString to satisfy TypeScript
- align Next.js generated TypeScript config metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6162ea60083248afd4dcf5cd3c31a