### PR TITLE
Add deliverable serializer module

### DIFF
--- a/lib/deliverables/serialize.ts
+++ b/lib/deliverables/serialize.ts
@@ -1,0 +1,16 @@
+import type { DeliverableResponse } from '@/lib/deliverables/types'
+import type { DeliverableRecord } from '@/lib/repos/deliverable-repository'
+
+export const serializeDeliverable = (record: DeliverableRecord): DeliverableResponse => ({
+  id: record.id,
+  accountId: record.accountId,
+  type: record.type,
+  title: record.title,
+  status: record.status,
+  owner: record.owner,
+  dueDate: record.dueDate ? record.dueDate.toISOString() : null,
+  lastReviewAt: record.lastReviewAt ? record.lastReviewAt.toISOString() : null,
+  exportLink: record.exportLink,
+  createdAt: record.createdAt.toISOString(),
+  updatedAt: record.updatedAt.toISOString()
+})


### PR DESCRIPTION
## Summary
- add the missing deliverable serializer module so the API routes can import it

## Testing
- pnpm run typecheck *(fails: `@prisma/client` in this workspace is missing the generated Prisma types such as `PrismaClient`)*
- pnpm run build *(fails: same type errors from `@prisma/client` when Next.js runs type checking)*

------
https://chatgpt.com/codex/tasks/task_e_68e70a7eef08832483b2063a34cd8014