### PR TITLE
Add client workspace and sync project statuses

### DIFF
--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -1,0 +1,302 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { actionMoveKanban, actionSaveGap, actionSaveQRA, actionSetStatus, actionToggleSource } from '@/core/clients/actions'
+import { phaseBadgeClasses, REVOS_PHASES } from '@/core/clients/constants'
+import { getClient, listClients } from '@/core/clients/store'
+import type { ClientRecord } from '@/core/clients/types'
+
+export async function generateStaticParams() {
+  return listClients().map((c) => ({ id: c.id }))
+}
+
+export default async function ClientPage({ params }: { params: { id: string } }) {
+  const client = getClient(params.id)
+  if (!client) return notFound()
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-[color:var(--color-text)]">{client.name}</h1>
+          <p className="text-xs text-[color:var(--color-text-muted)]">Owner: {client.owner ?? '—'}</p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className={`rounded-full px-3 py-1 ${phaseBadgeClasses[client.status]}`}>{client.status}</span>
+          <Link className="underline" href="/projects">
+            Back to Projects
+          </Link>
+        </div>
+      </header>
+
+      <div className="border-b border-[color:var(--color-outline)]">
+        <nav className="flex flex-wrap gap-2">
+          {REVOS_PHASES.map((phase) => (
+            <form key={phase} action={actionSetStatus.bind(null, client.id, phase)}>
+              <button
+                className={`rounded-t-lg border border-b-0 px-4 py-2 text-sm transition ${
+                  client.status === phase
+                    ? 'border-[color:var(--color-outline)] bg-[color:var(--color-surface)] text-[color:var(--color-text)]'
+                    : 'border-transparent bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]'
+                }`}
+              >
+                {phase}
+              </button>
+            </form>
+          ))}
+        </nav>
+      </div>
+
+      {client.status === 'Discovery' && <DiscoveryPanel id={client.id} />}
+      {client.status === 'Data' && <DataPanel id={client.id} />}
+      {client.status === 'Algorithm' && <AlgorithmPanel id={client.id} />}
+      {client.status === 'Architecture' && <ArchitecturePanel id={client.id} />}
+      {client.status === 'Compounding' && <CompoundingPanel id={client.id} />}
+    </div>
+  )
+}
+
+async function DiscoveryPanel({ id }: { id: string }) {
+  const c = getClient(id)
+  if (!c) return null
+
+  const prompts = [
+    { id: 'g1', q: 'What’s the primary revenue motion?' },
+    { id: 'g2', q: 'Biggest churn driver?' },
+    { id: 'g3', q: 'Current pricing model?' },
+  ]
+  const answers = new Map(c.gapAnswers.map((entry) => [entry.id, entry.a]))
+
+  async function save(form: FormData) {
+    'use server'
+    const payload: Array<{ id: string; q: string; a: string }> = []
+    for (const prompt of prompts) {
+      payload.push({
+        id: prompt.id,
+        q: prompt.q,
+        a: String(form.get(prompt.id) ?? ''),
+      })
+    }
+    await actionSaveGap(id, payload)
+  }
+
+  return (
+    <section className="space-y-4 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4">
+      <header>
+        <h2 className="text-sm font-medium text-[color:var(--color-text)]">Gap questions</h2>
+        <p className="text-xs text-[color:var(--color-text-muted)]">
+          Capture discovery context. We’ll sync with the intake doc when the API is ready.
+        </p>
+      </header>
+      <form action={save} className="space-y-3">
+        {prompts.map((prompt) => (
+          <label key={prompt.id} className="block space-y-1">
+            <span className="text-xs text-[color:var(--color-text-muted)]">{prompt.q}</span>
+            <input
+              name={prompt.id}
+              defaultValue={answers.get(prompt.id) ?? ''}
+              placeholder="Answer…"
+              className="w-full rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm text-[color:var(--color-text)]"
+            />
+          </label>
+        ))}
+        <button className="rounded-md bg-[color:var(--color-text)] px-3 py-2 text-xs font-medium text-white">Save</button>
+      </form>
+    </section>
+  )
+}
+
+async function DataPanel({ id }: { id: string }) {
+  const c = getClient(id)
+  if (!c) return null
+
+  async function toggle(form: FormData) {
+    'use server'
+    const src = String(form.get('src'))
+    await actionToggleSource(id, src)
+  }
+
+  return (
+    <section className="grid gap-4 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4 md:grid-cols-2">
+      <div>
+        <h3 className="mb-2 text-sm font-medium text-[color:var(--color-text)]">Available data sources</h3>
+        <ul className="space-y-2">
+          {c.availableSources.map((source) => (
+            <li
+              key={source}
+              className="flex items-center justify-between rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm"
+            >
+              <span>{source}</span>
+              <form action={toggle}>
+                <input type="hidden" name="src" value={source} />
+                <button className="text-xs font-medium underline">Toggle</button>
+              </form>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className="mb-2 text-sm font-medium text-[color:var(--color-text)]">Collected data</h3>
+        <ul className="space-y-2">
+          {c.collectedSources.length === 0 && (
+            <li className="rounded-md border border-dashed border-[color:var(--color-outline)] px-3 py-2 text-xs text-[color:var(--color-text-muted)]">
+              No sources collected yet.
+            </li>
+          )}
+          {c.collectedSources.map((source) => (
+            <li key={source} className="rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm">
+              {source}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+async function AlgorithmPanel({ id }: { id: string }) {
+  const c = getClient(id)
+  if (!c) return null
+
+  async function save(form: FormData) {
+    'use server'
+    await actionSaveQRA(id, String(form.get('notes') ?? ''))
+  }
+
+  return (
+    <section className="space-y-3 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4">
+      <div>
+        <h3 className="text-sm font-medium text-[color:var(--color-text)]">QRA Strategy</h3>
+        <p className="text-xs text-[color:var(--color-text-muted)]">
+          Summarize the qualitative revenue analysis before we pipe in the real model.
+        </p>
+      </div>
+      <form action={save} className="space-y-2">
+        <textarea
+          name="notes"
+          defaultValue={c.qraNotes ?? ''}
+          placeholder="Write strategy synthesis…"
+          className="h-40 w-full rounded-md border border-[color:var(--color-outline)] bg-white p-2 text-sm"
+        />
+        <button className="rounded-md bg-[color:var(--color-text)] px-3 py-2 text-xs font-medium text-white">Save</button>
+      </form>
+      <p className="text-xs text-[color:var(--color-text-muted)]">
+        Next iteration will run the automated QRA to produce playbooks and projections.
+      </p>
+    </section>
+  )
+}
+
+async function ArchitecturePanel({ id }: { id: string }) {
+  const c = getClient(id)
+  if (!c) return null
+  const columns: Array<keyof ClientRecord['kanban']> = ['Backlog', 'Doing', 'Review', 'Done']
+
+  async function move(form: FormData) {
+    'use server'
+    const card = String(form.get('card'))
+    const from = String(form.get('from')) as keyof ClientRecord['kanban']
+    const to = String(form.get('to')) as keyof ClientRecord['kanban']
+    await actionMoveKanban(id, card, from, to)
+  }
+
+  return (
+    <section className="space-y-3 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4">
+      <h3 className="text-sm font-medium text-[color:var(--color-text)]">Revenue OS build kanban</h3>
+      <div className="grid gap-3 md:grid-cols-4">
+        {columns.map((column) => (
+          <div key={column} className="rounded-lg border border-[color:var(--color-outline)] bg-white">
+            <div className="border-b border-[color:var(--color-outline)] px-3 py-2 text-xs font-medium text-[color:var(--color-text-muted)]">
+              {column}
+            </div>
+            <ul className="space-y-2 p-2">
+              {c.kanban[column].length === 0 && (
+                <li className="rounded-md border border-dashed border-[color:var(--color-outline)] px-2 py-3 text-xs text-[color:var(--color-text-muted)]">
+                  Nothing here yet.
+                </li>
+              )}
+              {c.kanban[column].map((card) => (
+                <li key={card} className="rounded-md border border-[color:var(--color-outline)] px-2 py-2 text-sm">
+                  <div className="flex items-center justify-between gap-2">
+                    <span>{card}</span>
+                    <form action={move} className="flex items-center gap-1 text-xs">
+                      <input type="hidden" name="card" value={card} />
+                      <input type="hidden" name="from" value={column} />
+                      <select
+                        name="to"
+                        className="rounded border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] px-1 py-0.5 text-xs"
+                        defaultValue={column}
+                      >
+                        {columns
+                          .filter((other) => other !== column)
+                          .map((other) => (
+                            <option key={other} value={other}>
+                              {other}
+                            </option>
+                          ))}
+                      </select>
+                      <button className="underline">Move</button>
+                    </form>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+async function CompoundingPanel({ id }: { id: string }) {
+  const c = getClient(id)
+  if (!c) return null
+
+  const pct =
+    c.baselineARR && c.realizedARR ? Math.round(((c.realizedARR - c.baselineARR) / c.baselineARR) * 100) : 0
+
+  const maxArr = Math.max(c.realizedARR ?? 0, ...c.history.map((entry) => entry.arr)) || 1
+
+  return (
+    <section className="space-y-4 rounded-xl border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] p-4">
+      <h3 className="text-sm font-medium text-[color:var(--color-text)]">Compounding impact</h3>
+      <div className="grid gap-3 md:grid-cols-3">
+        <Stat label="Baseline ARR" value={`$${(c.baselineARR ?? 0).toLocaleString()}`} />
+        <Stat label="Realized ARR" value={`$${(c.realizedARR ?? 0).toLocaleString()}`} />
+        <Stat label="Uplift" value={`${pct}%`} />
+      </div>
+      <div className="rounded-lg border border-[color:var(--color-outline)] bg-white p-3">
+        <div className="mb-2 text-xs text-[color:var(--color-text-muted)]">ARR trajectory (quarter)</div>
+        <svg viewBox="0 0 320 100" className="h-28 w-full">
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            points={c.history
+              .map((entry, index) => {
+                const x = (index / Math.max(c.history.length - 1, 1)) * 320
+                const normalized = entry.arr / maxArr
+                const y = 90 - normalized * 80
+                return `${x},${y}`
+              })
+              .join(' ')}
+          />
+        </svg>
+        <div className="text-[11px] text-[color:var(--color-text-muted)]">
+          Projection will connect to QRA once the scoring model lands. Trendline is placeholder data.
+        </div>
+      </div>
+      <p className="text-xs text-[color:var(--color-text-muted)]">
+        Track where the client started and the revenue uplift unlocked since activating Revos. Replace with production metrics later.
+      </p>
+    </section>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-[color:var(--color-outline)] bg-white p-3">
+      <div className="text-xs text-[color:var(--color-text-muted)]">{label}</div>
+      <div className="text-lg font-semibold text-[color:var(--color-text)]">{value}</div>
+    </div>
+  )
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,46 +1,157 @@
+import { listClients } from '@/core/clients/store'
+import { phaseBadgeClasses, REVOS_PHASES } from '@/core/clients/constants'
+import type { RevosPhase } from '@/core/clients/types'
 import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
 import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
-import { Button } from '@/ui/button'
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/ui/table'
 
-const mockProjects = [
-  { id: '1', name: 'Q4 Revenue Optimization Workshop', client: 'Acme Corp', owner: 'Sarah Chen', status: 'In Progress', dueDate: '2025-10-30', progress: 65, health: 'green' },
-  { id: '2', name: 'Clarity Audit & Scorecard', client: 'GlobalTech Inc', owner: 'Mike Johnson', status: 'In Progress', dueDate: '2025-11-05', progress: 40, health: 'yellow' },
-  { id: '3', name: 'Partner Enablement Package', client: 'DataFlow Systems', owner: 'Alex Rivera', status: 'Not Started', dueDate: '2025-11-15', progress: 0, health: 'green' },
-  { id: '4', name: 'ROI Analysis Report', client: 'CloudBridge', owner: 'Sarah Chen', status: 'At Risk', dueDate: '2025-10-22', progress: 25, health: 'red' },
-  { id: '5', name: 'Customer Success Playbook', client: 'TechVentures LLC', owner: 'Mike Johnson', status: 'Complete', dueDate: '2025-09-28', progress: 100, health: 'green' },
-  { id: '6', name: 'Pipeline Review Session', client: 'Innovation Labs', owner: 'Alex Rivera', status: 'In Progress', dueDate: '2025-10-25', progress: 80, health: 'green' },
-]
+import { ProjectRow } from './project-row'
 
-const statusCounts = {
-  'Not Started': mockProjects.filter(p => p.status === 'Not Started').length,
-  'In Progress': mockProjects.filter(p => p.status === 'In Progress').length,
-  'At Risk': mockProjects.filter(p => p.status === 'At Risk').length,
-  'Complete': mockProjects.filter(p => p.status === 'Complete').length,
+export type ProjectRowData = {
+  id: string
+  name: string
+  clientId: string
+  clientName: string
+  owner: string
+  status: RevosPhase
+  progress: number
+  dueDate: string
+  health: 'green' | 'yellow' | 'red'
+  clientOwner?: string
 }
 
-export default function ProjectsPage() {
+type MockProject = {
+  id: string
+  name: string
+  clientId: string
+  clientName: string
+  owner: string
+  status?: string
+  dueDate: string
+  progress: number
+  health: 'green' | 'yellow' | 'red'
+}
+
+const mockProjects: MockProject[] = [
+  {
+    id: '1',
+    name: 'Q4 Revenue Optimization Workshop',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Sarah Chen',
+    status: 'In Progress',
+    dueDate: '2025-10-30',
+    progress: 65,
+    health: 'green',
+  },
+  {
+    id: '2',
+    name: 'Clarity Audit & Scorecard',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Mike Johnson',
+    status: 'In Progress',
+    dueDate: '2025-11-05',
+    progress: 40,
+    health: 'yellow',
+  },
+  {
+    id: '3',
+    name: 'Partner Enablement Package',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Alex Rivera',
+    status: 'Not Started',
+    dueDate: '2025-11-15',
+    progress: 0,
+    health: 'green',
+  },
+  {
+    id: '4',
+    name: 'ROI Analysis Report',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Sarah Chen',
+    status: 'At Risk',
+    dueDate: '2025-10-22',
+    progress: 25,
+    health: 'red',
+  },
+  {
+    id: '5',
+    name: 'Customer Success Playbook',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Mike Johnson',
+    status: 'Complete',
+    dueDate: '2025-09-28',
+    progress: 100,
+    health: 'green',
+  },
+  {
+    id: '6',
+    name: 'Pipeline Review Session',
+    clientId: 'acme',
+    clientName: 'ACME Corp',
+    owner: 'Alex Rivera',
+    status: 'In Progress',
+    dueDate: '2025-10-25',
+    progress: 80,
+    health: 'green',
+  },
+]
+
+const phaseOrder: RevosPhase[] = REVOS_PHASES
+
+export default async function ProjectsPage() {
+  const clients = listClients()
+  const clientsById = new Map(clients.map((client) => [client.id, client]))
+
+  const projects: ProjectRowData[] = mockProjects.map((project) => {
+    const client = clientsById.get(project.clientId)
+    return {
+      id: project.id,
+      name: project.name,
+      clientId: project.clientId,
+      clientName: client?.name ?? project.clientName,
+      owner: project.owner ?? client?.owner ?? 'Unassigned',
+      status: client?.status ?? 'Discovery',
+      progress: project.progress,
+      dueDate: project.dueDate,
+      health: project.health,
+      clientOwner: client?.owner,
+    }
+  })
+
+  const phaseCounts = phaseOrder.reduce<Record<RevosPhase, number>>((acc, phase) => {
+    acc[phase] = clients.filter((client) => client.status === phase).length
+    return acc
+  }, Object.fromEntries(phaseOrder.map((phase) => [phase, 0])) as Record<RevosPhase, number>)
+
   return (
     <div className="space-y-6">
       <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
         <PageTitle>Projects</PageTitle>
         <PageDescription>Coordinate deliverables, track progress, and manage client engagements.</PageDescription>
         <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge variant="success">{statusCounts['Complete']} Complete</Badge>
-          <Badge variant="default">{statusCounts['In Progress']} In Progress</Badge>
-          {statusCounts['At Risk'] > 0 && <Badge variant="outline">{statusCounts['At Risk']} At Risk</Badge>}
+          {phaseOrder.map((phase) => (
+            <Badge key={phase} variant="outline" className={phaseBadgeClasses[phase]}>
+              {phaseCounts[phase]} {phase}
+            </Badge>
+          ))}
         </div>
       </PageHeader>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-        {Object.entries(statusCounts).map(([status, count]) => (
-          <Card key={status}>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-5">
+        {phaseOrder.map((phase) => (
+          <Card key={phase}>
             <CardHeader>
-              <CardTitle className="text-sm font-medium text-[color:var(--color-text-muted)]">{status}</CardTitle>
+              <CardTitle className="text-sm font-medium text-[color:var(--color-text-muted)]">{phase}</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-3xl font-semibold text-[color:var(--color-text)]">{count}</p>
+              <p className="text-3xl font-semibold text-[color:var(--color-text)]">{phaseCounts[phase]}</p>
             </CardContent>
           </Card>
         ))}
@@ -53,7 +164,9 @@ export default function ProjectsPage() {
               <CardTitle>Active engagements</CardTitle>
               <CardDescription>All client deliverables with owners, timelines, and health status.</CardDescription>
             </div>
-            <Button variant="outline" size="sm">Add project</Button>
+            <Button variant="outline" size="sm">
+              Add project
+            </Button>
           </div>
         </CardHeader>
         <CardContent>
@@ -70,42 +183,8 @@ export default function ProjectsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {mockProjects.map((project) => (
-                <TableRow key={project.id}>
-                  <TableCell className="font-medium">{project.name}</TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">{project.client}</TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">{project.owner}</TableCell>
-                  <TableCell>
-                    <Badge variant={
-                      project.status === 'Complete' ? 'success' :
-                      project.status === 'At Risk' ? 'outline' :
-                      'default'
-                    }>
-                      {project.status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <div className="h-2 w-24 overflow-hidden rounded-full bg-[color:var(--color-surface-muted)]">
-                        <div
-                          className="h-full bg-[color:var(--color-primary)]"
-                          style={{ width: `${project.progress}%` }}
-                        />
-                      </div>
-                      <span className="text-xs text-[color:var(--color-text-muted)]">{project.progress}%</span>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-sm text-[color:var(--color-text-muted)]">
-                    {new Date(project.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </TableCell>
-                  <TableCell>
-                    <div className={`h-3 w-3 rounded-full ${
-                      project.health === 'green' ? 'bg-[color:var(--color-positive)]' :
-                      project.health === 'yellow' ? 'bg-yellow-500' :
-                      'bg-[color:var(--color-negative)]'
-                    }`} />
-                  </TableCell>
-                </TableRow>
+              {projects.map((project) => (
+                <ProjectRow key={project.id} project={project} />
               ))}
             </TableBody>
           </Table>
@@ -114,31 +193,37 @@ export default function ProjectsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Risks & blockers</CardTitle>
+          <CardTitle>Risks &amp; blockers</CardTitle>
           <CardDescription>Projects requiring immediate attention based on SLA adherence and status.</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {mockProjects.filter(p => p.status === 'At Risk' || p.health === 'yellow' || p.health === 'red').map((project) => (
-              <div key={project.id} className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <p className="font-medium text-[color:var(--color-text)]">{project.name}</p>
-                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">
-                      {project.client} • Owner: {project.owner}
-                    </p>
+            {projects
+              .filter((project) => project.health !== 'green')
+              .map((project) => (
+                <div
+                  key={project.id}
+                  className="rounded-lg border border-[color:var(--color-outline)] bg-white p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <p className="font-medium text-[color:var(--color-text)]">{project.name}</p>
+                      <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">
+                        {project.clientName} • Owner: {project.owner}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className={phaseBadgeClasses[project.status]}>
+                        {project.status}
+                      </Badge>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant={project.health === 'red' ? 'outline' : 'default'}>
-                      {project.health === 'red' ? 'Critical' : 'Monitor'}
-                    </Badge>
-                  </div>
+                  <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">
+                    Due: {new Date(project.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} •{' '}
+                    {project.progress}% complete
+                  </p>
                 </div>
-                <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">
-                  Due: {new Date(project.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} • {project.progress}% complete
-                </p>
-              </div>
-            ))}
+              ))}
           </div>
         </CardContent>
       </Card>

--- a/app/projects/project-row.tsx
+++ b/app/projects/project-row.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, type MouseEvent } from 'react'
+
+import { phaseBadgeClasses } from '@/core/clients/constants'
+import type { ProjectRowData } from './page'
+import { Badge } from '@/ui/badge'
+import { TableCell, TableRow } from '@/ui/table'
+
+export function ProjectRow({ project }: { project: ProjectRowData }) {
+  const router = useRouter()
+
+  const handleRowClick = useCallback(() => {
+    router.push(`/clients/${project.clientId}`)
+  }, [project.clientId, router])
+
+  const handleClientLinkClick = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <TableRow className="cursor-pointer" onClick={handleRowClick}>
+      <TableCell className="font-medium text-[color:var(--color-text)]">{project.name}</TableCell>
+      <TableCell className="text-sm text-[color:var(--color-text-muted)]">
+        <Link
+          href={`/clients/${project.clientId}`}
+          title="Open client"
+          onClick={handleClientLinkClick}
+          className="underline-offset-2 hover:text-[color:var(--color-text)] hover:underline"
+        >
+          {project.clientName}
+        </Link>
+      </TableCell>
+      <TableCell className="text-sm text-[color:var(--color-text-muted)]">{project.owner}</TableCell>
+      <TableCell>
+        <Badge variant="outline" className={phaseBadgeClasses[project.status]}>
+          {project.status}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <div className="h-2 w-24 overflow-hidden rounded-full bg-[color:var(--color-surface-muted)]">
+            <div className="h-full bg-[color:var(--color-primary)]" style={{ width: `${project.progress}%` }} />
+          </div>
+          <span className="text-xs text-[color:var(--color-text-muted)]">{project.progress}%</span>
+        </div>
+      </TableCell>
+      <TableCell className="text-sm text-[color:var(--color-text-muted)]">
+        {new Date(project.dueDate).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })}
+      </TableCell>
+      <TableCell>
+        <div
+          className={`h-3 w-3 rounded-full ${
+            project.health === 'green'
+              ? 'bg-[color:var(--color-positive)]'
+              : project.health === 'yellow'
+              ? 'bg-yellow-500'
+              : 'bg-[color:var(--color-negative)]'
+          }`}
+        />
+      </TableCell>
+    </TableRow>
+  )
+}

--- a/core/clients/actions.ts
+++ b/core/clients/actions.ts
@@ -1,0 +1,24 @@
+'use server'
+
+import { moveKanban, saveGapAnswers, setQRA, toggleCollectedSource, updateStatus } from './store'
+import type { RevosPhase } from './types'
+
+export async function actionSetStatus(id: string, phase: RevosPhase) {
+  return updateStatus(id, phase)
+}
+
+export async function actionSaveGap(id: string, answers: Array<{ id: string; q: string; a: string }>) {
+  return saveGapAnswers(id, answers)
+}
+
+export async function actionToggleSource(id: string, src: string) {
+  return toggleCollectedSource(id, src)
+}
+
+export async function actionMoveKanban(id: string, card: string, from: string, to: string) {
+  return moveKanban(id, card as any, from as any, to as any)
+}
+
+export async function actionSaveQRA(id: string, notes: string) {
+  return setQRA(id, notes)
+}

--- a/core/clients/constants.ts
+++ b/core/clients/constants.ts
@@ -1,0 +1,11 @@
+import type { RevosPhase } from './types'
+
+export const REVOS_PHASES: RevosPhase[] = ['Discovery', 'Data', 'Algorithm', 'Architecture', 'Compounding']
+
+export const phaseBadgeClasses: Record<RevosPhase, string> = {
+  Discovery: 'border border-[color:var(--color-outline)] bg-[color:var(--color-surface)] text-[color:var(--color-text)]',
+  Data: 'border border-blue-100 bg-blue-50 text-blue-600',
+  Algorithm: 'border border-purple-100 bg-purple-50 text-purple-600',
+  Architecture: 'border border-emerald-100 bg-emerald-50 text-emerald-600',
+  Compounding: 'border border-amber-100 bg-amber-50 text-amber-600',
+}

--- a/core/clients/store.ts
+++ b/core/clients/store.ts
@@ -1,0 +1,88 @@
+import { ClientRecord, RevosPhase } from './types'
+
+const CLIENTS = new Map<string, ClientRecord>()
+
+export function seedClients() {
+  if (CLIENTS.size) return
+  const today = new Date().toISOString().slice(0, 10)
+  CLIENTS.set('acme', {
+    id: 'acme',
+    name: 'ACME Corp',
+    owner: 'Jay',
+    status: 'Discovery',
+    createdAt: today,
+    gapAnswers: [],
+    availableSources: ['Stripe', 'HubSpot', 'Postgres', 'Mixpanel', 'Billing CSV'],
+    collectedSources: ['Stripe'],
+    qraNotes: '',
+    kanban: {
+      Backlog: ['Scope pricing rules', 'Partner CRM skeleton'],
+      Doing: ['Daily plan shell'],
+      Review: [],
+      Done: [],
+    },
+    baselineARR: 120000,
+    realizedARR: 138000,
+    history: [
+      { date: '2025-07-01', arr: 120000 },
+      { date: '2025-08-01', arr: 126000 },
+      { date: '2025-09-01', arr: 132000 },
+      { date: '2025-10-01', arr: 138000 },
+    ],
+  })
+}
+
+export function getClient(id: string) {
+  seedClients()
+  return CLIENTS.get(id) || null
+}
+
+export function listClients() {
+  seedClients()
+  return Array.from(CLIENTS.values())
+}
+
+export function updateStatus(id: string, phase: RevosPhase) {
+  seedClients()
+  const c = CLIENTS.get(id)
+  if (!c) return null
+  c.status = phase
+  CLIENTS.set(id, c)
+  return c
+}
+
+export function saveGapAnswers(id: string, answers: Array<{ id: string; q: string; a: string }>) {
+  const c = getClient(id)
+  if (!c) return null
+  c.gapAnswers = answers
+  return c
+}
+
+export function toggleCollectedSource(id: string, src: string) {
+  const c = getClient(id)
+  if (!c) return null
+  const set = new Set(c.collectedSources)
+  set.has(src) ? set.delete(src) : set.add(src)
+  c.collectedSources = Array.from(set)
+  return c
+}
+
+export function moveKanban(
+  id: string,
+  card: string,
+  from: keyof ClientRecord['kanban'],
+  to: keyof ClientRecord['kanban'],
+) {
+  const c = getClient(id)
+  if (!c) return null
+  c.kanban[from] = c.kanban[from].filter((x) => x !== card)
+  c.kanban[to].push(card)
+  return c
+}
+
+export function setQRA(id: string, notes: string) {
+  const c = getClient(id)
+  if (!c) return null
+  c.qraNotes = notes
+  return c
+}

--- a/core/clients/types.ts
+++ b/core/clients/types.ts
@@ -1,0 +1,26 @@
+export type RevosPhase = 'Discovery' | 'Data' | 'Algorithm' | 'Architecture' | 'Compounding'
+export type ClientRecord = {
+  id: string
+  name: string
+  owner?: string
+  status: RevosPhase // mirrors current tab
+  createdAt: string
+  // Discovery
+  gapAnswers: Array<{ id: string; q: string; a: string }>
+  // Data
+  availableSources: string[]
+  collectedSources: string[]
+  // Algorithm
+  qraNotes?: string // result of QRA strategy pass (stub)
+  // Architecture
+  kanban: {
+    Backlog: string[]
+    Doing: string[]
+    Review: string[]
+    Done: string[]
+  }
+  // Compounding
+  baselineARR?: number // at start
+  realizedARR?: number // current realized uplift
+  history: Array<{ date: string; arr: number }> // for charts
+}


### PR DESCRIPTION
## Summary
- add in-memory client model with phase constants, actions, and stores for tab state and interactions
- introduce client detail route with status-controlled panels, kanban updates, and compounding summary stubs
- update projects dashboard to surface client status badges, link rows, and support row navigation via a client-side component

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e73151ec78832480202a3726e5b1d2