### PR TITLE
feat: scaffold revenueos foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .DS_Store
 .env
 .vercel
+tsconfig.tsbuildinfo

--- a/app/_components/app-shell.tsx
+++ b/app/_components/app-shell.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import * as React from 'react'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { CommandPaletteTrigger, useCommandPalette } from '@/ui/command-palette'
+import { Sheet, SheetContent, SheetTrigger } from '@/ui/sheet'
+import { cn } from '@/lib/utils'
+
+export type NavItem = {
+  href: string
+  label: string
+  badge?: string
+}
+
+export type SessionUser = {
+  id: string
+  name: string
+  role: string
+}
+
+type AppShellProps = {
+  children: React.ReactNode
+  navItems: NavItem[]
+  user: SessionUser
+}
+
+export function AppShell({ children, navItems, user }: AppShellProps) {
+  const pathname = usePathname()
+  const { openPalette } = useCommandPalette()
+  const [sheetOpen, setSheetOpen] = React.useState(false)
+
+  const navContent = (
+    <nav className="space-y-2">
+      {navItems.map((item) => {
+        const active = pathname === item.href
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              'flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition',
+              active
+                ? 'bg-[color:var(--color-surface-muted)] text-[color:var(--color-text)]'
+                : 'text-[color:var(--color-text-muted)] hover:bg-[color:var(--color-surface-muted)] hover:text-[color:var(--color-text)]',
+            )}
+            onClick={() => setSheetOpen(false)}
+          >
+            <span>{item.label}</span>
+            {item.badge ? <Badge variant="outline">{item.badge}</Badge> : null}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+
+  const breadcrumbs = buildBreadcrumbs(pathname)
+
+  return (
+    <div className="flex min-h-screen bg-[color:var(--color-background)]">
+      <aside className="hidden w-60 shrink-0 border-r border-[color:var(--color-outline)] bg-[color:var(--color-surface)] px-5 py-6 md:block">
+        <div className="flex items-center justify-between">
+          <Link href="/" className="text-sm font-semibold text-[color:var(--color-text)]">
+            TRS RevenueOS
+          </Link>
+          <Badge variant="success">beta</Badge>
+        </div>
+        <p className="mt-3 text-xs text-[color:var(--color-text-muted)]">
+          Daily operating canvas for GTM, finance, and partners.
+        </p>
+        <div className="mt-6 space-y-6">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]">Navigate</p>
+            {navContent}
+          </div>
+        </div>
+      </aside>
+      <div className="flex min-h-screen flex-1 flex-col">
+        <header className="sticky top-0 z-40 border-b border-[color:var(--color-outline)] bg-[color:var(--color-surface)]/90 backdrop-blur">
+          <div className="flex items-center justify-between gap-4 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+                <SheetTrigger>
+                  <Button className="md:hidden" variant="outline" size="sm">
+                    Menu
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="left" className="w-[260px] border-r bg-[color:var(--color-surface)]">
+                  <div className="space-y-6">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold text-[color:var(--color-text)]">TRS RevenueOS</span>
+                      <Badge variant="success">beta</Badge>
+                    </div>
+                    {navContent}
+                  </div>
+                </SheetContent>
+              </Sheet>
+              <div>
+                <p className="text-sm font-semibold text-[color:var(--color-text)]">Good day, {user.name.split(' ')[0]}</p>
+                <p className="text-xs text-[color:var(--color-text-muted)]">{user.role.toUpperCase()} OPERATIONS</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <CommandPaletteTrigger className="hidden sm:inline-flex" />
+              <Button variant="outline" size="sm" onClick={openPalette} className="sm:hidden">
+                Search
+              </Button>
+              <div className="flex items-center gap-2 rounded-full border border-[color:var(--color-outline)] px-3 py-1">
+                <span className="h-2 w-2 rounded-full bg-[color:var(--color-positive)]" />
+                <span className="text-xs font-medium text-[color:var(--color-text-muted)]">TRS Score 68</span>
+              </div>
+              <div className="hidden items-center gap-2 rounded-full border border-[color:var(--color-outline)] px-3 py-1 text-xs font-medium text-[color:var(--color-text-muted)] md:flex">
+                {user.name}
+              </div>
+            </div>
+          </div>
+          <div className="border-t border-[color:var(--color-outline)] px-6 py-2">
+            <nav className="flex items-center gap-2 text-xs text-[color:var(--color-text-muted)]">
+              {breadcrumbs.map((crumb, index) => (
+                <React.Fragment key={crumb.href}>
+                  {index > 0 ? <span>/</span> : null}
+                  <Link
+                    href={crumb.href}
+                    className={cn(
+                      'hover:text-[color:var(--color-text)]',
+                      crumb.active ? 'text-[color:var(--color-text)] font-medium' : '',
+                    )}
+                  >
+                    {crumb.label}
+                  </Link>
+                </React.Fragment>
+              ))}
+            </nav>
+          </div>
+        </header>
+        <main className="flex-1 bg-transparent">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">{children}</div>
+        </main>
+      </div>
+    </div>
+  )
+}
+
+type Breadcrumb = { href: string; label: string; active: boolean }
+
+function buildBreadcrumbs(pathname: string): Breadcrumb[] {
+  const segments = pathname.split('/').filter(Boolean)
+  const crumbs: Breadcrumb[] = [
+    { href: '/', label: 'Home', active: segments.length === 0 },
+  ]
+  if (segments.length === 0) return crumbs
+
+  let href = ''
+  segments.forEach((segment, index) => {
+    href += `/${segment}`
+    crumbs.push({
+      href,
+      label: segment.replace(/\[|\]/g, '').replace(/-/g, ' '),
+      active: index === segments.length - 1,
+    })
+  })
+  return crumbs
+}

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -1,0 +1,29 @@
+import { listFlags, requireRole } from '@/core/flags/flags'
+import { getSession } from '@/lib/session'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { FlagsTable } from './table'
+
+export default async function FeatureFlagsPage() {
+  const session = await getSession()
+  requireRole(session.user, ['admin', 'revops'])
+  const flags = listFlags()
+
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Feature flags</PageTitle>
+        <PageDescription>Toggle experiments and guard access. UI stubs only for now.</PageDescription>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Flag registry</CardTitle>
+          <CardDescription>Changes are local to this session. TODO: persist to database and auditing pipeline.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <FlagsTable initialFlags={flags} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/flags/table.tsx
+++ b/app/admin/flags/table.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import * as React from 'react'
+import { FeatureFlag, setFlagEnabled } from '@/core/flags/flags'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+import { showToast } from '@/ui/toast'
+
+type FlagsTableProps = {
+  initialFlags: FeatureFlag[]
+}
+
+export function FlagsTable({ initialFlags }: FlagsTableProps) {
+  const [flags, setFlags] = React.useState(initialFlags)
+
+  const toggleFlag = React.useCallback(
+    (key: string) => {
+      setFlags((prev) =>
+        prev.map((flag) =>
+          flag.key === key
+            ? { ...flag, enabled: !flag.enabled }
+            : flag,
+        ),
+      )
+      const updated = setFlagEnabled(key, !flags.find((flag) => flag.key === key)?.enabled)
+      showToast({
+        title: `Flag ${key}`,
+        description: updated?.enabled ? 'Enabled for eligible roles.' : 'Disabled for now.',
+      })
+    },
+    [flags],
+  )
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Flag</TableHead>
+          <TableHead>Description</TableHead>
+          <TableHead>Audience</TableHead>
+          <TableHead className="text-right">Enabled</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {flags.map((flag) => (
+          <TableRow key={flag.key}>
+            <TableCell className="font-medium text-[color:var(--color-text)]">{flag.label}</TableCell>
+            <TableCell className="text-sm text-[color:var(--color-text-muted)]">{flag.description}</TableCell>
+            <TableCell>
+              <div className="flex flex-wrap gap-2">
+                {flag.audience.map((role) => (
+                  <Badge key={role} variant="outline">
+                    {role}
+                  </Badge>
+                ))}
+              </div>
+            </TableCell>
+            <TableCell className="text-right">
+              <Button
+                type="button"
+                variant={flag.enabled ? 'primary' : 'outline'}
+                size="sm"
+                onClick={() => toggleFlag(flag.key)}
+              >
+                {flag.enabled ? 'On' : 'Off'}
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,0 +1,50 @@
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+
+export default function ClientsPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Clients</PageTitle>
+        <PageDescription>Directory of accounts, health, and TRS Score levers. TODO: connect to account service.</PageDescription>
+        <Badge variant="outline">Client sync pending</Badge>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Account overview</CardTitle>
+          <CardDescription>TODO: pipe ARR, NRR, and TRS score banding.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Account</TableHead>
+                <TableHead>Segment</TableHead>
+                <TableHead>Owner</TableHead>
+                <TableHead>TRS Score</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell colSpan={4} className="text-sm text-[color:var(--color-text-muted)]">
+                  No accounts loaded. TODO: fetch from client directory API.
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Voice of customer</CardTitle>
+          <CardDescription>TODO: surface sentiment snapshots and upcoming check-ins.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Feedback stream offline. Connect to CS insights feed soon.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -1,0 +1,35 @@
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+
+export default function ContentPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Content</PageTitle>
+        <PageDescription>
+          Editorial and enablement assets powering revenue narratives. TODO: connect to content calendar and asset library.
+        </PageDescription>
+        <Badge variant="outline">Story builder stubs</Badge>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Upcoming stories</CardTitle>
+          <CardDescription>TODO: map demand gen + lifecycle themes to TRS Score levers.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          No drafts ready. Sync with marketing CMS for planned releases.
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Asset requests</CardTitle>
+          <CardDescription>TODO: queue design, copy, and revops enablement asks.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Waiting for intake service. Hook submission form soon.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center px-6 py-12">
+      <Card>
+        <CardHeader>
+          <CardTitle>Something went wrong</CardTitle>
+          <CardDescription>We&apos;re logging this failure. Try again or refresh the page.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-[color:var(--color-text-muted)]">
+          <p>{error.message}</p>
+          <Button type="button" variant="primary" size="sm" onClick={() => reset()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -1,0 +1,52 @@
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+
+export default function FinancePage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Finance</PageTitle>
+        <PageDescription>
+          Monitor efficiency metrics, runway, and reconciliations. TODO: plug into finance data warehouse and ledger connectors.
+        </PageDescription>
+        <Badge variant="outline">Finance guardrails coming soon</Badge>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Capital efficiency</CardTitle>
+          <CardDescription>TODO: compute burn multiple, rule of 40, and margin trendlines.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Metrics offline. Awaiting integration with finance ETL job.
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Invoice aging</CardTitle>
+          <CardDescription>TODO: show invoice buckets and actions.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Client</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Due</TableHead>
+                <TableHead>Amount</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell colSpan={4} className="text-sm text-[color:var(--color-text-muted)]">
+                  No invoices pulled. TODO: connect to billing service.
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,45 +1,40 @@
 import './globals.css'
-import React from 'react'
+import type { Metadata } from 'next'
+import * as React from 'react'
+import { AppShell, NavItem } from './_components/app-shell'
+import { CommandPaletteProvider } from '@/ui/command-palette'
+import { ToastViewport } from '@/ui/toast'
+import { getSession } from '@/lib/session'
 
-export const metadata = {
-  title: 'TRS Internal SaaS',
-  description: 'RevenueOS Copilot — static scaffold preview'
+export const metadata: Metadata = {
+  title: 'TRS RevenueOS',
+  description: 'The daily source of truth for GTM, finance, and partner motions.',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+const navigation: NavItem[] = [
+  { href: '/', label: 'Morning briefing' },
+  { href: '/pipeline', label: 'Pipeline' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/content', label: 'Content' },
+  { href: '/finance', label: 'Finance' },
+  { href: '/partners', label: 'Partners' },
+  { href: '/clients', label: 'Clients' },
+  { href: '/admin/flags', label: 'Feature flags', badge: 'ops' },
+]
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const session = await getSession()
+  const user = session.user
+
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50 text-gray-900">
-        <div className="flex h-screen">
-          <aside className="hidden w-60 border-r bg-white p-4 text-sm md:block">
-            <p className="font-semibold">TRS Copilot</p>
-            <p className="mt-2 text-xs text-gray-500">
-              Dummy navigation placeholder for future modules.
-            </p>
-          </aside>
-          <main className="flex-1 overflow-y-auto">
-            <header className="sticky top-0 flex flex-wrap items-center justify-between gap-3 border-b bg-white px-4 py-3 text-sm">
-              <div>
-                <p className="font-medium">TRS Internal SaaS</p>
-                <p className="text-xs text-gray-500">
-                  Static preview using mocked data and scaffolding.
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="rounded-full bg-yellow-100 px-3 py-1 text-xs font-semibold text-yellow-700">
-                  TRS Score: 68
-                </span>
-                <button
-                  type="button"
-                  className="rounded border border-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100"
-                >
-                  Placeholder Action
-                </button>
-              </div>
-            </header>
-            <div className="p-4">{children}</div>
-          </main>
-        </div>
+      <body className="antialiased">
+        <CommandPaletteProvider>
+          <AppShell navItems={navigation} user={user}>
+            {children}
+          </AppShell>
+          <ToastViewport />
+        </CommandPaletteProvider>
       </body>
     </html>
   )

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from '@/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-12">
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,1051 +1,162 @@
-'use client';
+import { getTodayPlan, computeTodayPlanAction, lockTodayPlanAction } from '@/core/dailyPlan/actions'
+import { getSession } from '@/lib/session'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { FocusTimer } from '@/ui/focus-timer'
+import { Input } from '@/ui/input'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
 
-import { useState } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Progress } from "@/components/ui/progress";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Activity,
-  AlertTriangle,
-  BarChart3,
-  BookOpen,
-  Brain,
-  Building2,
-  Calendar,
-  CheckCircle2,
-  ClipboardList,
-  DollarSign,
-  Download,
-  FileText,
-  Layers,
-  LineChart,
-  Mail,
-  Rocket,
-  Search,
-  Settings,
-  Shield,
-  Target,
-  TrendingUp,
-  Upload,
-  Users,
-  Wallet,
-  ChevronLeft,
-  ChevronRight,
-  Play,
-} from "lucide-react";
+export default async function HomePage() {
+  const session = await getSession()
+  const user = session.user
+  const today = new Date()
+  const plan = await getTodayPlan(user.id, today)
 
-/**
- * TRS Copilot — TypeScript + React scaffold
- * - Single-file preview scaffold showing layout, nav, KPIs, module shells, and core types.
- * - Production app would split into /app routes and components. This keeps it previewable in one file.
- * - Styling uses Tailwind (no import required in canvas). shadcn/ui components assumed available.
- */
-
-// ---------- Domain Types (minimal, extensible) ----------
-export type Id = string;
-
-export type Account = {
-  id: Id;
-  name: string;
-  segment: "SMB" | "MM" | "ENT";
-  acvBand: "<10k" | "10-50k" | ">50k";
-  ownerId?: Id;
-};
-
-export type Contact = {
-  id: Id;
-  accountId: Id;
-  name: string;
-  email: string;
-  role: string;
-  phone?: string;
-};
-
-export type Opportunity = {
-  id: Id;
-  accountId: Id;
-  name: string;
-  stage:
-    | "New"
-    | "Discovery"
-    | "Proposal"
-    | "Negotiation"
-    | "Closed Won"
-    | "Closed Lost";
-  amount: number;
-  closeDate?: string; // ISO
-  source?: string;
-  probability?: number; // 0..1
-};
-
-export type Offer = {
-  id: Id;
-  name: string;
-  priceMetric: "seat" | "usage" | "flat";
-  basePrice: number;
-  floor: number;
-  ceiling: number;
-};
-
-export type Contract = {
-  id: Id;
-  accountId: Id;
-  arr: number;
-  startAt: string;
-  endAt: string;
-  terms?: string;
-};
-
-export type Invoice = {
-  id: Id;
-  contractId: Id;
-  amount: number;
-  dueAt: string;
-  paidAt?: string;
-  status: "pending" | "paid" | "failed";
-};
-
-export type ActivityEvent = {
-  id: Id;
-  type: "email" | "call" | "meeting" | "note";
-  accountId?: Id;
-  contactId?: Id;
-  opportunityId?: Id;
-  occurredAt: string;
-  notes?: string;
-};
-
-export type Experiment = {
-  id: Id;
-  hypothesis: string;
-  kpi: string;
-  startAt: string;
-  endAt?: string;
-  status: "draft" | "running" | "stopped" | "won" | "lost";
-};
-
-export type DeliverableType =
-  | "Clarity Audit"
-  | "Gap Map"
-  | "Intervention Blueprint"
-  | "RevBoard Dashboard"
-  | "Monthly ROI Report"
-  | "Quarterly ROI Synthesis"
-  | "Case Study Packet";
-
-export type Deliverable = {
-  id: Id;
-  accountId: Id;
-  type: DeliverableType;
-  status: "not started" | "in progress" | "review" | "approved" | "exported";
-  ownerId?: Id;
-  dueAt?: string;
-  exportLink?: string;
-  lastReviewedAt?: string;
-};
-
-export type GovernanceAction = {
-  id: Id;
-  entity: string;
-  entityId: Id;
-  requirement:
-    | "ROI hypothesis"
-    | "QA checklist"
-    | "Owner"
-    | "Payback window"
-    | "TRS Score lever";
-  status: "open" | "met" | "blocked";
-  ownerId?: Id;
-  evidenceLink?: string;
-  decidedAt?: string;
-};
-
-export type ModelCard = {
-  id: Id;
-  name: string;
-  version: string;
-  trainingSources: string[];
-  metrics: Record<string, number>; // e.g., { F1: 0.78, MAPE: 0.09 }
-  thresholds: Record<string, number>; // guardrails
-  retrainAt?: string;
-  approverId?: Id;
-};
-
-export type TRSScoreBand = "Red" | "Yellow" | "Green";
-
-export type TRSScore = {
-  accountId: Id;
-  score: number; // 0..100
-  band: TRSScoreBand;
-  computedAt: string;
-  drivers: { name: string; delta: number }[];
-};
-
-// ---------- Mock Data ----------
-const mockScore: TRSScore = {
-  accountId: "acct_1",
-  score: 68,
-  band: "Yellow",
-  computedAt: new Date().toISOString(),
-  drivers: [
-    { name: "NRR", delta: +4 },
-    { name: "Gross Margin", delta: +2 },
-    { name: "CAC Payback", delta: -3 },
-    { name: "Cash Conversion", delta: -1 },
-  ],
-};
-
-const kpis = [
-  { label: "NRR", value: "112%", icon: TrendingUp },
-  { label: "Gross Margin", value: "62%", icon: DollarSign },
-  { label: "CAC Payback", value: "8.5 mo", icon: BarChart3 },
-  { label: "Cash", value: "$1.2M", icon: Wallet },
-];
-
-// ---------- UI Helpers ----------
-const bandConfig: Record<TRSScoreBand, { color: string; label: string }> = {
-  Red: { color: "bg-red-500", label: "Stabilization Plays" },
-  Yellow: { color: "bg-yellow-500", label: "Incremental Plays" },
-  Green: { color: "bg-green-500", label: "Brilliant Plays" },
-};
-
-const modules = [
-  { key: "revboard", label: "Executive Room", icon: LineChart },
-  { key: "crm", label: "Pipeline Spine", icon: Building2 },
-  { key: "agents", label: "Agents", icon: Brain },
-  { key: "qra", label: "QRA Strategy", icon: Target },
-  { key: "dealdesk", label: "Deal Desk", icon: ClipboardList },
-  { key: "fpna", label: "FP&A + Cash", icon: DollarSign },
-  { key: "retention", label: "Retention", icon: Users },
-  { key: "experiments", label: "Experiments", icon: Activity },
-  { key: "partners", label: "Partner Scout", icon: Rocket },
-  { key: "content", label: "Content Engine", icon: BookOpen },
-  { key: "billing", label: "Billing & RevOps", icon: Wallet },
-  { key: "deliverables", label: "Deliverables", icon: FileText },
-  { key: "governance", label: "Governance", icon: Shield },
-  { key: "settings", label: "Settings", icon: Settings },
-] as const;
-
-type ModuleKey = (typeof modules)[number]["key"];
-
-// ---------- Core Layout ----------
-export default function TRSCopilotScaffold() {
-  const [active, setActive] = useState<ModuleKey>("revboard");
   return (
-    <div className="min-h-screen w-full bg-neutral-50 text-neutral-900">
-      <Header score={mockScore} />
-      <div className="flex">
-        <Sidebar active={active} onChange={setActive} />
-        <main className="flex-1 p-6">
-          {active === "revboard" && <ExecutiveRoom />}
-          {active === "crm" && <PipelineSpine />}
-          {active === "agents" && <AgentsHub />}
-          {active === "qra" && <QRASection />}
-          {active === "dealdesk" && <DealDesk />}
-          {active === "fpna" && <FPnA />}
-          {active === "retention" && <Retention />}
-          {active === "experiments" && <Experiments />}
-          {active === "partners" && <PartnerScout />}
-          {active === "content" && <ContentEngine />}
-          {active === "billing" && <BillingRevOps />}
-          {active === "deliverables" && <DeliverablesPanel />}
-          {active === "governance" && <GovernancePanel />}
-          {active === "settings" && <SettingsPanel />}
-        </main>
-      </div>
-    </div>
-  );
-}
-
-function Header({ score }: { score: TRSScore }) {
-  const pct = Math.max(0, Math.min(100, score.score));
-  const band = bandConfig[score.band];
-  return (
-    <div className="sticky top-0 z-10 border-b bg-white/70 backdrop-blur">
-      <div className="mx-auto flex max-w-7xl items-center gap-4 px-6 py-4">
-        <div className="flex items-center gap-3">
-          <Layers className="h-6 w-6" />
-          <span className="font-semibold">TRS Copilot</span>
-          <Badge variant="secondary" className="rounded-full">
-            Internal
-          </Badge>
-        </div>
-        <div className="ml-auto flex w-full max-w-xl items-center gap-4">
-          <div className="w-full">
-            <div className="flex items-center justify-between text-sm">
-              <span className="font-medium">TRS Score</span>
-              <span className="font-semibold">{pct}</span>
-            </div>
-            <Progress value={pct} className="h-2" />
-            <div className="mt-1 flex items-center justify-between text-xs text-neutral-600">
-              <span>{new Date(score.computedAt).toLocaleString()}</span>
-              <span className={`inline-flex items-center gap-1`}>
-                <span className={`h-2 w-2 rounded-full ${band.color}`} /> {band.label}
-              </span>
-            </div>
+    <div className="space-y-8">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <div className="flex flex-col gap-3">
+          <PageTitle>Morning briefing</PageTitle>
+          <PageDescription>
+            Welcome back, {user.name.split(' ')[0]}. This workspace will evolve into your single source of truth for pipeline
+            confidence, customer health, and capital efficiency.
+          </PageDescription>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-[color:var(--color-text-muted)]">
+            <span>Today is {today.toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' })}</span>
+            <Badge variant="success">Momentum: steady</Badge>
+            <span>Confidence calibrated with session stubs.</span>
           </div>
-          <Button variant="outline" className="gap-2">
-            <Download className="h-4 w-4" />
-            Export Deck
-          </Button>
         </div>
-      </div>
-    </div>
-  );
-}
+      </PageHeader>
 
-function Sidebar({
-  active,
-  onChange,
-}: {
-  active: ModuleKey;
-  onChange: (m: ModuleKey) => void;
-}) {
-  return (
-    <aside className="sticky top-[64px] h-[calc(100vh-64px)] w-72 shrink-0 border-r bg-white p-4">
-      <div className="mb-3 flex items-center gap-2">
-        <Search className="h-4 w-4" />
-        <Input placeholder="Search accounts, deals…" />
-      </div>
-      <nav className="space-y-1">
-        {modules.map((m) => (
-          <button
-            key={m.key}
-            onClick={() => onChange(m.key)}
-            className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition ${
-              active === m.key ? "bg-neutral-900 text-white" : "hover:bg-neutral-100"
-            }`}
-          >
-            <m.icon className="h-4 w-4" />
-            <span className="text-sm font-medium">{m.label}</span>
-            {m.key === "deliverables" && (
-              <Badge
-                className="ml-auto"
-                variant={active === m.key ? "secondary" : "outline"}
-              >
-                3
-              </Badge>
-            )}
-          </button>
-        ))}
-      </nav>
-      <div className="mt-6 rounded-2xl bg-neutral-50 p-3 text-xs text-neutral-600">
-        <div className="mb-1 font-semibold text-neutral-800">Master Switches</div>
-        <div className="flex items-center justify-between py-1">
-          <span>Deal Desk</span>
-          <SwitchInline enabled />
-        </div>
-        <div className="flex items-center justify-between py-1">
-          <span>Partner Scout</span>
-          <SwitchInline enabled />
-        </div>
-        <div className="flex items-center justify-between py-1">
-          <span>AI Auto-Execute</span>
-          <SwitchInline />
-        </div>
-      </div>
-    </aside>
-  );
-}
-
-function SwitchInline({ enabled = false }: { enabled?: boolean }) {
-  const [on, setOn] = useState(enabled);
-  return (
-    <button
-      onClick={() => setOn((v) => !v)}
-      className={`relative h-6 w-11 rounded-full transition ${
-        on ? "bg-neutral-900" : "bg-neutral-300"
-      }`}
-      aria-label="toggle"
-    >
-      <span
-        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition ${
-          on ? "right-0.5" : "left-0.5"
-        }`}
-      />
-    </button>
-  );
-}
-
-// ---------- Executive Room ----------
-function ExecutiveRoom() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Executive Room</h1>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        {kpis.map(({ label, value, icon: Icon }) => (
-          <Card key={label} className="rounded-2xl">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm text-neutral-600">{label}</CardTitle>
-            </CardHeader>
-            <CardContent className="flex items-center justify-between">
-              <div className="text-2xl font-bold">{value}</div>
-              <Icon className="h-6 w-6" />
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Top 5 Plays in Motion</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {[
-            "Raise list price 8% within floor/ceiling",
-            "Freeze lowest-ROI channel",
-            "Expansion trigger for Tier A accounts",
-            "Dunning for failed payments 7d",
-            "Partner launch: Rev-share with MSP Guild",
-          ].map((p, i) => (
-            <div key={i} className="flex items-center justify-between rounded-xl border p-3">
-              <div className="flex items-center gap-3">
-                <ChevronRight className="h-4 w-4" />
-                <span className="text-sm font-medium">{p}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Badge variant="outline">Owner: You</Badge>
-                <Badge variant="secondary">In progress</Badge>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <Card className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">Risks & Blockers</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <RiskRow icon={AlertTriangle} text="Forecast error >10% for 2 cycles" status="Investigating" />
-            <RiskRow icon={AlertTriangle} text="Failed payments up 25% (7d MA)" status="Dunning Live" />
-            <RiskRow icon={AlertTriangle} text="Discount leakage > guardrail" status="Deal Desk Gate" />
-          </CardContent>
-        </Card>
-        <Card className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">Cadence</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <CadenceRow icon={Calendar} label="Weekly" items={["RevBoard deck", "Signals readout", "Agent stats"]} />
-            <CadenceRow icon={Calendar} label="Monthly" items={["ROI report", "Blueprint delta", "TRS Score movement"]} />
-            <CadenceRow icon={Calendar} label="Quarterly" items={["ROI synthesis", "CaseCompiler packet"]} />
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
-}
-
-function RiskRow({ icon: Icon, text, status }: { icon: any; text: string; status: string }) {
-  return (
-    <div className="flex items-center justify-between rounded-xl border p-3">
-      <div className="flex items-center gap-3">
-        <Icon className="h-4 w-4" />
-        <span>{text}</span>
-      </div>
-      <Badge variant="outline">{status}</Badge>
-    </div>
-  );
-}
-
-function CadenceRow({ icon: Icon, label, items }: { icon: any; label: string; items: string[] }) {
-  return (
-    <div className="rounded-xl border p-3">
-      <div className="mb-2 flex items-center gap-2 font-medium">
-        <Icon className="h-4 w-4" />
-        {label}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {items.map((i) => (
-          <Badge key={i} variant="secondary">
-            {i}
-          </Badge>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------- Pipeline Spine (Mini-CRM) ----------
-function PipelineSpine() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Pipeline Spine</h1>
-      <Tabs defaultValue="inbox">
-        <TabsList>
-          <TabsTrigger value="inbox">Inbox → Revenue</TabsTrigger>
-          <TabsTrigger value="deals">Deal Desk</TabsTrigger>
-          <TabsTrigger value="renewals">Renewal Radar</TabsTrigger>
-        </TabsList>
-        <TabsContent value="inbox">
-          <InboxToRevenue />
-        </TabsContent>
-        <TabsContent value="deals">
-          <DealTable />
-        </TabsContent>
-        <TabsContent value="renewals">
-          <RenewalTable />
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
-}
-
-function InboxToRevenue() {
-  return (
-    <Card className="rounded-2xl">
-      <CardHeader>
-        <CardTitle className="text-base">Leads</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2 text-sm">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex items-center justify-between rounded-xl border p-3">
-            <div className="flex items-center gap-3">
-              <Mail className="h-4 w-4" />
-              <div>
-                <div className="font-medium">Lead {i + 1} • ICP 86</div>
-                <div className="text-neutral-600">Problem: Pricing confusion; Request: ROI model</div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="outline">
-                Draft Reply
-              </Button>
-              <Button size="sm">Book</Button>
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
-
-function DealTable() {
-  return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      {(["New", "Discovery", "Proposal", "Negotiation"] as const).map((stage) => (
-        <Card key={stage} className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">{stage}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between rounded-xl border p-3">
-                <div>
-                  <div className="font-medium">ACME • $24k</div>
-                  <div className="text-neutral-600">
-                    Prob: {Math.round(20 + Math.random() * 60)}% • Source: Outbound
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button size="icon" variant="outline">
-                    <ChevronLeft className="h-4 w-4" />
-                  </Button>
-                  <Button size="icon" variant="outline">
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function RenewalTable() {
-  return (
-    <Card className="rounded-2xl">
-      <CardHeader>
-        <CardTitle className="text-base">Next 90 Days</CardTitle>
-      </CardHeader>
-      <CardContent className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="rounded-xl border p-3 text-sm">
-            <div className="flex items-center justify-between">
-              <span className="font-medium">Account {i + 1}</span>
-              <Badge variant="outline">Risk: {(10 + i) % 3 ? "Low" : "High"}</Badge>
-            </div>
-            <div className="text-neutral-600">Reason: Low adoption • Play: QBR + expansion offer</div>
-            <div className="mt-2 flex items-center gap-2">
-              <Button size="sm" variant="outline">
-                Rescue Plan
-              </Button>
-              <Button size="sm">Schedule QBR</Button>
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
-
-// ---------- Agents Hub ----------
-function AgentsHub() {
-  const agents = [
-    { name: "ICP Prospector", kpi: "Meetings/week", status: "Running", icon: Search },
-    { name: "Outreach Copy Chief", kpi: "Reply rate", status: "Paused", icon: Mail },
-    { name: "Meeting Orchestrator", kpi: "Show rate", status: "Running", icon: Calendar },
-    { name: "Deal Coach", kpi: "Win rate", status: "Running", icon: Target },
-    { name: "Pricing Analyst", kpi: "Margin uplift", status: "Running", icon: DollarSign },
-    { name: "Churn Rescue", kpi: "Save rate", status: "Running", icon: Shield },
-    { name: "Expansion Hunter", kpi: "NRR", status: "Running", icon: TrendingUp },
-    { name: "FP&A Copilot", kpi: "Forecast error", status: "Running", icon: BarChart3 },
-    { name: "Partner Scout", kpi: "Partner pipeline", status: "Running", icon: Rocket },
-    { name: "Authority Writer", kpi: "SQLs from content", status: "Running", icon: BookOpen },
-  ];
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Agents</h1>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        {agents.map((a) => (
-          <Card key={a.name} className="rounded-2xl">
-            <CardHeader className="flex-row items-center justify-between">
-              <div className="flex items-center gap-2">
-                <a.icon className="h-4 w-4" />
-                <CardTitle className="text-base">{a.name}</CardTitle>
-              </div>
-              <Badge variant="secondary">KPI: {a.kpi}</Badge>
-            </CardHeader>
-            <CardContent className="flex items-center justify-between">
-              <div className="text-sm text-neutral-600">Status: {a.status}</div>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  <Settings className="h-4 w-4" />
-                  Config
-                </Button>
-                <Button size="sm">
-                  <Play className="h-4 w-4" />
-                  Run
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------- QRA Strategy ----------
-function QRASection() {
-  const plays = [
-    { tier: "Brilliant", title: "Rebundle + 8% price raise", uplift: "+$220k GM", tti: "30d" },
-    { tier: "Incremental", title: "Trim paid channel B by 30%", uplift: "+$45k FCF", tti: "14d" },
-    { tier: "Stabilization", title: "Payment failure dunning", uplift: "+$18k/mo", tti: "7d" },
-  ];
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">QRA Strategy Generator</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Prioritized Plays</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {plays.map((p) => (
-            <div key={p.title} className="flex items-center justify-between rounded-xl border p-3">
-              <div>
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary">{p.tier}</Badge>
-                  <span className="font-medium">{p.title}</span>
-                </div>
-                <div className="text-sm text-neutral-600">
-                  Forecast Uplift {p.uplift} • Time-to-Impact {p.tti}
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  Explain
-                </Button>
-                <Button size="sm">Add to Blueprint</Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Deal Desk ----------
-function DealDesk() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Deal Desk & Pricing</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Guardrails</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
-          <Guardrail label="Max Discount" value="12%" />
-          <Guardrail label="Min Term" value="12 mo" />
-          <Guardrail label="Approval Required &gt;" value="$50k" />
-        </CardContent>
-      </Card>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Value-Metric Simulator</CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-end gap-3">
-          <div className="w-full">
-            <label className="text-sm">Base Price</label>
-            <Input defaultValue={1200} />
-          </div>
-          <div className="w-full">
-            <label className="text-sm">Price Metric</label>
-            <Input defaultValue="seat" />
-          </div>
-          <Button className="gap-2">
-            <LineChart className="h-4 w-4" />
-            Simulate
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function Guardrail({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border p-3">
-      <div className="text-xs text-neutral-600">{label}</div>
-      <div className="text-lg font-semibold">{value}</div>
-    </div>
-  );
-}
-
-// ---------- FP&A ----------
-function FPnA() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">FP&A + Cash Console</h1>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Card className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">Runway</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">18 months</div>
-          </CardContent>
-        </Card>
-        <Card className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">Free Cash Flow</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">$85k/mo</div>
-          </CardContent>
-        </Card>
-        <Card className="rounded-2xl">
-          <CardHeader>
-            <CardTitle className="text-base">Scenario</CardTitle>
-          </CardHeader>
-          <CardContent className="flex items-center gap-2">
-            <Button variant="outline">Worst</Button>
-            <Button variant="secondary">Base</Button>
-            <Button variant="outline">Good</Button>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
-}
-
-// ---------- Retention ----------
-function Retention() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Retention & Expansion</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">At-Risk Accounts</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-xl border p-3 text-sm">
-              <div className="flex items-center justify-between">
-                <span className="font-medium">Account {i + 1}</span>
-                <Badge variant="outline">Health: {60 + i}%</Badge>
-              </div>
-              <div className="text-neutral-600">Low adoption • Recommend: playbook + QBR</div>
-              <div className="mt-2 flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  Playbook
-                </Button>
-                <Button size="sm">Trigger</Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Experiments ----------
-function Experiments() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Experiments & Attribution</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Active Tests</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          {["Pricing A/B", "Onboarding Variant", "Channel Budget Realloc"].map((name) => (
-            <div key={name} className="flex items-center justify-between rounded-xl border p-3">
-              <div className="font-medium">{name}</div>
-              <div className="flex items-center gap-2">
-                <Badge variant="secondary">Running</Badge>
-                <Button size="sm" variant="outline">
-                  Readout
-                </Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Partner Scout ----------
-function PartnerScout() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Partner & Channel Scout</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Scorecards</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-xl border p-3">
-              <div className="flex items-center justify-between">
-                <span className="font-medium">Partner {i + 1}</span>
-                <Badge variant="outline">Overlap: {70 + i}%</Badge>
-              </div>
-              <div className="text-neutral-600">
-                Deal influence high • Expected pipeline: ${50 + i * 10}k
-              </div>
-              <div className="mt-2 flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  Offer
-                </Button>
-                <Button size="sm">Activate</Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Content Engine ----------
-function ContentEngine() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Content & Authority Engine</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Topic Map</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          {["Pricing strategy", "NRR mechanics", "FP&A for founders", "RevenueOS case"].map((t) => (
-            <div key={t} className="rounded-xl border p-3 text-sm">
-              <div className="font-medium">{t}</div>
-              <div className="text-neutral-600">Draft ready • Needs proof inserts</div>
-              <div className="mt-2 flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  Draft
-                </Button>
-                <Button size="sm">Publish</Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Billing & RevOps ----------
-function BillingRevOps() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Billing & RevOps</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Revenue Leakage</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          {[
-            "Failed payment recovery",
-            "Quote → Contract → Invoice sync",
-            "DSO coaching",
-          ].map((t) => (
-            <div key={t} className="flex items-center justify-between rounded-xl border p-3">
-              <div className="flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4" />
-                <span className="font-medium">{t}</span>
-              </div>
-              <Button size="sm" variant="outline">
-                Resolve
-              </Button>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Deliverables ----------
-function DeliverablesPanel() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Deliverables</h1>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        {[
-          "Clarity Audit",
-          "Gap Map",
-          "Intervention Blueprint",
-          "RevBoard Dashboard",
-          "Monthly ROI Report",
-          "Quarterly ROI Synthesis",
-          "Case Study Packet",
-        ].map((d) => (
-          <Card key={d} className="rounded-2xl">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[2fr,1fr]">
+        <div className="space-y-6">
+          <Card>
             <CardHeader>
-              <CardTitle className="text-base">{d}</CardTitle>
+              <CardTitle>Yesterday recap</CardTitle>
+              <CardDescription>
+                Snapshot of momentum, blockers, and wins from the past 24 hours. TODO: integrate activity pulse and sentiment.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="flex items-center justify-between text-sm">
-              <Badge variant="secondary">In progress</Badge>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="outline">
-                  <Upload className="h-4 w-4" />
-                  Attach
-                </Button>
-                <Button size="sm">
-                  <Download className="h-4 w-4" />
-                  Export
-                </Button>
-              </div>
+            <CardContent className="space-y-4 text-sm text-[color:var(--color-text-muted)]">
+              <p>• TODO hook: feed closed-won revenue diffs and churn signals.</p>
+              <p>• TODO hook: align partner pipeline coverage vs. goal.</p>
+              <p>• TODO hook: surface finance reconciliations requiring action.</p>
             </CardContent>
           </Card>
-        ))}
+
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <CardTitle>Today&apos;s plan</CardTitle>
+                  <CardDescription>
+                    Rank-ordered focus list combining impact, probability, strategy weight, urgency, and confidence divided by
+                    effort.
+                  </CardDescription>
+                </div>
+                <div className="flex items-center gap-2">
+                  <form action={computeTodayPlanAction}>
+                    <input type="hidden" name="userId" value={user.id} />
+                    <Button type="submit" variant="primary" size="sm">
+                      Compute
+                    </Button>
+                  </form>
+                  <form action={lockTodayPlanAction}>
+                    <input type="hidden" name="userId" value={user.id} />
+                    <Button type="submit" variant="secondary" size="sm" disabled={!plan}>
+                      {plan?.locked ? 'Locked' : 'Lock plan'}
+                    </Button>
+                  </form>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {plan ? (
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                    <span>
+                      Generated {new Date(plan.generatedAt).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                    {plan.locked ? <Badge variant="outline">Locked for the day</Badge> : <Badge variant="outline">Draft</Badge>}
+                  </div>
+                  <ol className="space-y-3">
+                    {plan.items.map((item, index) => (
+                      <li key={item.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4 shadow-sm">
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                              Rank {index + 1}
+                            </p>
+                            <p className="text-base font-semibold text-[color:var(--color-text)]">{item.title}</p>
+                            <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{item.summary}</p>
+                            <p className="mt-2 text-sm text-[color:var(--color-text)]">
+                              Next action: <span className="font-medium">{item.nextAction}</span>
+                            </p>
+                          </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge variant="outline">Score {item.score}</Badge>
+                            <span className="text-xs text-[color:var(--color-text-muted)]">Effort {item.effort}</span>
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-dashed border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/40 p-6 text-sm text-[color:var(--color-text-muted)]">
+                  <p className="font-medium text-[color:var(--color-text)]">No plan generated yet.</p>
+                  <p className="mt-1">Tap compute to synthesize a 5–7 item focus list from upcoming signals.</p>
+                  <p className="mt-2 text-xs uppercase tracking-wide">TODO hook: fetch previous plan fallback.</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick capture</CardTitle>
+              <CardDescription>Drop a note for later triage. TODO: pipe into inbox service.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <form className="space-y-3">
+                <Input placeholder="What needs attention?" />
+                <Button type="button" variant="outline" size="sm">
+                  Save draft
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+          <FocusTimer />
+          <Card>
+            <CardHeader>
+              <CardTitle>Operating radar</CardTitle>
+              <CardDescription>Snapshots across pipeline, finance, and client health. TODO: hydrate metrics.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="pipeline">
+                <TabsList>
+                  <TabsTrigger value="pipeline">Pipeline</TabsTrigger>
+                  <TabsTrigger value="finance">Finance</TabsTrigger>
+                  <TabsTrigger value="clients">Clients</TabsTrigger>
+                </TabsList>
+                <TabsContent value="pipeline" className="text-sm text-[color:var(--color-text-muted)]">
+                  TODO: pipeline coverage vs. commit chart.
+                </TabsContent>
+                <TabsContent value="finance" className="text-sm text-[color:var(--color-text-muted)]">
+                  TODO: weekly ARR waterfall and burn multiple.
+                </TabsContent>
+                <TabsContent value="clients" className="text-sm text-[color:var(--color-text-muted)]">
+                  TODO: NPS + activation funnel summary.
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
-  );
-}
-
-// ---------- Governance ----------
-function GovernancePanel() {
-  const items = [
-    { requirement: "ROI hypothesis", status: "met" },
-    { requirement: "QA checklist", status: "met" },
-    { requirement: "Owner", status: "met" },
-    { requirement: "Payback window", status: "open" },
-    { requirement: "TRS Score lever", status: "open" },
-  ];
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Governance</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Activation Gate</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          {items.map((it) => (
-            <div key={it.requirement} className="flex items-center justify-between rounded-xl border p-3">
-              <span className="font-medium">{it.requirement}</span>
-              {it.status === "met" ? (
-                <Badge className="gap-1" variant="secondary">
-                  <CheckCircle2 className="h-3 w-3" />
-                  Met
-                </Badge>
-              ) : (
-                <Badge variant="outline">Open</Badge>
-              )}
-            </div>
-          ))}
-          <div className="pt-2">
-            <Button className="gap-2" disabled>
-              <Play className="h-4 w-4" />
-              Enable Module
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">AI Engine Compliance</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
-          <div className="rounded-xl border p-3">
-            <div className="mb-1 font-medium">Model: QRA-Forecast v1.2</div>
-            <div>F1 0.78 • MAPE 9% • Thresholds: F1≥0.75, MAPE≤10%</div>
-            <div className="mt-2 flex items-center gap-2">
-              <Badge variant="secondary">Approved</Badge>
-              <Button size="sm" variant="outline">
-                View Card
-              </Button>
-            </div>
-          </div>
-          <div className="rounded-xl border p-3">
-            <div className="mb-1 font-medium">Model: Churn-Risk v0.9</div>
-            <div>AUROC 0.73 • Precision@Top10% 0.41 • Thresholds: AUROC≥0.7</div>
-            <div className="mt-2 flex items-center gap-2">
-              <Badge variant="secondary">Approved</Badge>
-              <Button size="sm" variant="outline">
-                View Card
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ---------- Settings ----------
-function SettingsPanel() {
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Settings</h1>
-      <Card className="rounded-2xl">
-        <CardHeader>
-          <CardTitle className="text-base">Integrations</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
-          <IntegrationRow name="Google Calendar" status="Connected" />
-          <IntegrationRow name="Email" status="Connected" />
-          <IntegrationRow name="Payments" status="Connected" />
-          <IntegrationRow name="Ads" status="Pending" />
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function IntegrationRow({
-  name,
-  status,
-}: {
-  name: string;
-  status: "Connected" | "Pending";
-}) {
-  return (
-    <div className="flex items-center justify-between rounded-xl border p-3">
-      <div className="font-medium">{name}</div>
-      <Badge variant={status === "Connected" ? "secondary" : "outline"}>{status}</Badge>
-    </div>
-  );
+  )
 }

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -1,0 +1,33 @@
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+
+export default function PartnersPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Partners</PageTitle>
+        <PageDescription>Manage ecosystem momentum. TODO: integrate partner CRM + MDF tracking.</PageDescription>
+        <Badge variant="outline">Ecosystem experiments pending</Badge>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Partner pipeline</CardTitle>
+          <CardDescription>TODO: display sourced, influenced, and co-sell motions.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Waiting on partner source feed. Connect to partner API soon.
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Enablement scorecard</CardTitle>
+          <CardDescription>TODO: show certification status and play activation.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          No partners scored. Add enablement telemetry ingest.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/pipeline/page.tsx
+++ b/app/pipeline/page.tsx
@@ -1,0 +1,38 @@
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Badge } from '@/ui/badge'
+
+export default function PipelinePage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Pipeline</PageTitle>
+        <PageDescription>
+          Track forecast health, coverage, and conversion. TODO: hydrate from pipeline API and scoring engine.
+        </PageDescription>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--color-text-muted)]">
+          <Badge variant="outline">TODO: tie into dynamic filters</Badge>
+          <span>Zero state until data hooks wire up.</span>
+        </div>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Commit overview</CardTitle>
+          <CardDescription>TODO: show commit vs. goal, coverage ratios, and slippage callouts.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          No deals loaded. Sync CRM adapter to populate stages and weighted revenue.
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Stage velocity</CardTitle>
+          <CardDescription>TODO: compute time-in-stage trends, drop-offs, and rep focus suggestions.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Waiting for dataset. Hook into RevOps analytics service.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,33 @@
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+
+export default function ProjectsPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Projects</PageTitle>
+        <PageDescription>Coordinate deliverables, owners, and due dates. TODO: connect to project workspace service.</PageDescription>
+        <Badge variant="outline">Assignments syncing soon</Badge>
+      </PageHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>Active engagements</CardTitle>
+          <CardDescription>TODO: pull live deliverable states and owner workloads.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          No projects yet. Plug in deliverables API for upcoming Clarity Audits, ROI reports, and workshops.
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Risks &amp; blockers</CardTitle>
+          <CardDescription>TODO: surface red/yellow states based on SLA adherence.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-[color:var(--color-text-muted)]">
+          Waiting on governance signals. Link QA service to populate this list.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -1,0 +1,50 @@
+import { getShareById } from '@/core/shares/actions'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Badge } from '@/ui/badge'
+
+export default async function SharePage({ params }: { params: { id: string } }) {
+  const share = await getShareById(params.id)
+
+  if (!share) {
+    return (
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center gap-4 px-6 py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Share link expired</CardTitle>
+            <CardDescription>Token {params.id} is no longer active. Request a new share from the owner.</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-6 py-12">
+      <Card className="relative overflow-hidden">
+        {share.watermark ? <Watermark /> : null}
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>{share.title}</CardTitle>
+              <CardDescription>{share.summary}</CardDescription>
+            </div>
+            <Badge variant="outline">Preview</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-[color:var(--color-text-muted)]">
+          <p>Shared on {new Date(share.createdAt).toLocaleString()} by {share.createdBy}.</p>
+          <p>TODO: hydrate with report modules, metrics, and collaboration controls.</p>
+          <p>Watermark {share.watermark ? 'enabled' : 'disabled'}.</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function Watermark() {
+  return (
+    <div className="pointer-events-none absolute inset-0 grid place-items-center text-5xl font-semibold uppercase tracking-widest text-[color:var(--color-outline)]/40">
+      TRS SHARE
+    </div>
+  )
+}

--- a/core/dailyPlan/actions.ts
+++ b/core/dailyPlan/actions.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { computeDailyPlan } from './service'
+import { Plan } from './types'
+
+const planStore = new Map<string, Plan>()
+
+function storeKey(userId: string, day: string) {
+  return `${userId}:${day}`
+}
+
+export async function getTodayPlan(userId: string, date: Date) {
+  const day = date.toISOString().slice(0, 10)
+  return planStore.get(storeKey(userId, day)) ?? null
+}
+
+export async function computeTodayPlanAction(formData: FormData) {
+  const userId = (formData.get('userId') as string) || 'revops-lead'
+  const plan = await computeDailyPlan(userId, new Date())
+  planStore.set(storeKey(userId, plan.date), plan)
+  revalidatePath('/')
+  return plan
+}
+
+export async function lockTodayPlanAction(formData: FormData) {
+  const userId = (formData.get('userId') as string) || 'revops-lead'
+  const today = new Date()
+  const day = today.toISOString().slice(0, 10)
+  const existing = planStore.get(storeKey(userId, day))
+  const plan: Plan = existing
+    ? { ...existing, locked: true, generatedAt: new Date().toISOString() }
+    : { ...(await computeDailyPlan(userId, today)), locked: true }
+  planStore.set(storeKey(userId, day), plan)
+  revalidatePath('/')
+  return plan
+}

--- a/core/dailyPlan/score.ts
+++ b/core/dailyPlan/score.ts
@@ -1,0 +1,18 @@
+import { PriorityItem } from './types'
+
+type PriorityInputs = Pick<
+  PriorityItem,
+  'expectedImpact' | 'probability' | 'strategicWeight' | 'urgency' | 'confidence' | 'effort'
+>
+
+export function calculatePriorityScore(inputs: PriorityInputs) {
+  const numerator =
+    inputs.expectedImpact *
+    inputs.probability *
+    inputs.strategicWeight *
+    inputs.urgency *
+    inputs.confidence
+  const effort = inputs.effort <= 0 ? 1 : inputs.effort
+  const score = numerator / effort
+  return Number.isFinite(score) ? Number(score.toFixed(2)) : 0
+}

--- a/core/dailyPlan/service.ts
+++ b/core/dailyPlan/service.ts
@@ -1,0 +1,121 @@
+import { calculatePriorityScore } from './score'
+import { Plan, PriorityItem } from './types'
+
+const library: Array<Omit<PriorityItem, 'id' | 'score'>> = [
+  {
+    title: 'Reset top 10 opportunities forecast',
+    summary: 'Tighten probability weights ahead of exec huddle.',
+    nextAction: 'Review pipeline analytics and update Close IO records.',
+    expectedImpact: 8,
+    probability: 0.7,
+    strategicWeight: 1.2,
+    urgency: 1.1,
+    confidence: 0.8,
+    effort: 3,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Draft partner enablement brief',
+    summary: 'Refresh co-selling guidance for Q4 incentives.',
+    nextAction: 'Outline talking points and assign SMEs for review.',
+    expectedImpact: 6,
+    probability: 0.65,
+    strategicWeight: 1.3,
+    urgency: 1,
+    confidence: 0.7,
+    effort: 2,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Finance reconciliation sweep',
+    summary: 'Confirm ARR deltas align with RevOps model.',
+    nextAction: 'Sync with finance lead on flagged invoices.',
+    expectedImpact: 7,
+    probability: 0.6,
+    strategicWeight: 1.4,
+    urgency: 1.2,
+    confidence: 0.75,
+    effort: 2.5,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Client renewal scenario planning',
+    summary: 'Frame options for 3 at-risk customers.',
+    nextAction: 'Draft next steps doc and share with AM team.',
+    expectedImpact: 9,
+    probability: 0.55,
+    strategicWeight: 1.6,
+    urgency: 1.3,
+    confidence: 0.65,
+    effort: 3.5,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Content audit for weekly briefing',
+    summary: 'Ensure stories align with TRS Score movements.',
+    nextAction: 'Collect highlights from marketing insights.',
+    expectedImpact: 5,
+    probability: 0.7,
+    strategicWeight: 1,
+    urgency: 0.9,
+    confidence: 0.8,
+    effort: 1.5,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Partner onboarding pulse',
+    summary: 'Check readiness of two new ecosystem partners.',
+    nextAction: 'Send enablement kit and confirm product access.',
+    expectedImpact: 4,
+    probability: 0.8,
+    strategicWeight: 0.9,
+    urgency: 1,
+    confidence: 0.85,
+    effort: 1.2,
+    status: 'pending',
+    ownerName: 'You',
+  },
+  {
+    title: 'Executive briefing narrative',
+    summary: 'Prep story for Monday leadership standup.',
+    nextAction: 'Draft slides with refreshed revenue north star.',
+    expectedImpact: 8,
+    probability: 0.75,
+    strategicWeight: 1.5,
+    urgency: 1.2,
+    confidence: 0.7,
+    effort: 3,
+    status: 'pending',
+    ownerName: 'You',
+  },
+]
+
+export async function computeDailyPlan(userId: string, date: Date): Promise<Plan> {
+  const day = date.toISOString().slice(0, 10)
+  const randomSpan = 5 + Math.floor(Math.random() * 3)
+  const sampleSize = Math.min(library.length, randomSpan)
+  const selected = library.slice(0, sampleSize).map((item, index) => {
+    const score = calculatePriorityScore(item)
+    return {
+      ...item,
+      id: `${day}-${index + 1}`,
+      score,
+    }
+  })
+
+  const sorted = [...selected].sort((a, b) => b.score - a.score)
+
+  return {
+    id: `${userId}-${day}`,
+    userId,
+    date: day,
+    generatedAt: new Date().toISOString(),
+    locked: false,
+    items: sorted,
+  }
+}

--- a/core/dailyPlan/types.ts
+++ b/core/dailyPlan/types.ts
@@ -1,0 +1,26 @@
+export type PriorityItemStatus = 'pending' | 'in-progress' | 'complete'
+
+export type PriorityItem = {
+  id: string
+  title: string
+  summary: string
+  nextAction: string
+  expectedImpact: number
+  probability: number
+  strategicWeight: number
+  urgency: number
+  confidence: number
+  effort: number
+  score: number
+  status: PriorityItemStatus
+  ownerName?: string
+}
+
+export type Plan = {
+  id: string
+  userId: string
+  date: string // YYYY-MM-DD
+  generatedAt: string
+  locked: boolean
+  items: PriorityItem[]
+}

--- a/core/flags/flags.ts
+++ b/core/flags/flags.ts
@@ -1,0 +1,72 @@
+export type Role = 'admin' | 'revops' | 'finance' | 'partner'
+
+export type User = {
+  id: string
+  name: string
+  role: Role
+}
+
+export type FeatureFlag = {
+  key: string
+  label: string
+  description: string
+  enabled: boolean
+  audience: Role[]
+}
+
+const flagStore = new Map<string, FeatureFlag>([
+  [
+    'daily-plan-v1',
+    {
+      key: 'daily-plan-v1',
+      label: 'Daily plan orchestrator',
+      description: 'Expose morning briefing prioritization experience.',
+      enabled: true,
+      audience: ['admin', 'revops'],
+    },
+  ],
+  [
+    'share-spaces',
+    {
+      key: 'share-spaces',
+      label: 'Shareable spaces',
+      description: 'Allow tokenized links for cross-tenant previews.',
+      enabled: false,
+      audience: ['admin', 'partner'],
+    },
+  ],
+  [
+    'finance-dash-v2',
+    {
+      key: 'finance-dash-v2',
+      label: 'Finance dashboard v2',
+      description: 'Preview capital efficiency workbook.',
+      enabled: false,
+      audience: ['admin', 'finance'],
+    },
+  ],
+])
+
+export function listFlags() {
+  return Array.from(flagStore.values())
+}
+
+export function setFlagEnabled(key: string, enabled: boolean) {
+  const current = flagStore.get(key)
+  if (!current) return
+  flagStore.set(key, { ...current, enabled })
+  return flagStore.get(key)
+}
+
+export function canUse(user: User, key: string) {
+  const flag = flagStore.get(key)
+  if (!flag) return false
+  if (!flag.enabled) return false
+  return flag.audience.includes(user.role)
+}
+
+export function requireRole(user: User, allowedRoles: Role[]) {
+  if (!allowedRoles.includes(user.role)) {
+    throw new Error('Not authorized for this route')
+  }
+}

--- a/core/shares/actions.ts
+++ b/core/shares/actions.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { ShareSpace } from './types'
+
+const shares = new Map<string, ShareSpace>()
+
+export async function getShareById(id: string) {
+  return shares.get(id) ?? null
+}
+
+export async function createShareAction(formData: FormData) {
+  const title = (formData.get('title') as string) || 'Shared workspace'
+  const watermark = formData.get('watermark') === 'true'
+  const id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  const share: ShareSpace = {
+    id,
+    title,
+    summary: 'Preview bundle will load from future data service.',
+    watermark,
+    createdAt: new Date().toISOString(),
+    createdBy: 'revops-lead',
+  }
+  shares.set(id, share)
+  revalidatePath(`/share/${id}`)
+  return share
+}
+
+export async function revokeShareAction(formData: FormData) {
+  const id = formData.get('id') as string
+  if (!id) return false
+  const existed = shares.delete(id)
+  if (existed) {
+    revalidatePath(`/share/${id}`)
+  }
+  return existed
+}

--- a/core/shares/types.ts
+++ b/core/shares/types.ts
@@ -1,0 +1,8 @@
+export type ShareSpace = {
+  id: string
+  title: string
+  summary: string
+  watermark: boolean
+  createdAt: string
+  createdBy: string
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,17 @@
+export type Session = {
+  user: {
+    id: string
+    name: string
+    role: 'admin' | 'revops' | 'finance' | 'partner'
+  }
+}
+
+export async function getSession(): Promise<Session> {
+  return {
+    user: {
+      id: 'revops-lead',
+      name: 'Morgan Singh',
+      role: 'revops',
+    },
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | false | null | undefined>) {
+  return inputs.filter(Boolean).join(' ')
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,4 +2,45 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { --trs-green: #16a34a; --trs-yellow: #f59e0b; --trs-red: #ef4444; }
+:root {
+  --color-background: #f9fafb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f3f4f6;
+  --color-text: #111827;
+  --color-text-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-outline: #d1d5db;
+  --color-accent: #111827;
+  --color-accent-muted: #4b5563;
+  --color-positive: #16a34a;
+  --color-caution: #f59e0b;
+  --color-critical: #ef4444;
+  --trs-green: var(--color-positive);
+  --trs-yellow: var(--color-caution);
+  --trs-red: var(--color-critical);
+}
+
+body {
+  background: radial-gradient(circle at top left, rgba(15, 23, 42, 0.04), transparent 45%), var(--color-background);
+  color: var(--color-text);
+  font-family: 'Inter', 'SF Pro Text', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-feature-settings: 'liga' 1, 'calt' 1;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-accent);
+}
+
+* {
+  border-color: var(--color-outline);
+}
+
+::selection {
+  background: rgba(17, 24, 39, 0.16);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,56 @@
 import type { Config } from 'tailwindcss'
-export default {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+import { colors, fontSizes, radius, shadows, spacing } from './ui/tokens'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './ui/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: colors.background,
+        surface: colors.surface,
+        'surface-muted': colors.surfaceMuted,
+        text: colors.text,
+        'text-muted': colors.textMuted,
+        border: colors.border,
+        outline: colors.outline,
+        accent: colors.accent,
+        'accent-muted': colors.accentMuted,
+        positive: colors.positive,
+        caution: colors.caution,
+        critical: colors.critical,
+      },
+      borderRadius: {
+        sm: radius.sm,
+        md: radius.md,
+        lg: radius.lg,
+        xl: radius.xl,
+        full: radius.full,
+      },
+      fontSize: {
+        xs: fontSizes.xs,
+        sm: fontSizes.sm,
+        base: fontSizes.base,
+        lg: fontSizes.lg,
+        xl: fontSizes.xl,
+        '2xl': fontSizes['2xl'],
+        '3xl': fontSizes['3xl'],
+      },
+      spacing: {
+        none: spacing.none,
+        xs: spacing.xs,
+        sm: spacing.sm,
+        md: spacing.md,
+        lg: spacing.lg,
+        xl: spacing.xl,
+        '2xl': spacing['2xl'],
+      },
+      boxShadow: {
+        sm: shadows.sm,
+        md: shadows.md,
+      },
+    },
+  },
   plugins: [],
-} satisfies Config
+}
+
+export default config

--- a/ui/badge.tsx
+++ b/ui/badge.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & {
+  variant?: 'default' | 'outline' | 'success' | 'warning' | 'destructive'
+}
+
+const variantStyles: Record<NonNullable<BadgeProps['variant']>, string> = {
+  default: 'bg-[color:var(--color-surface-muted)] text-[color:var(--color-text)]',
+  outline: 'border border-[color:var(--color-outline)] text-[color:var(--color-text-muted)]',
+  success: 'bg-[color:var(--color-positive)]/10 text-[color:var(--color-positive)]',
+  warning: 'bg-[color:var(--color-caution)]/10 text-[color:var(--color-caution)]',
+  destructive: 'bg-[color:var(--color-critical)]/10 text-[color:var(--color-critical)]',
+}
+
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+          variantStyles[variant],
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+Badge.displayName = 'Badge'

--- a/ui/button.tsx
+++ b/ui/button.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const variantClasses = {
+  primary:
+    'bg-[color:var(--color-accent)] text-white hover:bg-[color:var(--color-accent-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]',
+  secondary:
+    'bg-[color:var(--color-surface-muted)] text-[color:var(--color-text)] hover:bg-[color:var(--color-surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--color-outline)]',
+  outline:
+    'border border-[color:var(--color-outline)] bg-white text-[color:var(--color-text)] hover:bg-[color:var(--color-surface-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--color-outline)]',
+  ghost:
+    'text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] hover:bg-[color:var(--color-surface-muted)]',
+}
+
+const sizeClasses = {
+  sm: 'h-8 px-3 text-xs',
+  md: 'h-9 px-4 text-sm',
+  lg: 'h-11 px-5 text-base',
+  icon: 'h-9 w-9 p-0',
+}
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: keyof typeof variantClasses
+  size?: keyof typeof sizeClasses
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', size = 'md', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60',
+          variantClasses[variant],
+          sizeClasses[size],
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = 'Button'

--- a/ui/card.tsx
+++ b/ui/card.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type CardProps = React.HTMLAttributes<HTMLDivElement>
+
+export function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardHeader({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn('flex flex-col gap-1 border-b border-[color:var(--color-outline)] px-5 py-4', className)}
+      {...props}
+    />
+  )
+}
+
+export function CardTitle({ className, ...props }: CardProps) {
+  return <h3 className={cn('text-base font-semibold text-[color:var(--color-text)]', className)} {...props} />
+}
+
+export function CardDescription({ className, ...props }: CardProps) {
+  return <p className={cn('text-sm text-[color:var(--color-text-muted)]', className)} {...props} />
+}
+
+export function CardContent({ className, ...props }: CardProps) {
+  return <div className={cn('px-5 py-4', className)} {...props} />
+}
+
+export function CardFooter({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn('flex items-center justify-end gap-2 border-t border-[color:var(--color-outline)] px-5 py-3', className)}
+      {...props}
+    />
+  )
+}

--- a/ui/command-palette.tsx
+++ b/ui/command-palette.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { showToast } from '@/ui/toast'
+
+export type Command = {
+  id: string
+  label: string
+  group: 'Navigation' | 'Action'
+  shortcut?: string
+  run: () => void
+}
+
+type CommandPaletteContextValue = {
+  open: boolean
+  openPalette: () => void
+  closePalette: () => void
+}
+
+const CommandPaletteContext = React.createContext<CommandPaletteContextValue | null>(null)
+
+export function useCommandPalette() {
+  const context = React.useContext(CommandPaletteContext)
+  if (!context) throw new Error('useCommandPalette must be used within CommandPaletteProvider')
+  return context
+}
+
+export function CommandPaletteProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const commands = React.useMemo<Command[]>(() => {
+    const navigate = (href: string) => () => {
+      setOpen(false)
+      if (pathname !== href) {
+        router.push(href)
+      }
+    }
+    return [
+      { id: 'nav-home', label: 'Go to Home briefing', group: 'Navigation', shortcut: 'H', run: navigate('/') },
+      { id: 'nav-pipeline', label: 'Review Pipeline', group: 'Navigation', shortcut: 'P', run: navigate('/pipeline') },
+      { id: 'nav-projects', label: 'Projects Workspace', group: 'Navigation', shortcut: 'J', run: navigate('/projects') },
+      { id: 'nav-content', label: 'Content Studio', group: 'Navigation', shortcut: 'C', run: navigate('/content') },
+      { id: 'nav-finance', label: 'Finance Desk', group: 'Navigation', shortcut: 'F', run: navigate('/finance') },
+      { id: 'nav-partners', label: 'Partner Network', group: 'Navigation', shortcut: 'R', run: navigate('/partners') },
+      { id: 'nav-clients', label: 'Client Directory', group: 'Navigation', shortcut: 'L', run: navigate('/clients') },
+      {
+        id: 'action-compute',
+        label: 'Compute Today plan',
+        group: 'Action',
+        shortcut: 'Shift+Enter',
+        run: () => {
+          showToast({ title: 'Compute Today plan', description: 'Server action stub invoked.' })
+          setOpen(false)
+        },
+      },
+      {
+        id: 'action-lock',
+        label: 'Lock Today plan',
+        group: 'Action',
+        shortcut: 'Shift+L',
+        run: () => {
+          showToast({ title: 'Lock plan', description: 'Lock flow stub ready.' })
+          setOpen(false)
+        },
+      },
+      {
+        id: 'action-focus',
+        label: 'Start Focus 50m session',
+        group: 'Action',
+        shortcut: 'Shift+F',
+        run: () => {
+          showToast({ title: 'Focus timer', description: 'Starting a 50 minute focus block soon.' })
+          setOpen(false)
+        },
+      },
+      {
+        id: 'action-task',
+        label: 'New Task',
+        group: 'Action',
+        run: () => {
+          showToast({ title: 'New Task', description: 'Task creation placeholder.' })
+          setOpen(false)
+        },
+      },
+      {
+        id: 'action-opportunity',
+        label: 'New Opportunity',
+        group: 'Action',
+        run: () => {
+          showToast({ title: 'New Opportunity', description: 'Opportunity creation placeholder.' })
+          setOpen(false)
+        },
+      },
+      {
+        id: 'action-share',
+        label: 'Share current page',
+        group: 'Action',
+        run: () => {
+          showToast({ title: 'Share link', description: 'Share flow placeholder.' })
+          setOpen(false)
+        },
+      },
+    ]
+  }, [pathname, router])
+
+  const value = React.useMemo(
+    () => ({
+      open,
+      openPalette: () => setOpen(true),
+      closePalette: () => setOpen(false),
+    }),
+    [open],
+  )
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+      <PaletteOverlay commands={commands} open={open} onOpenChange={setOpen} />
+    </CommandPaletteContext.Provider>
+  )
+}
+
+function PaletteOverlay({
+  commands,
+  open,
+  onOpenChange,
+}: {
+  commands: Command[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [mounted, setMounted] = React.useState(false)
+  const [query, setQuery] = React.useState('')
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  React.useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        onOpenChange(!open)
+      }
+      if (event.key === 'Escape') {
+        onOpenChange(false)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onOpenChange])
+
+  React.useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => inputRef.current?.focus(), 20)
+      return () => clearTimeout(timer)
+    }
+    return
+  }, [open])
+
+  const filtered = React.useMemo(() => {
+    if (!query) return commands
+    const lower = query.toLowerCase()
+    return commands.filter((command) => command.label.toLowerCase().includes(lower))
+  }, [commands, query])
+
+  if (!mounted) return null
+
+  return open ? (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4">
+      <div className="w-full max-w-xl rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4 shadow-xl">
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search actions or navigation..."
+          className="mb-3 w-full rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--color-accent-muted)]"
+        />
+        <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+          {filtered.length === 0 ? (
+            <p className="px-2 py-6 text-center text-sm text-[color:var(--color-text-muted)]">No matches yet.</p>
+          ) : (
+            ['Navigation', 'Action'].map((group) => {
+              const items = filtered.filter((item) => item.group === group)
+              if (items.length === 0) return null
+              return (
+                <div key={group} className="space-y-1">
+                  <p className="px-2 text-xs font-semibold uppercase text-[color:var(--color-text-muted)]">{group}</p>
+                  <ul className="divide-y divide-[color:var(--color-outline)] overflow-hidden rounded-lg border border-[color:var(--color-outline)]">
+                    {items.map((item) => (
+                      <li key={item.id}>
+                        <button
+                          type="button"
+                          className="flex w-full items-center justify-between gap-3 bg-[color:var(--color-surface)] px-3 py-2 text-left text-sm hover:bg-[color:var(--color-surface-muted)]"
+                          onClick={() => {
+                            item.run()
+                            onOpenChange(false)
+                          }}
+                        >
+                          <span>{item.label}</span>
+                          {item.shortcut ? (
+                            <span className="text-xs text-[color:var(--color-text-muted)]">{item.shortcut}</span>
+                          ) : null}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  ) : null
+}
+
+export function CommandPaletteTrigger({ className }: { className?: string }) {
+  const { openPalette } = useCommandPalette()
+  return (
+    <button
+      type="button"
+      onClick={openPalette}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-1.5 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]',
+        className,
+      )}
+    >
+      ⌘K
+      <span className="text-xs text-[color:var(--color-text-muted)]">Command</span>
+    </button>
+  )
+}

--- a/ui/dialog.tsx
+++ b/ui/dialog.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+const DialogContext = React.createContext<{
+  open: boolean
+  setOpen: (value: boolean) => void
+} | null>(null)
+
+export function Dialog({
+  children,
+  open,
+  onOpenChange,
+}: {
+  children: React.ReactNode
+  open?: boolean
+  onOpenChange?: (value: boolean) => void
+}) {
+  const [internalOpen, setInternalOpen] = React.useState(false)
+  const isControlled = typeof open === 'boolean'
+  const currentOpen = isControlled ? (open as boolean) : internalOpen
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(value)
+      }
+      onOpenChange?.(value)
+    },
+    [isControlled, onOpenChange],
+  )
+
+  return (
+    <DialogContext.Provider value={{ open: currentOpen, setOpen }}>{children}</DialogContext.Provider>
+  )
+}
+
+function useDialog(component: string) {
+  const context = React.useContext(DialogContext)
+  if (!context) throw new Error(`${component} must be used within <Dialog />`)
+  return context
+}
+
+export function DialogTrigger({ children }: { children: React.ReactElement }) {
+  const { setOpen } = useDialog('DialogTrigger')
+  return React.cloneElement(children, {
+    onClick: (event: React.MouseEvent) => {
+      children.props.onClick?.(event)
+      if (!event.defaultPrevented) {
+        setOpen(true)
+      }
+    },
+  })
+}
+
+export function DialogContent({
+  className,
+  children,
+}: {
+  className?: string
+  children: React.ReactNode
+}) {
+  const { open, setOpen } = useDialog('DialogContent')
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  React.useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('keydown', handleKey)
+    }
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, setOpen])
+
+  if (!mounted) return null
+
+  return createPortal(
+    open ? (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div className={cn('w-full max-w-md rounded-lg bg-[color:var(--color-surface)] p-6 shadow-xl', className)}>
+          {children}
+        </div>
+      </div>
+    ) : null,
+    document.body,
+  )
+}
+
+export function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('space-y-1', className)} {...props} />
+}
+
+export function DialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold text-[color:var(--color-text)]', className)} {...props} />
+}
+
+export function DialogDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm text-[color:var(--color-text-muted)]', className)} {...props} />
+}
+
+export function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-6 flex justify-end gap-2', className)} {...props} />
+}
+
+export function DialogClose({ children }: { children: React.ReactElement }) {
+  const { setOpen } = useDialog('DialogClose')
+  return React.cloneElement(children, {
+    onClick: (event: React.MouseEvent) => {
+      children.props.onClick?.(event)
+      if (!event.defaultPrevented) {
+        setOpen(false)
+      }
+    },
+  })
+}

--- a/ui/focus-timer.tsx
+++ b/ui/focus-timer.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import * as React from 'react'
+import { Button } from '@/ui/button'
+import { showToast } from '@/ui/toast'
+
+function formatTime(seconds: number) {
+  const minutes = Math.floor(seconds / 60)
+  const remaining = seconds % 60
+  return `${minutes.toString().padStart(2, '0')}:${remaining.toString().padStart(2, '0')}`
+}
+
+type FocusTimerProps = {
+  durationMinutes?: number
+}
+
+export function FocusTimer({ durationMinutes = 50 }: FocusTimerProps) {
+  const [secondsLeft, setSecondsLeft] = React.useState(durationMinutes * 60)
+  const [running, setRunning] = React.useState(false)
+  const intervalRef = React.useRef<NodeJS.Timeout | null>(null)
+
+  const stop = React.useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    setRunning(false)
+  }, [])
+
+  const start = React.useCallback(() => {
+    if (running) return
+    showToast({ title: 'Focus mode armed', description: `Block set for ${durationMinutes} minutes.` })
+    setRunning(true)
+    intervalRef.current = setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev <= 1) {
+          stop()
+          showToast({ title: 'Focus block complete', description: 'Time to reset or reflect.' })
+          return durationMinutes * 60
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }, [durationMinutes, running, stop])
+
+  const reset = React.useCallback(() => {
+    stop()
+    setSecondsLeft(durationMinutes * 60)
+  }, [durationMinutes, stop])
+
+  React.useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  return (
+    <div className="flex w-full flex-col gap-3 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4 shadow-sm">
+      <div className="flex items-baseline justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]">Focus timer</p>
+        <span className="text-sm text-[color:var(--color-text-muted)]">{durationMinutes} minute sprint</span>
+      </div>
+      <p className="text-4xl font-semibold text-[color:var(--color-text)]">{formatTime(secondsLeft)}</p>
+      <div className="flex gap-2">
+        <Button onClick={running ? stop : start} variant="primary" size="md">
+          {running ? 'Pause' : 'Start'}
+        </Button>
+        <Button onClick={reset} variant="secondary" size="md">
+          Reset
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/ui/input.tsx
+++ b/ui/input.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={cn(
+          'w-full rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm text-[color:var(--color-text)] shadow-sm shadow-transparent transition focus-visible:border-[color:var(--color-accent-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-muted)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60',
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+Input.displayName = 'Input'

--- a/ui/page-header.tsx
+++ b/ui/page-header.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export function PageHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 border-b border-[color:var(--color-outline)] bg-[color:var(--color-surface)] px-6 py-5 shadow-sm', className)}
+      {...props}
+    />
+  )
+}
+
+export function PageTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h1 className={cn('text-2xl font-semibold text-[color:var(--color-text)]', className)} {...props} />
+}
+
+export function PageDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('max-w-2xl text-sm text-[color:var(--color-text-muted)]', className)} {...props} />
+}

--- a/ui/select.tsx
+++ b/ui/select.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          'w-full appearance-none rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm text-[color:var(--color-text)] shadow-sm transition focus-visible:border-[color:var(--color-accent-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-muted)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    )
+  },
+)
+Select.displayName = 'Select'

--- a/ui/sheet.tsx
+++ b/ui/sheet.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+const SheetContext = React.createContext<{
+  open: boolean
+  setOpen: (value: boolean) => void
+} | null>(null)
+
+export function Sheet({ children, open, onOpenChange }: {
+  children: React.ReactNode
+  open?: boolean
+  onOpenChange?: (value: boolean) => void
+}) {
+  const [internalOpen, setInternalOpen] = React.useState(false)
+  const isControlled = typeof open === 'boolean'
+  const currentOpen = isControlled ? (open as boolean) : internalOpen
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(value)
+      }
+      onOpenChange?.(value)
+    },
+    [isControlled, onOpenChange],
+  )
+
+  React.useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    if (currentOpen) {
+      document.addEventListener('keydown', handleKey)
+    }
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [currentOpen, setOpen])
+
+  return (
+    <SheetContext.Provider value={{ open: currentOpen, setOpen }}>{children}</SheetContext.Provider>
+  )
+}
+
+function useSheetContext(component: string) {
+  const context = React.useContext(SheetContext)
+  if (!context) {
+    throw new Error(`${component} must be used within a <Sheet />`)
+  }
+  return context
+}
+
+export function SheetTrigger({ children }: { children: React.ReactElement }) {
+  const { setOpen } = useSheetContext('SheetTrigger')
+  return React.cloneElement(children, {
+    onClick: (event: React.MouseEvent) => {
+      children.props.onClick?.(event)
+      if (!event.defaultPrevented) {
+        setOpen(true)
+      }
+    },
+  })
+}
+
+export function SheetContent({
+  side = 'right',
+  className,
+  children,
+}: {
+  side?: 'right' | 'left'
+  className?: string
+  children: React.ReactNode
+}) {
+  const { open, setOpen } = useSheetContext('SheetContent')
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  return createPortal(
+    open ? (
+      <div className="fixed inset-0 z-50 flex">
+        <div
+          aria-hidden
+          className="flex-1 bg-black/40"
+          onClick={() => setOpen(false)}
+        />
+        <aside
+          className={cn(
+            'flex w-[320px] flex-col gap-4 border-l border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-6 shadow-xl transition-transform',
+            side === 'left' ? 'border-l-0 border-r' : '',
+            className,
+          )}
+        >
+          {children}
+        </aside>
+      </div>
+    ) : null,
+    document.body,
+  )
+}
+
+export function SheetHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('space-y-1', className)} {...props} />
+}
+
+export function SheetTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold text-[color:var(--color-text)]', className)} {...props} />
+}
+
+export function SheetDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm text-[color:var(--color-text-muted)]', className)} {...props} />
+}
+
+export function SheetFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-auto flex flex-col gap-2', className)} {...props} />
+}
+
+export function SheetClose({ children }: { children: React.ReactElement }) {
+  const { setOpen } = useSheetContext('SheetClose')
+  return React.cloneElement(children, {
+    onClick: (event: React.MouseEvent) => {
+      children.props.onClick?.(event)
+      if (!event.defaultPrevented) {
+        setOpen(false)
+      }
+    },
+  })
+}

--- a/ui/skeleton.tsx
+++ b/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils'
+
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-[color:var(--color-surface-muted)]', className)}
+      {...props}
+    />
+  )
+}

--- a/ui/table.tsx
+++ b/ui/table.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type TableProps = React.HTMLAttributes<HTMLTableElement>
+
+type TableSubComponentProps<T extends HTMLElement> = React.HTMLAttributes<T>
+
+export function Table({ className, ...props }: TableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className={cn(
+          'min-w-full divide-y divide-[color:var(--color-outline)] text-left text-sm text-[color:var(--color-text)]',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+export function TableHeader({ className, ...props }: TableSubComponentProps<HTMLTableSectionElement>) {
+  return <thead className={cn('bg-[color:var(--color-surface-muted)]', className)} {...props} />
+}
+
+export function TableBody({ className, ...props }: TableSubComponentProps<HTMLTableSectionElement>) {
+  return <tbody className={cn('divide-y divide-[color:var(--color-outline)] bg-[color:var(--color-surface)]', className)} {...props} />
+}
+
+export function TableRow({ className, ...props }: TableSubComponentProps<HTMLTableRowElement>) {
+  return <tr className={cn('transition hover:bg-[color:var(--color-surface-muted)]', className)} {...props} />
+}
+
+export function TableHead({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn('px-4 py-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]', className)}
+      {...props}
+    />
+  )
+}
+
+export function TableCell({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-4 py-3 align-top text-sm', className)} {...props} />
+}

--- a/ui/tabs.tsx
+++ b/ui/tabs.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type TabsContextValue = {
+  value: string
+  setValue: (value: string) => void
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null)
+
+export function Tabs({
+  defaultValue,
+  value,
+  onValueChange,
+  children,
+  className,
+}: {
+  defaultValue: string
+  value?: string
+  onValueChange?: (value: string) => void
+  children: React.ReactNode
+  className?: string
+}) {
+  const [internalValue, setInternalValue] = React.useState(defaultValue)
+  const isControlled = typeof value === 'string'
+  const currentValue = isControlled ? (value as string) : internalValue
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (!isControlled) {
+        setInternalValue(next)
+      }
+      onValueChange?.(next)
+    },
+    [isControlled, onValueChange],
+  )
+
+  return (
+    <TabsContext.Provider value={{ value: currentValue, setValue }}>
+      <div className={cn('space-y-3', className)}>{children}</div>
+    </TabsContext.Provider>
+  )
+}
+
+function useTabs(component: string) {
+  const context = React.useContext(TabsContext)
+  if (!context) throw new Error(`${component} must be used within <Tabs />`)
+  return context
+}
+
+export function TabsList({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-1',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+}: {
+  value: string
+  className?: string
+  children: React.ReactNode
+}) {
+  const { value: activeValue, setValue } = useTabs('TabsTrigger')
+  const active = activeValue === value
+  return (
+    <button
+      type="button"
+      onClick={() => setValue(value)}
+      className={cn(
+        'rounded-full px-3 py-1 text-sm font-medium transition',
+        active
+          ? 'bg-[color:var(--color-accent)] text-white shadow'
+          : 'text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]',
+        className,
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function TabsContent({
+  value,
+  className,
+  children,
+}: {
+  value: string
+  className?: string
+  children: React.ReactNode
+}) {
+  const { value: activeValue } = useTabs('TabsContent')
+  if (activeValue !== value) return null
+  return <div className={cn('rounded-lg border border-dashed border-[color:var(--color-outline)] p-4', className)}>{children}</div>
+}

--- a/ui/toast.tsx
+++ b/ui/toast.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type ToastVariant = 'default' | 'success' | 'warning' | 'destructive'
+
+export type Toast = {
+  id: string
+  title: string
+  description?: string
+  variant?: ToastVariant
+}
+
+type Listener = (toasts: Toast[]) => void
+
+const listeners = new Set<Listener>()
+let state: Toast[] = []
+
+function emit() {
+  for (const listener of listeners) {
+    listener([...state])
+  }
+}
+
+function removeToast(id: string) {
+  state = state.filter((toast) => toast.id !== id)
+  emit()
+}
+
+function enqueueToast(toast: Omit<Toast, 'id'> & { id?: string; duration?: number }) {
+  const id = toast.id ?? (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  const payload: Toast = { id, title: toast.title, description: toast.description, variant: toast.variant }
+  state = [...state, payload]
+  emit()
+  const duration = toast.duration ?? 4000
+  if (duration > 0) {
+    setTimeout(() => removeToast(id), duration)
+  }
+  return id
+}
+
+export function useToast() {
+  const [toasts, setToasts] = React.useState<Toast[]>(state)
+
+  React.useEffect(() => {
+    const listener: Listener = (items) => setToasts(items)
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }, [])
+
+  const showToast = React.useCallback(
+    (toast: Omit<Toast, 'id'> & { duration?: number }) => enqueueToast(toast),
+    [],
+  )
+
+  const dismiss = React.useCallback((id: string) => removeToast(id), [])
+
+  return { toasts, showToast, dismiss }
+}
+
+const variantStyles: Record<ToastVariant, string> = {
+  default: 'bg-[color:var(--color-surface)] text-[color:var(--color-text)]',
+  success: 'bg-[color:var(--color-positive)]/10 text-[color:var(--color-positive)]',
+  warning: 'bg-[color:var(--color-caution)]/10 text-[color:var(--color-caution)]',
+  destructive: 'bg-[color:var(--color-critical)]/10 text-[color:var(--color-critical)]',
+}
+
+export function ToastViewport({ className }: { className?: string }) {
+  const { toasts, dismiss } = useToast()
+
+  return (
+    <div className={cn('fixed bottom-6 right-6 flex w-80 flex-col gap-3', className)}>
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={cn('rounded-lg border border-[color:var(--color-outline)] p-4 shadow-md', variantStyles[toast.variant ?? 'default'])}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold">{toast.title}</p>
+              {toast.description ? (
+                <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">{toast.description}</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]"
+              onClick={() => dismiss(toast.id)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function showToast(toast: Omit<Toast, 'id'> & { id?: string; duration?: number }) {
+  return enqueueToast(toast)
+}
+
+export function dismissToast(id: string) {
+  removeToast(id)
+}

--- a/ui/tokens.ts
+++ b/ui/tokens.ts
@@ -1,0 +1,57 @@
+export const colors = {
+  background: '#f9fafb',
+  surface: '#ffffff',
+  surfaceMuted: '#f3f4f6',
+  border: '#e5e7eb',
+  outline: '#d1d5db',
+  text: '#111827',
+  textMuted: '#6b7280',
+  accent: '#111827',
+  accentMuted: '#4b5563',
+  positive: '#16a34a',
+  caution: '#f59e0b',
+  critical: '#ef4444',
+}
+
+export const spacing = {
+  none: '0',
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '0.75rem',
+  lg: '1rem',
+  xl: '1.5rem',
+  '2xl': '2rem',
+}
+
+export const radius = {
+  sm: '0.375rem',
+  md: '0.5rem',
+  lg: '0.75rem',
+  xl: '1rem',
+  full: '9999px',
+}
+
+export const fontSizes = {
+  xs: '0.75rem',
+  sm: '0.875rem',
+  base: '1rem',
+  lg: '1.125rem',
+  xl: '1.25rem',
+  '2xl': '1.5rem',
+  '3xl': '1.875rem',
+}
+
+export const shadows = {
+  sm: '0 1px 2px 0 rgba(15, 23, 42, 0.05)',
+  md: '0 10px 25px -10px rgba(15, 23, 42, 0.2)',
+}
+
+export const tokens = {
+  colors,
+  spacing,
+  radius,
+  fontSizes,
+  shadows,
+}
+
+export type Tokens = typeof tokens


### PR DESCRIPTION
## Summary
- extract tailwind tokens and add reusable UI primitives for the RevenueOS shell
- implement the new layout with command palette, focus timer, and zero-state routes across core modules
- add daily plan, feature flag, and share modules with server actions backed by in-memory stores

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e71846bc4c8324a961357e19f484d9