### PR TITLE
feat: add ai agents hub experience

### DIFF
--- a/app/agents/[key]/page.tsx
+++ b/app/agents/[key]/page.tsx
@@ -1,0 +1,142 @@
+import { notFound } from 'next/navigation'
+
+import { actionListAgents, actionLogs, actionRunAgent, actionToggleAgent } from '@/core/agents/actions'
+
+export default async function AgentDetailPage({ params }: { params: { key: string } }) {
+  const list = await actionListAgents()
+  const agent = list.find((entry) => entry.meta.key === params.key)
+
+  if (!agent) {
+    return notFound()
+  }
+
+  const selectedAgent = agent
+
+  async function runAgent(formData: FormData) {
+    'use server'
+    const payloadRaw = formData.get('payload')
+    let payload: any
+    if (payloadRaw) {
+      try {
+        payload = JSON.parse(String(payloadRaw))
+      } catch (error) {
+        console.error('Invalid payload JSON', error)
+        payload = undefined
+      }
+    }
+    await actionRunAgent(selectedAgent.meta.key, payload)
+  }
+
+  async function toggleAgent() {
+    'use server'
+    await actionToggleAgent(selectedAgent.meta.key, !selectedAgent.status.enabled)
+  }
+
+  const logs = await actionLogs(selectedAgent.meta.key)
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-950 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-neutral-500">{selectedAgent.meta.category}</p>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-neutral-100">{selectedAgent.meta.name}</h1>
+          <p className="text-sm text-gray-600 dark:text-neutral-400">{selectedAgent.meta.description}</p>
+          <dl className="mt-3 grid grid-cols-1 gap-3 text-xs text-gray-500 dark:text-neutral-400 sm:grid-cols-3">
+            <div>
+              <dt className="font-semibold text-gray-700 dark:text-neutral-300">Status</dt>
+              <dd>{selectedAgent.status.enabled ? 'Enabled' : 'Disabled'}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-700 dark:text-neutral-300">Last run</dt>
+              <dd>{selectedAgent.status.lastRun ? new Date(selectedAgent.status.lastRun).toLocaleString() : '—'}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-700 dark:text-neutral-300">Impact to date</dt>
+              <dd>{selectedAgent.status.impact$ ? `$${Number(selectedAgent.status.impact$).toLocaleString()}` : '—'}</dd>
+            </div>
+          </dl>
+        </div>
+        <form action={toggleAgent}>
+          <button
+            className={`rounded-md px-4 py-2 text-xs font-semibold transition ${
+              selectedAgent.status.enabled
+                ? 'bg-[var(--trs-accent)] text-white hover:opacity-90'
+                : 'border border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-900'
+            }`}
+            type="submit"
+          >
+            {selectedAgent.status.enabled ? 'Disable auto-run' : 'Enable auto-run'}
+          </button>
+        </form>
+      </header>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-950">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-neutral-100">Run agent</h2>
+            <p className="text-xs text-gray-500 dark:text-neutral-500">Optional JSON payload overrides defaults.</p>
+          </div>
+          {selectedAgent.meta.autoRunnable ? (
+            <span className="rounded-full border border-emerald-300 px-2 py-1 text-[10px] font-semibold uppercase text-emerald-600">
+              Auto runnable
+            </span>
+          ) : null}
+        </div>
+        <form action={runAgent} className="mt-4 space-y-3">
+          <textarea
+            name="payload"
+            placeholder='{"accountId":"acme"}'
+            className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[var(--trs-accent)] dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100"
+            rows={4}
+            defaultValue={selectedAgent.samplePayload ? JSON.stringify(selectedAgent.samplePayload, null, 2) : ''}
+          />
+          {selectedAgent.samplePayload ? (
+            <details className="text-xs text-gray-500 dark:text-neutral-400">
+              <summary className="cursor-pointer font-semibold text-gray-700 dark:text-neutral-300">Sample payload</summary>
+              <pre className="mt-2 overflow-x-auto rounded-md bg-gray-50 p-3 text-[11px] leading-relaxed dark:bg-neutral-900">
+                {JSON.stringify(selectedAgent.samplePayload, null, 2)}
+              </pre>
+            </details>
+          ) : null}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-[var(--trs-accent)] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:opacity-90"
+            >
+              Run now
+            </button>
+            <span className="text-xs text-gray-500 dark:text-neutral-500">
+              Auto-run scheduling will connect to orchestration later.
+            </span>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-950">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-neutral-100">Recent runs</h2>
+        <div className="mt-3 divide-y divide-gray-200 text-sm dark:divide-neutral-800">
+          {logs.length ? (
+            logs.map((entry, index) => (
+              <div key={index} className="py-4">
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500 dark:text-neutral-400">
+                  <span>{new Date(entry.ts).toLocaleString()}</span>
+                  <span className={entry.output.ok ? 'text-emerald-600' : 'text-red-500'}>
+                    {entry.output.ok ? 'OK' : 'Failed'}
+                  </span>
+                </div>
+                <div className="mt-2 text-xs text-gray-600 dark:text-neutral-400">
+                  Summary: {entry.output.summary ?? '—'}
+                </div>
+                <pre className="mt-2 overflow-x-auto rounded-md bg-gray-50 p-3 text-[11px] leading-relaxed dark:bg-neutral-900">
+                  {JSON.stringify(entry.output.data ?? {}, null, 2)}
+                </pre>
+              </div>
+            ))
+          ) : (
+            <div className="py-6 text-sm text-gray-500 dark:text-neutral-400">No runs yet.</div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link'
+
+import { actionListAgents } from '@/core/agents/actions'
+
+export default async function AgentsHubPage() {
+  const agents = await actionListAgents()
+
+  if (!agents.length) {
+    return (
+      <div className="space-y-4">
+        <header>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-neutral-100">AI Agents</h1>
+          <p className="text-sm text-gray-600 dark:text-neutral-400">
+            Operate TRS with focused automations. Click a card to run &amp; configure.
+          </p>
+        </header>
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white p-6 text-sm text-gray-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-400">
+          No agents registered yet.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-neutral-100">AI Agents</h1>
+        <p className="text-sm text-gray-600 dark:text-neutral-400">
+          Operate TRS with focused automations. Click a card to run &amp; configure.
+        </p>
+      </header>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {agents.map(({ meta, status }) => (
+          <Link
+            key={meta.key}
+            href={`/agents/${meta.key}`}
+            className="group rounded-xl border border-gray-200 bg-white transition hover:shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+          >
+            <div className="flex h-full flex-col p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-gray-900 dark:text-neutral-100">{meta.name}</div>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-neutral-400">{meta.description}</p>
+                </div>
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold tracking-wide ${
+                    status.enabled
+                      ? 'bg-[var(--trs-accent)] text-white'
+                      : 'border border-gray-200 text-gray-600 dark:border-neutral-800 dark:text-neutral-300'
+                  }`}
+                >
+                  {meta.category}
+                </span>
+              </div>
+              <div className="mt-4 flex flex-1 flex-col justify-end gap-1 text-xs text-gray-500 dark:text-neutral-400">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-gray-700 dark:text-neutral-300">Status</span>
+                  <span className={status.enabled ? 'text-emerald-600' : 'text-red-500'}>
+                    {status.enabled ? 'Enabled' : 'Disabled'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Last run</span>
+                  <span>{status.lastRun ? new Date(status.lastRun).toLocaleString() : '—'}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Impact</span>
+                  <span>{status.impact$ ? `$${Number(status.impact$).toLocaleString()}` : '—'}</span>
+                </div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/core/agents/actions.ts
+++ b/core/agents/actions.ts
@@ -1,0 +1,25 @@
+'use server'
+
+import './registry'
+
+import { listAgents, runAgent, logsFor, setEnabled } from './bus'
+import { AgentKey } from './types'
+
+const USER = 'me'
+const ORG = 'org'
+
+export async function actionListAgents() {
+  return listAgents()
+}
+
+export async function actionRunAgent(key: AgentKey, payload?: any) {
+  return runAgent(key, { userId: USER, orgId: ORG, payload })
+}
+
+export async function actionLogs(key: AgentKey) {
+  return logsFor(key)
+}
+
+export async function actionToggleAgent(key: AgentKey, enabled: boolean) {
+  return setEnabled(key, enabled)
+}

--- a/core/agents/bus.ts
+++ b/core/agents/bus.ts
@@ -1,0 +1,48 @@
+import { Agent, AgentKey, AgentRunInput, AgentRunOutput } from './types'
+
+const REGISTRY = new Map<AgentKey, Agent>()
+type Log = { ts: string; key: AgentKey; input: AgentRunInput; output: AgentRunOutput }
+const LOGS: Log[] = []
+const STATUS = new Map<AgentKey, { enabled: boolean; lastRun?: string; lastSummary?: string; impact$?: number }>()
+
+export function register(agent: Agent) {
+  REGISTRY.set(agent.meta.key, agent)
+  if (!STATUS.has(agent.meta.key)) STATUS.set(agent.meta.key, { enabled: true })
+}
+
+export function listAgents() {
+  return Array.from(REGISTRY.values()).map((a) => ({
+    meta: a.meta,
+    status: STATUS.get(a.meta.key) ?? { enabled: true },
+    samplePayload: a.samplePayload,
+  }))
+}
+
+export function getAgent(key: AgentKey) {
+  return REGISTRY.get(key)!
+}
+
+export async function runAgent(key: AgentKey, input: AgentRunInput) {
+  const a = getAgent(key)
+  const out = await a.run(input)
+  const ts = new Date().toISOString()
+  LOGS.unshift({ ts, key, input, output: out })
+  const s = STATUS.get(key) ?? { enabled: true }
+  s.lastRun = ts
+  s.lastSummary = out.summary ?? (out.ok ? 'Completed' : 'Failed')
+  const impact = (out.data && (out.data.expectedImpact$ || out.data.dollarsAdvanced$)) ?? 0
+  s.impact$ = (s.impact$ ?? 0) + Number(impact)
+  STATUS.set(key, s)
+  return out
+}
+
+export function logsFor(key: AgentKey, limit = 50) {
+  return LOGS.filter((l) => l.key === key).slice(0, limit)
+}
+
+export function setEnabled(key: AgentKey, enabled: boolean) {
+  const s = STATUS.get(key) ?? { enabled: true }
+  s.enabled = enabled
+  STATUS.set(key, s)
+  return s
+}

--- a/core/agents/registry.ts
+++ b/core/agents/registry.ts
@@ -1,0 +1,311 @@
+import { register } from './bus'
+import { Agent } from './types'
+
+const make = (meta: Agent['meta'], run: Agent['run'], samplePayload?: any): Agent => ({
+  meta,
+  run,
+  samplePayload,
+})
+
+// Projects
+register(
+  make(
+    {
+      key: 'delivery-orchestrator',
+      name: 'Delivery Orchestrator',
+      category: 'Projects',
+      description: 'Advance RevOS phases and generate next 3 actions',
+      icon: 'Workflow',
+      autoRunnable: true,
+    },
+    async ({ userId, payload }) => ({
+      ok: true,
+      summary: 'Set phase to Data; queued 3 next actions.',
+      data: {
+        phase: 'Data',
+        next: ['Interview billing owner', 'Connect Stripe', 'Sample cohort export'],
+        expectedImpact$: 3000,
+        runBy: userId,
+        payload,
+      },
+    }),
+    { clientId: 'acme-co', focus: 'billing' },
+  ),
+)
+register(
+  make(
+    {
+      key: 'gap-discovery',
+      name: 'Gap Discovery',
+      category: 'Projects',
+      description: 'Run gap questions; extract levers',
+      icon: 'Search',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Captured 12 answers; proposed 3 levers.',
+      data: {
+        levers: [
+          { name: 'Raise Plus 5%', impact$: 4000 },
+          { name: 'Prepay incentive', impact$: 2500 },
+          { name: 'Partner co-sell', impact$: 5000 },
+        ],
+        expectedImpact$: 11500,
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'data-intake',
+      name: 'Data Intake',
+      category: 'Projects',
+      description: 'Map available vs collected data',
+      icon: 'Database',
+    },
+    async () => ({
+      ok: true,
+      summary: '8/12 sources ready; flagged missing ARR field.',
+      data: {
+        completeness: 0.67,
+        missing: ['ARR', 'ChurnReason'],
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'qra-strategy',
+      name: 'QRA Strategy',
+      category: 'Projects',
+      description: 'Compute price/offer/channel moves',
+      icon: 'Brain',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Proposed pricing + retention play.',
+      data: {
+        pricing: '+5% Plus; floor 12% disc',
+        retention: 'N-day save sequence',
+        expectedImpact$: 9000,
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'build-planner',
+      name: 'Build Planner',
+      category: 'Projects',
+      description: 'Create Kanban plan and SLOs',
+      icon: 'Kanban',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Critical path set; 2 SLOs risk.',
+      data: {
+        columns: ['Backlog', 'Doing', 'Blocked', 'Review', 'Done'],
+        sloRisks: ['Auth latency p95', 'Invoice job'],
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'compounding',
+      name: 'Compounding',
+      category: 'Projects',
+      description: 'Quantify new revenue vs baseline',
+      icon: 'BarChart2',
+    },
+    async () => ({
+      ok: true,
+      summary: '$12.4k net new vs baseline; QTD forecast +$48k.',
+      data: {
+        dollarsAdvanced$: 12400,
+        forecastQTD: 48000,
+      },
+    }),
+  ),
+)
+
+// Content
+register(
+  make(
+    {
+      key: 'media-agent',
+      name: 'Media Agent',
+      category: 'Content',
+      description: 'Podcast + YouTube + shorts bundle',
+      icon: 'Mic',
+      autoRunnable: true,
+    },
+    async () => ({
+      ok: true,
+      summary: 'Generated pod + YT plan; 3 shorts; scheduled LI & Email.',
+      data: {
+        expectedImpact$: 8000,
+        artifacts: ['podcast', 'youtube', 'shorts'],
+        channels: ['LinkedIn', 'Email'],
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'brief-agent',
+      name: 'Brief Agent',
+      category: 'Content',
+      description: 'Generate persona-stage brief',
+      icon: 'FileText',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Brief for CFO @ Proposal created.',
+      data: {
+        outline: ['Problem', 'Offer', 'Proof', 'CTA'],
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'distribution-agent',
+      name: 'Distribution Agent',
+      category: 'Content',
+      description: 'Channel copy + UTM + schedule',
+      icon: 'Send',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Scheduled LI + X with UTM.',
+      data: {
+        utm: 'utm_source=li&utm_campaign=revos',
+        scheduledAt: new Date().toISOString(),
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'attribution-agent',
+      name: 'Attribution Agent',
+      category: 'Content',
+      description: 'Assign influenced/advanced/closed',
+      icon: 'Target',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Attributed $6k influenced; $2k closed.',
+      data: {
+        influenced$: 6000,
+        closedWon$: 2000,
+      },
+    }),
+  ),
+)
+
+// Clients
+register(
+  make(
+    {
+      key: 'account-intel',
+      name: 'Account Intelligence',
+      category: 'Clients',
+      description: 'Stakeholders, goals, health',
+      icon: 'IdCard',
+      autoRunnable: true,
+    },
+    async () => ({
+      ok: true,
+      summary: 'Health: 72 (green); 2 risks flagged.',
+      data: {
+        health: 72,
+        risks: ['Champion bandwidth', 'Security review'],
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'close-plan',
+      name: 'Close Plan',
+      category: 'Clients',
+      description: 'Mutual action plan',
+      icon: 'Handshake',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Next step set for 10/12.',
+      data: {
+        nextStep: 'Security review call',
+        due: '2025-10-12',
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'commercials',
+      name: 'Commercials',
+      category: 'Clients',
+      description: 'Price/terms guardrails',
+      icon: 'Scale',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Price floor approved; Net30 → Net15.',
+      data: {
+        priceFloor: '-12%',
+        terms: 'Net15',
+        expectedImpact$: 3500,
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'collections',
+      name: 'Collections',
+      category: 'Clients',
+      description: 'Dunning & recovery',
+      icon: 'CreditCard',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Dunning step 2 sent; $1.8k likely.',
+      data: {
+        dollarsAdvanced$: 1800,
+      },
+    }),
+  ),
+)
+register(
+  make(
+    {
+      key: 'client-health',
+      name: 'Client Health',
+      category: 'Clients',
+      description: 'Adoption & renewal risk',
+      icon: 'HeartPulse',
+    },
+    async () => ({
+      ok: true,
+      summary: 'Renewal risk low; expansion candidate.',
+      data: {
+        renewalRisk: 'Low',
+        expansionSignal: true,
+      },
+    }),
+  ),
+)

--- a/core/agents/types.ts
+++ b/core/agents/types.ts
@@ -1,0 +1,43 @@
+export type AgentKey =
+  | 'delivery-orchestrator'
+  | 'gap-discovery'
+  | 'data-intake'
+  | 'qra-strategy'
+  | 'build-planner'
+  | 'compounding'
+  | 'media-agent'
+  | 'brief-agent'
+  | 'distribution-agent'
+  | 'attribution-agent'
+  | 'account-intel'
+  | 'close-plan'
+  | 'commercials'
+  | 'collections'
+  | 'client-health'
+
+export type AgentMeta = {
+  key: AgentKey
+  name: string
+  category: 'Projects' | 'Content' | 'Clients'
+  description: string
+  icon?: string
+  autoRunnable?: boolean
+}
+
+export type AgentRunInput = {
+  userId: string
+  orgId?: string
+  payload?: Record<string, any>
+}
+export type AgentRunOutput = {
+  ok: boolean
+  summary?: string
+  data?: any
+  warnings?: string[]
+}
+
+export type Agent = {
+  meta: AgentMeta
+  run: (input: AgentRunInput) => Promise<AgentRunOutput>
+  samplePayload?: Record<string, any>
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -10,6 +10,7 @@ export const MAIN_NAV: NavItem[] = [
   { label: 'Morning briefing', href: '/', icon: 'Sun', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Pipeline', href: '/pipeline', icon: 'TrendingUp', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Projects', href: '/projects', icon: 'Kanban', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
+  { label: 'AI Agents', href: '/agents', icon: 'Bot', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Content', href: '/content', icon: 'FileText', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Finance', href: '/finance', icon: 'Wallet', roles: ['SuperAdmin', 'Admin', 'Director'] },
   { label: 'Partners', href: '/partners', icon: 'Handshake', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },


### PR DESCRIPTION
## Summary
- add an in-memory agent core with registry, bus, and server actions
- build the agents hub and detail pages to run agents, view logs, and toggle automation
- expose the AI Agents entry in the main navigation

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e739a17688832493029491be80d64c