### PR TITLE
feat: launch revenue content studio

### DIFF
--- a/app/content/content-studio.tsx
+++ b/app/content/content-studio.tsx
@@ -1,0 +1,1121 @@
+'use client'
+
+import { useCallback, useMemo, useState, useTransition } from 'react'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Input } from '@/ui/input'
+import { Select } from '@/ui/select'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/ui/table'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/ui/sheet'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/dialog'
+import {
+  ContentItem,
+  ContentStatus,
+  Distribution,
+  Metrics,
+  Touch,
+  Variant,
+} from '@/core/content/types'
+import { ContentSuggestion } from '@/core/content/recommender'
+import {
+  createItem as actionCreateItem,
+  createVariant as actionCreateVariant,
+  getContentSnapshot,
+  getMetrics as actionGetMetrics,
+  getSuggestions as actionGetSuggestions,
+  markExperimentOutcome,
+  recordTouch as actionRecordTouch,
+  saveBrief as actionSaveBrief,
+  scheduleDistribution as actionScheduleDistribution,
+  updateItem as actionUpdateItem,
+  updateStatus as actionUpdateStatus,
+} from '@/core/content/actions'
+import {
+  MediaChannel,
+  MediaDistribution,
+  MediaIdea,
+  MediaMetrics,
+  MediaProject,
+} from '@/core/mediaAgent/types'
+import {
+  actionCreateProjectFromIdea,
+  actionGenerateAssets,
+  actionIngestTranscript,
+  actionMarkRecording,
+  actionMediaMetrics,
+  actionMediaState,
+  actionScheduleDistribution as actionScheduleMediaDistribution,
+  actionSuggestIdeas,
+} from '@/core/mediaAgent/actions'
+
+const statusOrder: ContentStatus[] = ['Idea', 'Draft', 'Review', 'Scheduled', 'Published']
+const stageOptions: ContentItem['stage'][] = ['Discovery', 'Evaluation', 'Decision', 'Onboarding', 'Adoption']
+const contentTypes = ['One-pager', 'Guide', 'Newsletter', 'Insight Report', 'Battlecard']
+const distributionChannels = ['LinkedIn', 'Email', 'YouTube', 'Podcast', 'X', 'Partner']
+
+export interface ContentStudioProps {
+  initialItems: ContentItem[]
+  initialVariants: Variant[]
+  initialDistributions: Distribution[]
+  initialTouches: Touch[]
+  metrics: Metrics
+  suggestions: ContentSuggestion[]
+  mediaIdeas: MediaIdea[]
+  mediaProjects: MediaProject[]
+  mediaDistributions: MediaDistribution[]
+  mediaMetrics: MediaMetrics
+}
+
+export function ContentStudio(props: ContentStudioProps) {
+  const [items, setItems] = useState(props.initialItems)
+  const [variants, setVariants] = useState(props.initialVariants)
+  const [distributions, setDistributions] = useState(props.initialDistributions)
+  const [touches, setTouches] = useState(props.initialTouches)
+  const [metrics, setMetrics] = useState(props.metrics)
+  const [suggestions, setSuggestions] = useState(props.suggestions)
+  const [mediaIdeas, setMediaIdeas] = useState(props.mediaIdeas)
+  const [mediaProjects, setMediaProjects] = useState(props.mediaProjects)
+  const [mediaDistributions, setMediaDistributions] = useState(props.mediaDistributions)
+  const [mediaMetrics, setMediaMetrics] = useState(props.mediaMetrics)
+
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null)
+  const [activeDrawerTab, setActiveDrawerTab] = useState('overview')
+  const [isPending, startTransition] = useTransition()
+  const [requestForm, setRequestForm] = useState({
+    title: '',
+    persona: '',
+    stage: stageOptions[0],
+    objection: '',
+    priority: 'Medium',
+  })
+  const [transcriptTarget, setTranscriptTarget] = useState<MediaProject | null>(null)
+  const [transcriptDraft, setTranscriptDraft] = useState('')
+
+  const selectedItem = useMemo(
+    () => (selectedItemId ? items.find(item => item.id === selectedItemId) ?? null : null),
+    [items, selectedItemId],
+  )
+
+  const relatedVariants = useMemo(
+    () => (selectedItem ? variants.filter(variant => variant.contentId === selectedItem.id) : []),
+    [selectedItem, variants],
+  )
+
+  const relatedDistributions = useMemo(
+    () => (selectedItem ? distributions.filter(entry => entry.contentId === selectedItem.id) : []),
+    [distributions, selectedItem],
+  )
+
+  const relatedTouches = useMemo(
+    () => (selectedItem ? touches.filter(touch => touch.contentId === selectedItem.id) : []),
+    [selectedItem, touches],
+  )
+
+  const mediaProjectsWithIdea = useMemo(() => {
+    return mediaProjects.map(project => ({
+      project,
+      idea: mediaIdeas.find(idea => idea.id === project.ideaId) ?? null,
+      scheduled: mediaDistributions.filter(entry => entry.projectId === project.id),
+    }))
+  }, [mediaDistributions, mediaIdeas, mediaProjects])
+
+  const refreshContent = useCallback(async () => {
+    const [snapshot, updatedMetrics, updatedSuggestions] = await Promise.all([
+      getContentSnapshot(),
+      actionGetMetrics(),
+      actionGetSuggestions(),
+    ])
+    setItems(snapshot.items)
+    setVariants(snapshot.variants)
+    setDistributions(snapshot.distributions)
+    setTouches(snapshot.touches)
+    setMetrics(updatedMetrics)
+    setSuggestions(updatedSuggestions)
+  }, [])
+
+  const refreshMedia = useCallback(async () => {
+    const [state, updatedMetrics, ideas] = await Promise.all([
+      actionMediaState(),
+      actionMediaMetrics(),
+      actionSuggestIdeas(),
+    ])
+    setMediaProjects(state.projects)
+    setMediaDistributions(state.distributions)
+    setMediaIdeas(ideas)
+    setMediaMetrics(updatedMetrics)
+  }, [])
+
+  const handleMove = (item: ContentItem, direction: 'forward' | 'back') => {
+    const index = statusOrder.indexOf(item.status)
+    const nextIndex = direction === 'forward' ? index + 1 : index - 1
+    if (nextIndex < 0 || nextIndex >= statusOrder.length) return
+    const nextStatus = statusOrder[nextIndex]
+    startTransition(async () => {
+      await actionUpdateStatus(item.id, nextStatus)
+      await refreshContent()
+    })
+  }
+
+  const handleStatusChange = (status: ContentStatus) => {
+    if (!selectedItem) return
+    startTransition(async () => {
+      await actionUpdateStatus(selectedItem.id, status)
+      await refreshContent()
+    })
+  }
+
+  const handleBriefSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedItem) return
+    const formData = new FormData(event.currentTarget)
+    const brief = {
+      cta: (formData.get('cta') as string) ?? '',
+      outline: (formData.get('outline') as string) ?? '',
+      notes: (formData.get('notes') as string) ?? '',
+    }
+    startTransition(async () => {
+      await actionSaveBrief(selectedItem.id, brief)
+      await refreshContent()
+    })
+  }
+
+  const handleVariantCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedItem) return
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      await actionCreateVariant({
+        contentId: selectedItem.id,
+        kind: (formData.get('kind') as string) || 'CTA',
+        headline: (formData.get('headline') as string) || 'Untitled headline',
+        cta: (formData.get('cta') as string) || 'Learn more',
+        group: (formData.get('group') as string) as 'A' | 'B' | undefined,
+      })
+      event.currentTarget.reset()
+      await refreshContent()
+    })
+  }
+
+  const handleVariantDecision = (variant: Variant, decision: 'kill' | 'scale') => {
+    const status = decision === 'kill' ? 'retired' : 'scaling'
+    startTransition(async () => {
+      await markExperimentOutcome(variant.id, status)
+      await refreshContent()
+    })
+  }
+
+  const handleTouchUpdate = (touch: Touch, action: Touch['action']) => {
+    startTransition(async () => {
+      await actionRecordTouch({
+        id: touch.id,
+        contentId: touch.contentId,
+        opportunityId: touch.opportunityId,
+        actor: touch.actor,
+        action,
+      })
+      await refreshContent()
+    })
+  }
+
+  const handleTouchCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedItem) return
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      await actionRecordTouch({
+        contentId: selectedItem.id,
+        opportunityId: (formData.get('opportunity') as string) || 'opportunity',
+        actor: (formData.get('actor') as string) || 'sales-user',
+        action: (formData.get('touch-action') as Touch['action']) || 'used',
+      })
+      event.currentTarget.reset()
+      await refreshContent()
+    })
+  }
+
+  const handleDistributionSchedule = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedItem) return
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      await actionScheduleDistribution({
+        contentId: selectedItem.id,
+        channel: (formData.get('channel') as string) || 'LinkedIn',
+        whenISO: formData.get('when') as string,
+        utm: (formData.get('utm') as string) || undefined,
+      })
+      event.currentTarget.reset()
+      await refreshContent()
+    })
+  }
+
+  const handlePublishStub = () => {
+    if (!selectedItem) return
+    startTransition(async () => {
+      await actionRecordTouch({
+        contentId: selectedItem.id,
+        opportunityId: 'marketing-release',
+        actor: 'content-bot',
+        action: 'used',
+      })
+      await refreshContent()
+    })
+  }
+
+  const handleRequestSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const { title, persona, stage, objection, priority } = requestForm
+    if (!title || !persona) return
+    const sla = priority === 'High' ? '24h' : priority === 'Low' ? '5d' : '72h'
+    startTransition(async () => {
+      await actionCreateItem({
+        title,
+        type: 'Enablement request',
+        persona,
+        stage: stage as ContentItem['stage'],
+        objection,
+        ownerId: 'intake-bot',
+        status: 'Idea',
+        sla,
+      })
+      setRequestForm({ title: '', persona: '', stage: stageOptions[0], objection: '', priority: 'Medium' })
+      await refreshContent()
+    })
+  }
+
+  const handleCopySnippet = (item: ContentItem) => {
+    const snippet = `${item.title} — ${item.persona} | ${item.stage}. CTA: ${item.brief?.cta ?? 'Book time.'}`
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(snippet)
+    }
+  }
+
+  const handleCreateDraftFromSuggestion = (suggestion: ContentSuggestion) => {
+    startTransition(async () => {
+      await actionCreateItem({
+        title: suggestion.title,
+        type: contentTypes[0],
+        persona: suggestion.persona,
+        stage: suggestion.stage,
+        objection: suggestion.objection,
+        ownerId: 'qra-team',
+        status: 'Draft',
+        sla: '72h',
+      })
+      await refreshContent()
+    })
+  }
+
+  const handleCreateMediaProject = (idea: MediaIdea) => {
+    startTransition(async () => {
+      await actionCreateProjectFromIdea(idea.id)
+      await refreshMedia()
+    })
+  }
+
+  const handleMarkRecording = (project: MediaProject) => {
+    startTransition(async () => {
+      await actionMarkRecording(project.id)
+      await refreshMedia()
+    })
+  }
+
+  const handleTranscriptSave = () => {
+    if (!transcriptTarget) return
+    startTransition(async () => {
+      await actionIngestTranscript(transcriptTarget.id, transcriptDraft)
+      setTranscriptTarget(null)
+      setTranscriptDraft('')
+      await refreshMedia()
+    })
+  }
+
+  const handleGenerateAssets = (project: MediaProject) => {
+    startTransition(async () => {
+      await actionGenerateAssets(project.id)
+      await refreshMedia()
+    })
+  }
+
+  const handleScheduleMedia = (event: React.FormEvent<HTMLFormElement>, project: MediaProject) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      await actionScheduleMediaDistribution(
+        project.id,
+        ((formData.get('channel') as string) || 'LinkedIn') as MediaChannel,
+        (formData.get('when') as string) ?? undefined,
+      )
+      event.currentTarget.reset()
+      await refreshMedia()
+    })
+  }
+
+  const usageRatePercent = useMemo(() => Math.round(metrics.usageRate * 100), [metrics.usageRate])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Content Studio</PageTitle>
+        <PageDescription>
+          Editorial calendar, revenue experiments, and media pipelines in one workspace.
+        </PageDescription>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge variant="success">{items.filter(item => item.status === 'Published').length} Published</Badge>
+          <Badge variant="default">{items.filter(item => item.status !== 'Published').length} In Motion</Badge>
+        </div>
+      </PageHeader>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Influenced pipeline</CardTitle>
+            <CardDescription>Attributed to content touches</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-[color:var(--color-text)]">${metrics.influenced.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Advanced pipeline</CardTitle>
+            <CardDescription>Opportunities moved forward</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-[color:var(--color-text)]">${metrics.advanced.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Closed won</CardTitle>
+            <CardDescription>Influenced via content</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-[color:var(--color-text)]">${metrics.closedWon.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Usage rate</CardTitle>
+            <CardDescription>Touches per asset</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-[color:var(--color-text)]">{usageRatePercent}%</p>
+            <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">{metrics.views.toLocaleString()} views · {metrics.ctr}% CTR</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_minmax(320px,1fr)]">
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <CardTitle>QRA suggestions</CardTitle>
+                  <CardDescription>Top content and media moves from pipeline gaps.</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="content">
+                <TabsList>
+                  <TabsTrigger value="content">Content</TabsTrigger>
+                  <TabsTrigger value="media">Media Agent</TabsTrigger>
+                </TabsList>
+                <TabsContent value="content" className="border-none p-0">
+                  <div className="grid gap-4 md:grid-cols-3">
+                    {suggestions.map(suggestion => (
+                      <div key={suggestion.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4">
+                        <p className="font-medium text-[color:var(--color-text)]">{suggestion.title}</p>
+                        <p className="mt-1 text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                          {suggestion.persona} · {suggestion.stage}
+                        </p>
+                        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">Objection: {suggestion.objection}</p>
+                        <p className="mt-2 text-xs text-[color:var(--color-text-muted)]">
+                          Impact {suggestion.expectedImpact} · Effort {suggestion.effort}
+                        </p>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          className="mt-3"
+                          onClick={() => handleCreateDraftFromSuggestion(suggestion)}
+                          disabled={isPending}
+                        >
+                          Create draft
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </TabsContent>
+                <TabsContent value="media" className="border-none p-0">
+                  <div className="grid gap-4 md:grid-cols-3">
+                    {mediaIdeas.map(idea => (
+                      <div key={idea.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4">
+                        <p className="font-medium text-[color:var(--color-text)]">{idea.title}</p>
+                        <p className="mt-1 text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                          {idea.persona} · {idea.stage}
+                        </p>
+                        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{idea.objection}</p>
+                        <p className="mt-2 text-xs text-[color:var(--color-text-muted)]">
+                          Impact {idea.expectedImpact} · Effort {idea.effort}
+                        </p>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="mt-3"
+                          onClick={() => handleCreateMediaProject(idea)}
+                          disabled={isPending}
+                        >
+                          Create media project
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Kanban</CardTitle>
+              <CardDescription>Idea to published, ready for revenue activation.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                {statusOrder.map(status => (
+                  <div key={status} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-[color:var(--color-text)]">{status}</p>
+                      <Badge variant="outline">{items.filter(item => item.status === status).length}</Badge>
+                    </div>
+                    <div className="mt-3 space-y-3">
+                      {items
+                        .filter(item => item.status === status)
+                        .map(item => (
+                          <div
+                            key={item.id}
+                            className="space-y-2 rounded-md border border-[color:var(--color-outline)] bg-white p-3 text-sm shadow-sm transition hover:border-[color:var(--color-accent-muted)]"
+                          >
+                            <button
+                              type="button"
+                              className="text-left text-[color:var(--color-text)]"
+                              onClick={() => {
+                                setSelectedItemId(item.id)
+                                setActiveDrawerTab('overview')
+                              }}
+                            >
+                              <span className="font-medium">{item.title}</span>
+                              <span className="mt-1 block text-xs text-[color:var(--color-text-muted)]">
+                                {item.persona} · {item.stage}
+                              </span>
+                            </button>
+                            <div className="flex items-center gap-2">
+                              <Button
+                                size="sm"
+                                className="h-7 px-2 text-[11px]"
+                                variant="outline"
+                                onClick={() => handleMove(item, 'back')}
+                                disabled={status === 'Idea' || isPending}
+                              >
+                                Back
+                              </Button>
+                              <Button
+                                size="sm"
+                                className="h-7 px-2 text-[11px]"
+                                variant="primary"
+                                onClick={() => handleMove(item, 'forward')}
+                                disabled={status === 'Published' || isPending}
+                              >
+                                Move
+                              </Button>
+                              <Button
+                                size="sm"
+                                className="h-7 px-2 text-[11px]"
+                                variant="outline"
+                                onClick={() => handleCopySnippet(item)}
+                              >
+                                Copy
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Media Agent</CardTitle>
+              <CardDescription>Coordinate Jellypod production and distribution.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <Card className="border-dashed">
+                  <CardHeader>
+                    <CardTitle className="text-base">Influenced pipeline</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-semibold text-[color:var(--color-text)]">
+                      ${mediaMetrics.influenced.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="border-dashed">
+                  <CardHeader>
+                    <CardTitle className="text-base">Advanced</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-semibold text-[color:var(--color-text)]">
+                      ${mediaMetrics.advanced.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="border-dashed">
+                  <CardHeader>
+                    <CardTitle className="text-base">Closed won</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-semibold text-[color:var(--color-text)]">
+                      ${mediaMetrics.closedWon.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="border-dashed">
+                  <CardHeader>
+                    <CardTitle className="text-base">Reach</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-semibold text-[color:var(--color-text)]">
+                      {mediaMetrics.views.toLocaleString()} views
+                    </p>
+                    <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">CTR {mediaMetrics.ctr}%</p>
+                  </CardContent>
+                </Card>
+              </div>
+
+              <div className="space-y-4">
+                {mediaProjectsWithIdea.map(({ project, idea, scheduled }) => (
+                  <div key={project.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-[color:var(--color-text)]">{idea?.title ?? 'Media project'}</p>
+                        <p className="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                          {idea?.persona ?? 'Persona'} · {idea?.stage ?? 'Stage'}
+                        </p>
+                      </div>
+                      <Badge variant={project.status === 'Published' ? 'success' : 'outline'}>{project.status}</Badge>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {project.jellypodUrl ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => window.open(project.jellypodUrl!, '_blank', 'noopener,noreferrer')}
+                        >
+                          Record in Jellypod
+                        </Button>
+                      ) : null}
+                      <Button
+                        size="sm"
+                        variant="primary"
+                        onClick={() => handleMarkRecording(project)}
+                        disabled={isPending}
+                      >
+                        Mark recording
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          setTranscriptTarget(project)
+                          setTranscriptDraft(project.transcript ?? '')
+                        }}
+                      >
+                        Paste transcript
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleGenerateAssets(project)}
+                        disabled={isPending}
+                      >
+                        Generate assets
+                      </Button>
+                    </div>
+                    {project.artifacts.podcastUrl || project.artifacts.youtubeUrl ? (
+                      <div className="mt-4 grid gap-2 text-sm text-[color:var(--color-text)]">
+                        {project.artifacts.podcastUrl ? (
+                          <a
+                            href={project.artifacts.podcastUrl}
+                            className="text-[color:var(--color-accent)] underline"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Podcast episode
+                          </a>
+                        ) : null}
+                        {project.artifacts.youtubeUrl ? (
+                          <a
+                            href={project.artifacts.youtubeUrl}
+                            className="text-[color:var(--color-accent)] underline"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            YouTube cut
+                          </a>
+                        ) : null}
+                        {project.artifacts.shorts.length ? (
+                          <div>
+                            <p className="font-medium">Shorts</p>
+                            <ul className="mt-1 list-inside list-disc text-xs text-[color:var(--color-text-muted)]">
+                              {project.artifacts.shorts.map(short => (
+                                <li key={short}>{short}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : null}
+                        {project.artifacts.social.length ? (
+                          <div>
+                            <p className="font-medium">Social copy</p>
+                            <ul className="mt-1 list-inside list-disc text-xs text-[color:var(--color-text-muted)]">
+                              {project.artifacts.social.map(post => (
+                                <li key={post}>{post}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : null}
+                        {project.artifacts.emails.length ? (
+                          <div>
+                            <p className="font-medium">Emails</p>
+                            <ul className="mt-1 list-inside list-disc text-xs text-[color:var(--color-text-muted)]">
+                              {project.artifacts.emails.map(email => (
+                                <li key={email}>{email}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : null}
+                        {project.artifacts.thumbnailPrompt ? (
+                          <p className="text-xs text-[color:var(--color-text-muted)]">
+                            Thumbnail: {project.artifacts.thumbnailPrompt}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    <form className="mt-4 flex flex-wrap gap-2" onSubmit={event => handleScheduleMedia(event, project)}>
+                      <Select name="channel" defaultValue="LinkedIn" className="w-32">
+                        {distributionChannels.map(channel => (
+                          <option key={channel} value={channel}>
+                            {channel}
+                          </option>
+                        ))}
+                      </Select>
+                      <Input type="datetime-local" name="when" className="w-48" />
+                      <Button type="submit" variant="outline" size="sm" disabled={isPending}>
+                        Schedule
+                      </Button>
+                    </form>
+                    {scheduled.length ? (
+                      <div className="mt-3 text-xs text-[color:var(--color-text-muted)]">
+                        <p className="font-medium text-[color:var(--color-text)]">Distribution</p>
+                        <ul className="mt-1 space-y-1">
+                          {scheduled.map(entry => (
+                            <li key={entry.id}>
+                              {entry.channel} · {entry.scheduledAt ? new Date(entry.scheduledAt).toLocaleString() : 'Pending'}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Request intake</CardTitle>
+              <CardDescription>Capture new briefs with SLA targets.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-3" onSubmit={handleRequestSubmit}>
+                <Input
+                  placeholder="Asset title"
+                  value={requestForm.title}
+                  onChange={event => setRequestForm(form => ({ ...form, title: event.target.value }))}
+                />
+                <Input
+                  placeholder="Persona"
+                  value={requestForm.persona}
+                  onChange={event => setRequestForm(form => ({ ...form, persona: event.target.value }))}
+                />
+                <Select
+                  value={requestForm.stage}
+                  onChange={event => setRequestForm(form => ({ ...form, stage: event.target.value as ContentItem['stage'] }))}
+                >
+                  {stageOptions.map(option => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </Select>
+                <Input
+                  placeholder="Objection"
+                  value={requestForm.objection}
+                  onChange={event => setRequestForm(form => ({ ...form, objection: event.target.value }))}
+                />
+                <Select
+                  value={requestForm.priority}
+                  onChange={event => setRequestForm(form => ({ ...form, priority: event.target.value }))}
+                >
+                  <option value="High">High</option>
+                  <option value="Medium">Medium</option>
+                  <option value="Low">Low</option>
+                </Select>
+                <Button type="submit" variant="primary" disabled={isPending}>
+                  Log request
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Sheet open={!!selectedItem} onOpenChange={open => !open && setSelectedItemId(null)}>
+        <SheetContent className="max-w-lg overflow-y-auto">
+          {selectedItem ? (
+            <div className="flex h-full flex-col gap-4">
+              <SheetHeader>
+                <SheetTitle>{selectedItem.title}</SheetTitle>
+                <p className="text-sm text-[color:var(--color-text-muted)]">
+                  {selectedItem.persona} · {selectedItem.stage}
+                </p>
+              </SheetHeader>
+              <Tabs value={activeDrawerTab} onValueChange={setActiveDrawerTab} defaultValue="overview">
+                <TabsList className="w-full justify-start">
+                  <TabsTrigger value="overview">Overview</TabsTrigger>
+                  <TabsTrigger value="brief">Brief</TabsTrigger>
+                  <TabsTrigger value="variants">Variants</TabsTrigger>
+                  <TabsTrigger value="distribution">Distribution</TabsTrigger>
+                  <TabsTrigger value="performance">Performance</TabsTrigger>
+                </TabsList>
+                <TabsContent value="overview">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium text-[color:var(--color-text)]">Status</p>
+                      <Badge variant="outline">SLA {selectedItem.sla}</Badge>
+                    </div>
+                    <Select value={selectedItem.status} onChange={event => handleStatusChange(event.target.value as ContentStatus)}>
+                      {statusOrder.map(status => (
+                        <option key={status} value={status}>
+                          {status}
+                        </option>
+                      ))}
+                    </Select>
+                    <div className="grid grid-cols-2 gap-2 text-sm text-[color:var(--color-text-muted)]">
+                      <div>
+                        <p className="font-medium text-[color:var(--color-text)]">Owner</p>
+                        <p>{selectedItem.ownerId}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-[color:var(--color-text)]">Created</p>
+                        <p>{new Date(selectedItem.createdAt).toLocaleDateString()}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-[color:var(--color-text)]">Type</p>
+                        <p>{selectedItem.type}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-[color:var(--color-text)]">Cost</p>
+                        <p>${selectedItem.cost.toLocaleString()}</p>
+                      </div>
+                    </div>
+                    <Button variant="outline" size="sm" onClick={() => handleCopySnippet(selectedItem)}>
+                      Copy snippet
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => console.info('Insert into email stub')}
+                    >
+                      Insert into email
+                    </Button>
+                  </div>
+                </TabsContent>
+                <TabsContent value="brief">
+                  <form className="space-y-3" onSubmit={handleBriefSave}>
+                    <Input name="cta" placeholder="CTA" defaultValue={selectedItem.brief?.cta} />
+                    <textarea
+                      name="outline"
+                      placeholder="Outline"
+                      defaultValue={selectedItem.brief?.outline}
+                      className="h-24 w-full rounded-md border border-[color:var(--color-outline)] p-2 text-sm"
+                    />
+                    <textarea
+                      name="notes"
+                      placeholder="Notes"
+                      defaultValue={selectedItem.brief?.notes}
+                      className="h-20 w-full rounded-md border border-[color:var(--color-outline)] p-2 text-sm"
+                    />
+                    <Button type="submit" variant="primary" disabled={isPending}>
+                      Save brief
+                    </Button>
+                  </form>
+                </TabsContent>
+                <TabsContent value="variants">
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      {relatedVariants.length ? (
+                        relatedVariants.map(variant => {
+                          const touchesForContent = relatedTouches.length
+                          const shouldDecide = touchesForContent >= 5 || (metrics.views ?? 0) >= 200
+                          return (
+                            <div
+                              key={variant.id}
+                              className="rounded-md border border-[color:var(--color-outline)] bg-white p-3 text-sm"
+                            >
+                              <p className="font-medium text-[color:var(--color-text)]">{variant.headline}</p>
+                              <p className="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                                {variant.kind} · Group {variant.group ?? '—'}
+                              </p>
+                              <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">CTA: {variant.cta}</p>
+                              <p className="mt-2 text-xs text-[color:var(--color-accent)]">Status: {variant.status}</p>
+                              {shouldDecide ? (
+                                <div className="mt-2 flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    className="h-7 px-2 text-[11px]"
+                                    variant="outline"
+                                    onClick={() => handleVariantDecision(variant, 'kill')}
+                                  >
+                                    Kill
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    className="h-7 px-2 text-[11px]"
+                                    variant="primary"
+                                    onClick={() => handleVariantDecision(variant, 'scale')}
+                                  >
+                                    Scale
+                                  </Button>
+                                </div>
+                              ) : null}
+                            </div>
+                          )
+                        })
+                      ) : (
+                        <p className="text-sm text-[color:var(--color-text-muted)]">No variants yet.</p>
+                      )}
+                    </div>
+                    <form className="space-y-2" onSubmit={handleVariantCreate}>
+                      <Input name="kind" placeholder="Variant type" />
+                      <Input name="headline" placeholder="Headline" />
+                      <Input name="cta" placeholder="CTA" />
+                      <Select name="group" defaultValue="">
+                        <option value="">Group</option>
+                        <option value="A">A</option>
+                        <option value="B">B</option>
+                      </Select>
+                      <Button type="submit" variant="outline" size="sm" disabled={isPending}>
+                        New variant
+                      </Button>
+                    </form>
+                  </div>
+                </TabsContent>
+                <TabsContent value="distribution">
+                  <div className="space-y-4">
+                    <form className="flex flex-col gap-2" onSubmit={handleDistributionSchedule}>
+                      <Select name="channel" defaultValue="LinkedIn">
+                        {distributionChannels.map(channel => (
+                          <option key={channel} value={channel}>
+                            {channel}
+                          </option>
+                        ))}
+                      </Select>
+                      <Input name="utm" placeholder="Generate UTM" />
+                      <Input type="datetime-local" name="when" />
+                      <Button type="submit" variant="outline" size="sm" disabled={isPending}>
+                        Schedule drop
+                      </Button>
+                    </form>
+                    <Button variant="primary" size="sm" onClick={handlePublishStub} disabled={isPending}>
+                      Publish (stub)
+                    </Button>
+                    <div className="space-y-2 text-sm text-[color:var(--color-text)]">
+                      {relatedDistributions.length ? (
+                        relatedDistributions.map(entry => (
+                          <div key={entry.id} className="rounded border border-[color:var(--color-outline)] p-2">
+                            <p className="font-medium">{entry.channel}</p>
+                            <p className="text-xs text-[color:var(--color-text-muted)]">
+                              {entry.scheduledAt
+                                ? `Scheduled ${new Date(entry.scheduledAt).toLocaleString()}`
+                                : entry.publishedAt
+                                  ? `Published ${new Date(entry.publishedAt).toLocaleString()}`
+                                  : 'Pending'}
+                            </p>
+                            {entry.utm ? <p className="text-xs text-[color:var(--color-text-muted)]">{entry.utm}</p> : null}
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-[color:var(--color-text-muted)]">No distribution planned.</p>
+                      )}
+                    </div>
+                  </div>
+                </TabsContent>
+                <TabsContent value="performance">
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-2 gap-2 text-xs text-[color:var(--color-text-muted)]">
+                      <div className="rounded-md border border-dashed border-[color:var(--color-outline)] p-3">
+                        <p className="text-xs font-semibold text-[color:var(--color-text)]">Touches</p>
+                        <p>{relatedTouches.length}</p>
+                      </div>
+                      <div className="rounded-md border border-dashed border-[color:var(--color-outline)] p-3">
+                        <p className="text-xs font-semibold text-[color:var(--color-text)]">Variant decision</p>
+                        <p>{relatedTouches.length >= 5 ? 'Ready for decision' : 'Collecting data'}</p>
+                      </div>
+                    </div>
+                    <form className="grid gap-2" onSubmit={handleTouchCreate}>
+                      <Input name="opportunity" placeholder="Opportunity ID" />
+                      <Input name="actor" placeholder="Actor" />
+                      <Select name="touch-action" defaultValue="used">
+                        <option value="used">Used</option>
+                        <option value="worked">Worked</option>
+                        <option value="failed">Failed</option>
+                      </Select>
+                      <Button type="submit" size="sm" variant="outline" disabled={isPending}>
+                        Log touch
+                      </Button>
+                    </form>
+                    <div className="rounded-lg border border-[color:var(--color-outline)]">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Opportunity</TableHead>
+                            <TableHead>Actor</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead>Logged</TableHead>
+                            <TableHead className="text-right">Actions</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {relatedTouches.length ? (
+                            relatedTouches.map(touch => (
+                              <TableRow key={touch.id}>
+                                <TableCell>{touch.opportunityId}</TableCell>
+                                <TableCell>{touch.actor}</TableCell>
+                                <TableCell>
+                                  <Badge
+                                    variant={
+                                      touch.action === 'worked'
+                                        ? 'success'
+                                        : touch.action === 'failed'
+                                          ? 'outline'
+                                          : 'default'
+                                    }
+                                  >
+                                    {touch.action}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell className="text-xs text-[color:var(--color-text-muted)]">
+                                  {new Date(touch.ts).toLocaleString()}
+                                </TableCell>
+                                <TableCell className="space-x-1 text-right">
+                                  <Button
+                                    size="sm"
+                                    className="h-7 px-2 text-[11px]"
+                                    variant="outline"
+                                    onClick={() => handleTouchUpdate(touch, 'worked')}
+                                  >
+                                    Worked
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    className="h-7 px-2 text-[11px]"
+                                    variant="outline"
+                                    onClick={() => handleTouchUpdate(touch, 'failed')}
+                                  >
+                                    Failed
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          ) : (
+                            <TableRow>
+                              <TableCell colSpan={5} className="text-center text-sm text-[color:var(--color-text-muted)]">
+                                No touches recorded yet.
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+                </TabsContent>
+              </Tabs>
+              <SheetFooter>
+                <SheetClose>
+                  <Button variant="outline">Close</Button>
+                </SheetClose>
+              </SheetFooter>
+            </div>
+          ) : null}
+        </SheetContent>
+      </Sheet>
+
+      <Dialog open={!!transcriptTarget} onOpenChange={open => !open && setTranscriptTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Ingest transcript</DialogTitle>
+            <DialogDescription>Drop Jellypod transcript for asset generation.</DialogDescription>
+          </DialogHeader>
+          <textarea
+            value={transcriptDraft}
+            onChange={event => setTranscriptDraft(event.target.value)}
+            className="mt-4 h-40 w-full rounded-md border border-[color:var(--color-outline)] p-2 text-sm"
+            placeholder="Paste transcript..."
+          />
+          <DialogFooter>
+            <DialogClose>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button variant="primary" onClick={handleTranscriptSave} disabled={isPending || !transcriptDraft.trim()}>
+              Save transcript
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -1,167 +1,29 @@
-import { Badge } from '@/ui/badge'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
-import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
-import { Button } from '@/ui/button'
-import { Input } from '@/ui/input'
+import { ContentStudio } from './content-studio'
+import { computeMetrics, getContentState } from '@/core/content/store'
+import { nextBestContent } from '@/core/content/recommender'
+import { computeMediaMetrics, getMediaState } from '@/core/mediaAgent/store'
+import { suggestMediaFromPipeline } from '@/core/mediaAgent/recommender'
 
-const mockContent = [
-  { id: '1', title: 'Q4 Revenue Growth Insights', type: 'Blog Post', status: 'Published', publishDate: '2025-10-05', author: 'Marketing Team', views: 1240 },
-  { id: '2', title: 'Customer Success Best Practices', type: 'Guide', status: 'In Review', publishDate: '2025-10-20', author: 'Sarah Chen', views: 0 },
-  { id: '3', title: 'Partner Enablement Deck', type: 'Presentation', status: 'Draft', publishDate: '2025-10-28', author: 'Alex Rivera', views: 0 },
-  { id: '4', title: 'ROI Calculator Tool', type: 'Interactive', status: 'In Production', publishDate: '2025-11-01', author: 'Product Team', views: 450 },
-  { id: '5', title: 'Weekly Revenue Briefing', type: 'Newsletter', status: 'Scheduled', publishDate: '2025-10-15', author: 'Mike Johnson', views: 0 },
-]
+export default async function ContentPage() {
+  const contentState = getContentState()
+  const metrics = computeMetrics()
+  const suggestions = nextBestContent()
+  const mediaState = getMediaState()
+  const mediaMetrics = computeMediaMetrics()
+  const mediaIdeas = suggestMediaFromPipeline()
 
-const assetRequests = [
-  { id: '1', title: 'Sales battle card for new feature', requestedBy: 'Sarah Chen', priority: 'High', status: 'In Progress', dueDate: '2025-10-18' },
-  { id: '2', title: 'Case study: TechVentures success story', requestedBy: 'Mike Johnson', priority: 'Medium', status: 'Pending', dueDate: '2025-10-25' },
-  { id: '3', title: 'Partner co-marketing one-pager', requestedBy: 'Alex Rivera', priority: 'Low', status: 'Pending', dueDate: '2025-11-01' },
-]
-
-export default function ContentPage() {
   return (
-    <div className="space-y-6">
-      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
-        <PageTitle>Content</PageTitle>
-        <PageDescription>
-          Editorial calendar, asset library, and enablement resources powering revenue narratives.
-        </PageDescription>
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge variant="success">{mockContent.filter(c => c.status === 'Published').length} Published</Badge>
-          <Badge variant="default">{mockContent.filter(c => c.status === 'Draft' || c.status === 'In Review').length} In Progress</Badge>
-        </div>
-      </PageHeader>
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Total Content Pieces</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold text-[color:var(--color-text)]">{mockContent.length}</p>
-            <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">Across all formats</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Total Views (30d)</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold text-[color:var(--color-text)]">
-              {mockContent.reduce((sum, c) => sum + c.views, 0).toLocaleString()}
-            </p>
-            <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">Published content only</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Pending Requests</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold text-[color:var(--color-text)]">
-              {assetRequests.filter(r => r.status === 'Pending').length}
-            </p>
-            <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">
-              {assetRequests.filter(r => r.priority === 'High').length} high priority
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <CardTitle>Content calendar</CardTitle>
-              <CardDescription>All content pieces with publication status and engagement metrics.</CardDescription>
-            </div>
-            <Button variant="primary" size="sm">Create content</Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Title</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Author</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Publish Date</TableHead>
-                <TableHead className="text-right">Views</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {mockContent.map((content) => (
-                <TableRow key={content.id}>
-                  <TableCell className="font-medium">{content.title}</TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">{content.type}</TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">{content.author}</TableCell>
-                  <TableCell>
-                    <Badge variant={
-                      content.status === 'Published' ? 'success' :
-                      content.status === 'Scheduled' ? 'default' :
-                      'outline'
-                    }>
-                      {content.status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">
-                    {new Date(content.publishDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </TableCell>
-                  <TableCell className="text-right font-medium">
-                    {content.views > 0 ? content.views.toLocaleString() : '—'}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Asset requests</CardTitle>
-          <CardDescription>Design, copy, and enablement material requests from the team.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {assetRequests.map((request) => (
-              <div key={request.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <p className="font-medium text-[color:var(--color-text)]">{request.title}</p>
-                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">
-                      Requested by {request.requestedBy}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant={request.priority === 'High' ? 'outline' : 'default'}>
-                      {request.priority}
-                    </Badge>
-                    <Badge variant={request.status === 'In Progress' ? 'success' : 'outline'}>
-                      {request.status}
-                    </Badge>
-                  </div>
-                </div>
-                <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">
-                  Due: {new Date(request.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                </p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-6 space-y-3 rounded-lg border border-dashed border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/40 p-4">
-            <p className="text-sm font-medium text-[color:var(--color-text)]">Submit new request</p>
-            <Input placeholder="Describe the asset you need..." />
-            <div className="flex gap-2">
-              <Button variant="primary" size="sm">Submit request</Button>
-              <Button variant="outline" size="sm">Cancel</Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <ContentStudio
+      initialItems={contentState.items}
+      initialVariants={contentState.variants}
+      initialDistributions={contentState.distributions}
+      initialTouches={contentState.touches}
+      metrics={metrics}
+      suggestions={suggestions}
+      mediaIdeas={mediaIdeas}
+      mediaProjects={mediaState.projects}
+      mediaDistributions={mediaState.distributions}
+      mediaMetrics={mediaMetrics}
+    />
   )
 }

--- a/core/content/actions.ts
+++ b/core/content/actions.ts
@@ -1,0 +1,115 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import {
+  computeMetrics,
+  createItem as createItemInStore,
+  createVariant as createVariantInStore,
+  getContentState,
+  markVariantStatus,
+  recordTouch as recordTouchInStore,
+  saveBrief as saveBriefInStore,
+  scheduleDistribution as scheduleDistributionInStore,
+  updateItem as updateItemInStore,
+  updateStatus as updateStatusInStore,
+} from './store'
+import { nextBestContent } from './recommender'
+import { ContentBrief, ContentStage, ContentStatus, TouchAction } from './types'
+
+const CONTENT_PATH = '/content'
+
+export async function createItem(input: {
+  title: string
+  type: string
+  persona: string
+  stage: ContentStage
+  objection: string
+  ownerId: string
+  cost?: number
+  status?: ContentStatus
+  sla?: string
+  brief?: ContentBrief
+}) {
+  const item = createItemInStore(input)
+  revalidatePath(CONTENT_PATH)
+  return item
+}
+
+export async function saveBrief(id: string, brief: ContentBrief) {
+  const item = saveBriefInStore(id, brief)
+  revalidatePath(CONTENT_PATH)
+  return item
+}
+
+export async function updateStatus(id: string, status: ContentStatus) {
+  const item = updateStatusInStore(id, status)
+  revalidatePath(CONTENT_PATH)
+  return item
+}
+
+export async function updateItem(id: string, patch: Partial<{ ownerId: string; sla: string }>) {
+  const item = updateItemInStore(id, patch)
+  revalidatePath(CONTENT_PATH)
+  return item
+}
+
+export async function createVariant(input: {
+  contentId: string
+  kind: string
+  headline: string
+  cta: string
+  group?: 'A' | 'B'
+}) {
+  const variant = createVariantInStore(input)
+  revalidatePath(CONTENT_PATH)
+  return variant
+}
+
+export async function markExperimentOutcome(variantId: string, status: string) {
+  const variant = markVariantStatus(variantId, status)
+  revalidatePath(CONTENT_PATH)
+  return variant
+}
+
+export async function recordTouch(input: {
+  id?: string
+  contentId: string
+  opportunityId: string
+  actor: string
+  action: TouchAction
+}) {
+  const touch = recordTouchInStore(input)
+  revalidatePath(CONTENT_PATH)
+  return touch
+}
+
+export async function scheduleDistribution(input: {
+  id?: string
+  contentId: string
+  channel: string
+  whenISO?: string
+  utm?: string
+}) {
+  const distribution = scheduleDistributionInStore({
+    id: input.id,
+    contentId: input.contentId,
+    channel: input.channel,
+    scheduledAt: input.whenISO ?? null,
+    utm: input.utm ?? null,
+  })
+  revalidatePath(CONTENT_PATH)
+  return distribution
+}
+
+export async function getMetrics() {
+  return computeMetrics()
+}
+
+export async function getContentSnapshot() {
+  return getContentState()
+}
+
+export async function getSuggestions() {
+  return nextBestContent()
+}

--- a/core/content/recommender.ts
+++ b/core/content/recommender.ts
@@ -1,0 +1,47 @@
+import { ContentItem } from './types'
+import { listContentItems } from './store'
+
+type ContentSuggestion = {
+  id: string
+  title: string
+  persona: string
+  stage: ContentItem['stage']
+  objection: string
+  expectedImpact: string
+  effort: string
+}
+
+const stagePriority: Record<ContentItem['stage'], number> = {
+  Discovery: 1,
+  Evaluation: 3,
+  Decision: 5,
+  Onboarding: 2,
+  Adoption: 4,
+}
+
+export function nextBestContent(_openOppsStub?: Array<{ stage: ContentItem['stage'] }>): ContentSuggestion[] {
+  const items = listContentItems()
+  const backlog = items.filter(item => item.status !== 'Published')
+
+  const ranked = backlog
+    .map(item => {
+      const urgency = stagePriority[item.stage] + (item.status === 'Idea' ? 2 : item.status === 'Draft' ? 1 : 0)
+      const impact = item.persona.includes('CFO') ? 'High' : item.persona.includes('COO') ? 'Medium' : 'Steady'
+      const effort = item.cost > 1500 ? 'High' : item.cost > 900 ? 'Medium' : 'Low'
+      return {
+        id: item.id,
+        title: item.title,
+        persona: item.persona,
+        stage: item.stage,
+        objection: item.objection,
+        score: urgency + (impact === 'High' ? 2 : impact === 'Medium' ? 1 : 0),
+        expectedImpact: impact,
+        effort,
+      }
+    })
+    .sort((a, b) => b.score - a.score)
+
+  return ranked.slice(0, 3).map(({ score, ...rest }) => rest)
+}
+
+export type { ContentSuggestion }

--- a/core/content/store.ts
+++ b/core/content/store.ts
@@ -1,0 +1,347 @@
+import {
+  ContentBrief,
+  ContentItem,
+  ContentStage,
+  ContentStatus,
+  Distribution,
+  Metrics,
+  Touch,
+  TouchAction,
+  Variant,
+} from './types'
+
+const contentItems: ContentItem[] = [
+  {
+    id: 'cnt-1',
+    title: 'RevOps QRA Narrative',
+    type: 'One-pager',
+    status: 'Draft',
+    persona: 'CRO',
+    stage: 'Evaluation',
+    objection: 'Needs proof of revenue impact',
+    ownerId: 'maya',
+    cost: 1200,
+    createdAt: new Date('2025-01-12').toISOString(),
+    publishedAt: null,
+    sla: '72h',
+    brief: {
+      cta: 'Book a revenue lab',
+      outline: '1. Urgency\n2. Narrative\n3. Business case',
+      notes: 'Use last quarter benchmarks as proof.',
+    },
+  },
+  {
+    id: 'cnt-2',
+    title: 'CFO Forecast Debrief',
+    type: 'Insight Report',
+    status: 'Review',
+    persona: 'CFO',
+    stage: 'Decision',
+    objection: 'Skeptical of automation',
+    ownerId: 'jordan',
+    cost: 1800,
+    createdAt: new Date('2024-12-05').toISOString(),
+    publishedAt: null,
+    sla: '48h',
+    brief: {
+      cta: 'Schedule working session',
+      outline: '1. Why now\n2. Risk mitigation\n3. 90-day proof',
+    },
+  },
+  {
+    id: 'cnt-3',
+    title: 'Implementation Playbook',
+    type: 'Guide',
+    status: 'Scheduled',
+    persona: 'COO',
+    stage: 'Onboarding',
+    objection: 'Worried about rollout risk',
+    ownerId: 'alexa',
+    cost: 950,
+    createdAt: new Date('2025-02-08').toISOString(),
+    publishedAt: null,
+    sla: '5d',
+  },
+  {
+    id: 'cnt-4',
+    title: 'Field Battlecard – AI Objections',
+    type: 'Battlecard',
+    status: 'Published',
+    persona: 'VP Sales',
+    stage: 'Adoption',
+    objection: 'Need talk track for AI concerns',
+    ownerId: 'danielle',
+    cost: 600,
+    createdAt: new Date('2024-11-20').toISOString(),
+    publishedAt: new Date('2025-02-01').toISOString(),
+    sla: '24h',
+  },
+  {
+    id: 'cnt-5',
+    title: 'Pipeline Momentum Newsletter',
+    type: 'Newsletter',
+    status: 'Idea',
+    persona: 'RevOps',
+    stage: 'Discovery',
+    objection: 'Need executive-ready summary',
+    ownerId: 'maya',
+    cost: 400,
+    createdAt: new Date('2025-02-15').toISOString(),
+    sla: '48h',
+  },
+]
+
+const variants: Variant[] = [
+  {
+    id: 'var-1',
+    contentId: 'cnt-4',
+    kind: 'Email CTA',
+    headline: 'AI objections? Arm the field fast',
+    cta: 'Drop into enablement hub',
+    group: 'A',
+    status: 'scaling',
+  },
+  {
+    id: 'var-2',
+    contentId: 'cnt-4',
+    kind: 'Email CTA',
+    headline: 'Disarm AI concerns in 2 minutes',
+    cta: 'Use the field script',
+    group: 'B',
+    status: 'testing',
+  },
+]
+
+const distributions: Distribution[] = [
+  {
+    id: 'dist-1',
+    contentId: 'cnt-4',
+    channel: 'LinkedIn',
+    publishedAt: new Date('2025-02-02').toISOString(),
+    utm: 'utm_source=linkedin&utm_campaign=ai-battlecard',
+    clicks: 420,
+  },
+  {
+    id: 'dist-2',
+    contentId: 'cnt-3',
+    channel: 'Email',
+    scheduledAt: new Date('2025-02-18T16:00:00Z').toISOString(),
+    utm: 'utm_source=email&utm_campaign=playbook',
+    clicks: 55,
+  },
+]
+
+const touches: Touch[] = [
+  {
+    id: 'touch-1',
+    contentId: 'cnt-4',
+    opportunityId: 'opp-8721',
+    actor: 'sdr-rachel',
+    action: 'worked',
+    ts: new Date('2025-02-12T15:02:00Z').toISOString(),
+  },
+  {
+    id: 'touch-2',
+    contentId: 'cnt-4',
+    opportunityId: 'opp-8728',
+    actor: 'ae-jules',
+    action: 'used',
+    ts: new Date('2025-02-13T12:18:00Z').toISOString(),
+  },
+  {
+    id: 'touch-3',
+    contentId: 'cnt-2',
+    opportunityId: 'opp-8650',
+    actor: 'cs-lee',
+    action: 'failed',
+    ts: new Date('2025-02-10T09:45:00Z').toISOString(),
+  },
+]
+
+const id = () => Math.random().toString(36).slice(2, 10)
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+export function listContentItems() {
+  return contentItems.map(item => clone(item))
+}
+
+export function listVariants() {
+  return variants.map(variant => clone(variant))
+}
+
+export function listDistributions() {
+  return distributions.map(distribution => clone(distribution))
+}
+
+export function listTouches() {
+  return touches.map(touch => clone(touch))
+}
+
+export function getContentState() {
+  return {
+    items: listContentItems(),
+    variants: listVariants(),
+    distributions: listDistributions(),
+    touches: listTouches(),
+  }
+}
+
+export function createItem(input: {
+  title: string
+  type: string
+  persona: string
+  stage: ContentStage
+  objection: string
+  ownerId: string
+  cost?: number
+  status?: ContentStatus
+  sla?: string
+  brief?: ContentBrief
+}) {
+  const now = new Date().toISOString()
+  const item: ContentItem = {
+    id: `cnt-${id()}`,
+    title: input.title,
+    type: input.type,
+    persona: input.persona,
+    stage: input.stage,
+    objection: input.objection,
+    ownerId: input.ownerId,
+    cost: input.cost ?? 0,
+    status: input.status ?? 'Idea',
+    createdAt: now,
+    publishedAt: null,
+    sla: input.sla ?? '72h',
+    brief: input.brief,
+  }
+  contentItems.push(item)
+  return clone(item)
+}
+
+export function updateItem(id: string, patch: Partial<ContentItem>) {
+  const item = contentItems.find(entry => entry.id === id)
+  if (!item) {
+    throw new Error(`Content item ${id} not found`)
+  }
+  Object.assign(item, patch)
+  return clone(item)
+}
+
+export function updateStatus(id: string, status: ContentStatus) {
+  const item = contentItems.find(entry => entry.id === id)
+  if (!item) {
+    throw new Error(`Content item ${id} not found`)
+  }
+  item.status = status
+  if (status === 'Published' && !item.publishedAt) {
+    item.publishedAt = new Date().toISOString()
+  }
+  return clone(item)
+}
+
+export function saveBrief(id: string, brief: ContentBrief) {
+  return updateItem(id, { brief })
+}
+
+export function createVariant(input: {
+  contentId: string
+  kind: string
+  headline: string
+  cta: string
+  group?: 'A' | 'B'
+}) {
+  const variant: Variant = {
+    id: `var-${id()}`,
+    contentId: input.contentId,
+    kind: input.kind,
+    headline: input.headline,
+    cta: input.cta,
+    group: input.group,
+    status: 'testing',
+  }
+  variants.push(variant)
+  return clone(variant)
+}
+
+export function markVariantStatus(variantId: string, status: string) {
+  const variant = variants.find(entry => entry.id === variantId)
+  if (!variant) {
+    throw new Error(`Variant ${variantId} not found`)
+  }
+  variant.status = status
+  return clone(variant)
+}
+
+export function recordTouch(input: {
+  id?: string
+  contentId: string
+  opportunityId: string
+  actor: string
+  action: TouchAction
+}) {
+  if (input.id) {
+    const existing = touches.find(touch => touch.id === input.id)
+    if (!existing) {
+      throw new Error(`Touch ${input.id} not found`)
+    }
+    existing.action = input.action
+    existing.ts = new Date().toISOString()
+    return clone(existing)
+  }
+  const touch: Touch = {
+    id: `touch-${id()}`,
+    contentId: input.contentId,
+    opportunityId: input.opportunityId,
+    actor: input.actor,
+    action: input.action,
+    ts: new Date().toISOString(),
+  }
+  touches.push(touch)
+  return clone(touch)
+}
+
+export function scheduleDistribution(input: {
+  id?: string
+  contentId: string
+  channel: string
+  scheduledAt?: string | null
+  publishedAt?: string | null
+  utm?: string | null
+}) {
+  if (input.id) {
+    const existing = distributions.find(entry => entry.id === input.id)
+    if (!existing) throw new Error(`Distribution ${input.id} not found`)
+    Object.assign(existing, input)
+    return clone(existing)
+  }
+  const distribution: Distribution = {
+    id: `dist-${id()}`,
+    contentId: input.contentId,
+    channel: input.channel,
+    scheduledAt: input.scheduledAt ?? null,
+    publishedAt: input.publishedAt ?? null,
+    utm: input.utm ?? null,
+    clicks: 0,
+  }
+  distributions.push(distribution)
+  return clone(distribution)
+}
+
+export function computeMetrics(): Metrics {
+  const totalTouches = touches.length
+  const productiveTouches = touches.filter(touch => touch.action !== 'failed').length
+  const workedTouches = touches.filter(touch => touch.action === 'worked').length
+  const totalClicks = distributions.reduce((sum, distribution) => sum + (distribution.clicks ?? 0), 0)
+
+  return {
+    influenced: productiveTouches * 7500,
+    advanced: workedTouches * 5200,
+    closedWon: Math.round(workedTouches * 18000 * 0.65),
+    usageRate: contentItems.length > 0 ? Number((productiveTouches / contentItems.length).toFixed(2)) : 0,
+    views: totalClicks,
+    ctr: distributions.length > 0 ? Number(((totalClicks / (distributions.length * 1200)) * 100).toFixed(2)) : 0,
+  }
+}

--- a/core/content/types.ts
+++ b/core/content/types.ts
@@ -1,0 +1,72 @@
+export type ContentStatus = 'Idea' | 'Draft' | 'Review' | 'Scheduled' | 'Published'
+
+export type ContentStage =
+  | 'Discovery'
+  | 'Evaluation'
+  | 'Decision'
+  | 'Onboarding'
+  | 'Adoption'
+
+export interface ContentBrief {
+  cta: string
+  outline: string
+  notes?: string
+}
+
+export interface ContentItem {
+  id: string
+  title: string
+  type: string
+  status: ContentStatus
+  persona: string
+  stage: ContentStage
+  objection: string
+  ownerId: string
+  cost: number
+  createdAt: string
+  publishedAt?: string | null
+  sla: string
+  brief?: ContentBrief
+}
+
+export type VariantGroup = 'A' | 'B'
+
+export interface Variant {
+  id: string
+  contentId: string
+  kind: string
+  headline: string
+  cta: string
+  group?: VariantGroup
+  status: string
+}
+
+export interface Distribution {
+  id: string
+  contentId: string
+  channel: string
+  scheduledAt?: string | null
+  publishedAt?: string | null
+  utm?: string | null
+  clicks?: number
+}
+
+export type TouchAction = 'used' | 'worked' | 'failed'
+
+export interface Touch {
+  id: string
+  contentId: string
+  opportunityId: string
+  actor: string
+  action: TouchAction
+  ts: string
+}
+
+export interface Metrics {
+  influenced: number
+  advanced: number
+  closedWon: number
+  usageRate: number
+  views: number
+  ctr: number
+}

--- a/core/mediaAgent/actions.ts
+++ b/core/mediaAgent/actions.ts
@@ -1,0 +1,66 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import {
+  attachGeneratedAssets,
+  computeMediaMetrics,
+  ensureProjectForIdea,
+  getMediaState,
+  listIdeas,
+  scheduleMediaDistribution,
+  saveTranscript,
+  updateProjectStatus,
+} from './store'
+import { MediaChannel } from './types'
+import { suggestMediaFromPipeline } from './recommender'
+
+const CONTENT_PATH = '/content'
+
+export async function actionSuggestIdeas() {
+  return suggestMediaFromPipeline()
+}
+
+export async function actionCreateProjectFromIdea(ideaId: string) {
+  const idea = listIdeas().find(entry => entry.id === ideaId)
+  if (!idea) throw new Error(`Idea ${ideaId} not found`)
+  const project = ensureProjectForIdea(idea)
+  revalidatePath(CONTENT_PATH)
+  return project
+}
+
+export async function actionMarkRecording(projectId: string) {
+  const project = updateProjectStatus(projectId, 'Recording')
+  revalidatePath(CONTENT_PATH)
+  return project
+}
+
+export async function actionIngestTranscript(projectId: string, transcript: string) {
+  const project = saveTranscript(projectId, transcript)
+  revalidatePath(CONTENT_PATH)
+  return project
+}
+
+export async function actionGenerateAssets(projectId: string) {
+  const project = attachGeneratedAssets(projectId)
+  revalidatePath(CONTENT_PATH)
+  return project
+}
+
+export async function actionScheduleDistribution(projectId: string, channel: MediaChannel, whenISO?: string) {
+  const distribution = scheduleMediaDistribution({
+    projectId,
+    channel,
+    scheduledAt: whenISO ?? null,
+  })
+  revalidatePath(CONTENT_PATH)
+  return distribution
+}
+
+export async function actionMediaMetrics() {
+  return computeMediaMetrics()
+}
+
+export async function actionMediaState() {
+  return getMediaState()
+}

--- a/core/mediaAgent/recommender.ts
+++ b/core/mediaAgent/recommender.ts
@@ -1,0 +1,7 @@
+import { MediaIdea } from './types'
+import { listIdeas } from './store'
+
+export function suggestMediaFromPipeline(): MediaIdea[] {
+  const allIdeas = listIdeas()
+  return allIdeas.slice(0, 3)
+}

--- a/core/mediaAgent/store.ts
+++ b/core/mediaAgent/store.ts
@@ -1,0 +1,192 @@
+import {
+  MediaChannel,
+  MediaDistribution,
+  MediaIdea,
+  MediaMetrics,
+  MediaProject,
+  MediaProjectStatus,
+} from './types'
+
+const ideas: MediaIdea[] = [
+  {
+    id: 'idea-1',
+    title: 'CFO price integrity briefing',
+    persona: 'CFO',
+    stage: 'Evaluation',
+    objection: 'Need confidence in forecast',
+    expectedImpact: 'High',
+    effort: 'Medium',
+  },
+  {
+    id: 'idea-2',
+    title: 'COO rollout de-risking series',
+    persona: 'COO',
+    stage: 'Onboarding',
+    objection: 'Worried about change fatigue',
+    expectedImpact: 'Medium',
+    effort: 'Medium',
+  },
+  {
+    id: 'idea-3',
+    title: 'Partner revenue playbook spotlight',
+    persona: 'Partner leader',
+    stage: 'Adoption',
+    objection: 'Need repeatable joint wins',
+    expectedImpact: 'High',
+    effort: 'Low',
+  },
+]
+
+const projects: MediaProject[] = [
+  {
+    id: 'proj-1',
+    ideaId: 'idea-3',
+    status: 'Post',
+    jellypodUrl: 'https://jellypod.ai/new?topic=partner%20revenue%20playbook',
+    transcript: 'Intro... partner co-sell wins...',
+    artifacts: {
+      podcastUrl: 'https://pods.example.com/partner-playbook',
+      youtubeUrl: 'https://youtu.be/partner-playbook',
+      shorts: ['https://shorts.example.com/partner-win'],
+      social: ['Partner spotlight copy ready for LinkedIn'],
+      emails: ['Draft email to partner community'],
+      thumbnailPrompt: 'Partners high-fiving over dashboard',
+    },
+  },
+]
+
+const distributions: MediaDistribution[] = [
+  {
+    id: 'mdist-1',
+    projectId: 'proj-1',
+    channel: 'LinkedIn',
+    publishedAt: new Date('2025-02-10T17:00:00Z').toISOString(),
+    utm: 'utm_source=linkedin&utm_medium=social&utm_campaign=partner-playbook',
+  },
+]
+
+const id = () => Math.random().toString(36).slice(2, 10)
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+export function listIdeas() {
+  return ideas.map(idea => clone(idea))
+}
+
+export function listProjects() {
+  return projects.map(project => clone(project))
+}
+
+export function listDistributions() {
+  return distributions.map(entry => clone(entry))
+}
+
+export function getMediaState() {
+  return {
+    ideas: listIdeas(),
+    projects: listProjects(),
+    distributions: listDistributions(),
+  }
+}
+
+export function ensureProjectForIdea(idea: MediaIdea) {
+  const existing = projects.find(project => project.ideaId === idea.id)
+  if (existing) {
+    return clone(existing)
+  }
+  const project: MediaProject = {
+    id: `proj-${id()}`,
+    ideaId: idea.id,
+    status: 'Planned',
+    jellypodUrl: `https://jellypod.ai/new?topic=${encodeURIComponent(idea.title)}`,
+    artifacts: {
+      shorts: [],
+      social: [],
+      emails: [],
+    },
+  }
+  projects.push(project)
+  return clone(project)
+}
+
+export function updateProjectStatus(projectId: string, status: MediaProjectStatus) {
+  const project = projects.find(entry => entry.id === projectId)
+  if (!project) throw new Error(`Media project ${projectId} not found`)
+  project.status = status
+  if (status === 'Recording' && !project.jellypodUrl) {
+    const idea = ideas.find(entry => entry.id === project.ideaId)
+    project.jellypodUrl = idea
+      ? `https://jellypod.ai/new?topic=${encodeURIComponent(idea.title)}`
+      : `https://jellypod.ai/new?topic=${projectId}`
+  }
+  return clone(project)
+}
+
+export function saveTranscript(projectId: string, transcript: string) {
+  const project = projects.find(entry => entry.id === projectId)
+  if (!project) throw new Error(`Media project ${projectId} not found`)
+  project.transcript = transcript
+  if (project.status === 'Recording') {
+    project.status = 'Post'
+  }
+  return clone(project)
+}
+
+export function attachGeneratedAssets(projectId: string) {
+  const project = projects.find(entry => entry.id === projectId)
+  if (!project) throw new Error(`Media project ${projectId} not found`)
+  project.artifacts = {
+    podcastUrl: `https://pods.example.com/${projectId}`,
+    youtubeUrl: `https://youtube.com/watch?v=${projectId}`,
+    shorts: [
+      `https://shorts.example.com/${projectId}-clip-1`,
+      `https://shorts.example.com/${projectId}-clip-2`,
+    ],
+    social: [
+      'LinkedIn teaser copy about the ROI storyline',
+      'X thread outline highlighting revenue wins',
+    ],
+    emails: [
+      'Customer newsletter intro paragraph',
+      'Sales follow-up template referencing the episode',
+    ],
+    thumbnailPrompt: 'Studio mic, revenue dashboard glow, confident host',
+  }
+  project.status = project.status === 'Planned' ? 'Post' : project.status
+  return clone(project)
+}
+
+export function scheduleMediaDistribution(input: {
+  projectId: string
+  channel: MediaChannel
+  scheduledAt?: string | null
+}) {
+  const distribution: MediaDistribution = {
+    id: `mdist-${id()}`,
+    projectId: input.projectId,
+    channel: input.channel,
+    scheduledAt: input.scheduledAt ?? null,
+    publishedAt: null,
+    utm: input.channel ? `utm_source=${input.channel.toLowerCase()}&utm_campaign=${input.projectId}` : null,
+  }
+  distributions.push(distribution)
+  const project = projects.find(entry => entry.id === input.projectId)
+  if (project) {
+    project.status = project.status === 'Post' ? 'Scheduled' : project.status
+  }
+  return clone(distribution)
+}
+
+export function computeMediaMetrics(): MediaMetrics {
+  const publishedCount = distributions.filter(entry => entry.publishedAt).length
+  const scheduledCount = distributions.filter(entry => entry.scheduledAt && !entry.publishedAt).length
+  return {
+    influenced: (publishedCount + scheduledCount) * 8800,
+    advanced: publishedCount * 6100,
+    closedWon: Math.round(publishedCount * 22000 * 0.4),
+    views: (publishedCount + 1) * 950,
+    ctr: Number(((publishedCount / Math.max(scheduledCount + publishedCount, 1)) * 58).toFixed(2)),
+  }
+}

--- a/core/mediaAgent/types.ts
+++ b/core/mediaAgent/types.ts
@@ -1,0 +1,46 @@
+export interface MediaIdea {
+  id: string
+  title: string
+  persona: string
+  stage: string
+  objection: string
+  expectedImpact: string
+  effort: string
+}
+
+export type MediaProjectStatus = 'Planned' | 'Recording' | 'Post' | 'Scheduled' | 'Published'
+
+export interface MediaProject {
+  id: string
+  ideaId: string
+  status: MediaProjectStatus
+  jellypodUrl?: string
+  transcript?: string
+  artifacts: {
+    podcastUrl?: string
+    youtubeUrl?: string
+    shorts: string[]
+    social: string[]
+    emails: string[]
+    thumbnailPrompt?: string
+  }
+}
+
+export type MediaChannel = 'YouTube' | 'Podcast' | 'LinkedIn' | 'X' | 'Email' | 'Partner'
+
+export interface MediaDistribution {
+  id: string
+  projectId: string
+  channel: MediaChannel
+  scheduledAt?: string | null
+  publishedAt?: string | null
+  utm?: string | null
+}
+
+export interface MediaMetrics {
+  influenced: number
+  advanced: number
+  closedWon: number
+  views: number
+  ctr: number
+}


### PR DESCRIPTION
## Summary
- add an in-memory content domain store, recommender, and server actions to manage assets, touches, and metrics
- introduce media agent storage plus actions for Jellypod production, asset generation, and distribution metrics
- rebuild `/content` as the interactive Content Studio with QRA suggestions, kanban workflow, drawer tools, request intake, and media agent controls

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e73379623c832481ef3e268258e9ed