### PR TITLE
feat: add grayscale dashboard layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+import * as React from "react";
+import { Bell, Download, Home, Search } from "lucide-react";
+import AdminSidebar from "@/components/nav/AdminSidebar";
+import { TopTabs } from "@/components/kit/TopTabs";
+import { Card } from "@/components/kit/Card";
+import { StatCard } from "@/components/kit/StatCard";
+import { LineChart, AreaChart, BarChart } from "@/components/kit/Charts";
+
+const H = { header: 56, tabs: 44, gap: 12 };
+
+export default function DashboardPage() {
+  return (
+    <div className="w-full min-h-screen bg-white text-black">
+      <header style={{ height: H.header }} className="border-b border-gray-200 flex items-center">
+        <div className="px-3 w-full flex items-center gap-3">
+          <button className="h-9 w-9 rounded-lg border flex items-center justify-center">
+            <Home size={16} />
+          </button>
+          <div className="text-lg font-semibold">Dashboard</div>
+          <div className="ml-4 flex items-center gap-2 h-9 px-2 rounded-lg border flex-1 max-w-xl">
+            <Search size={16} className="text-gray-500" />
+            <input placeholder="Search" className="flex-1 outline-none text-sm bg-transparent" />
+          </div>
+          <button className="h-9 px-3 rounded-lg border flex items-center gap-2 text-sm">
+            <Download size={16} /> Download
+          </button>
+          <button className="h-9 w-9 rounded-lg border flex items-center justify-center">
+            <Bell size={16} />
+          </button>
+          <button className="h-9 w-9 rounded-full bg-gray-200" aria-label="Account" />
+        </div>
+      </header>
+
+      <div className="flex" style={{ height: `calc(100vh - ${H.header}px)` }}>
+        <AdminSidebar />
+        <main className="flex-1" style={{ height: `calc(100vh - ${H.header}px)` }}>
+          <div className="px-3 border-b border-gray-200 flex items-center justify-between" style={{ height: H.tabs }}>
+            <TopTabs value="Overview" onChange={() => {}} />
+            <div className="text-xs text-gray-600">Pick a date</div>
+          </div>
+          <ViewportGrid />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function ViewportGrid() {
+  const [vh, setVh] = React.useState(800);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const update = () => setVh(window.innerHeight);
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const contentH = (vh ?? 800) - H.header - H.tabs - H.gap * 2;
+
+  return (
+    <div className="p-3" style={{ height: contentH }}>
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: "repeat(12, minmax(0,1fr))",
+          gridTemplateRows: "110px 200px 220px",
+          gap: H.gap,
+          height: "100%",
+        }}
+      >
+        <div className="col-span-3">
+          <StatCard label="New Subscriptions" value="4,682" delta="+15.5%" trend="up" />
+        </div>
+        <div className="col-span-3">
+          <StatCard label="New Orders" value="1,226" delta="-40.2%" trend="down" />
+        </div>
+        <div className="col-span-3">
+          <StatCard label="Avg Order Revenue" value="1,080" delta="+10.8%" trend="up" />
+        </div>
+        <Card title="Total Revenue" className="col-span-3">
+          <div className="h-[66px] p-2">
+            <LineChart />
+          </div>
+        </Card>
+
+        <Card title="Sale Activity - Monthly" subtitle="Last 6 months" className="col-span-8">
+          <div className="h-[156px] p-2">
+            <AreaChart />
+          </div>
+        </Card>
+        <Card title="Subscriptions" subtitle="+180% MoM" className="col-span-4">
+          <div className="h-[156px] p-2">
+            <BarChart />
+          </div>
+        </Card>
+
+        <Card
+          title="Payments"
+          className="col-span-8"
+          action={<button className="text-xs px-2 py-1 rounded-md border">Columns</button>}
+        >
+          <div className="h-[176px] overflow-hidden">
+            <Table
+              rows={[
+                { status: "Success", email: "ken99@yahoo.com", amount: "$316.00" },
+                { status: "Success", email: "abe45@gmail.com", amount: "$242.00" },
+                { status: "Pending", email: "lee@acme.com", amount: "$1,120.00" },
+                { status: "Failed", email: "ops@vendor.com", amount: "$88.00" },
+              ]}
+            />
+          </div>
+        </Card>
+        <Card title="Team Members" className="col-span-4">
+          <div className="h-[176px] p-3 text-sm">
+            <Member name="Dale Komen" role="Member" email="dale@example.com" />
+            <Member name="Sofia Davis" role="Owner" email="m@example.com" />
+            <Member name="Jackson Lee" role="Member" email="p@example.com" />
+            <Member name="Isabella Nguyen" role="Member" email="x@example.com" />
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+type TableRow = { status: string; email: string; amount: string };
+
+function Table({ rows }: { rows: Array<TableRow> }) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-[12px] text-gray-600">
+          <th className="px-3 py-2">Status</th>
+          <th className="px-3 py-2">Email</th>
+          <th className="px-3 py-2">Amount</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y">
+        {rows.map((r, i) => (
+          <tr key={i} className="hover:bg-gray-50">
+            <td className="px-3 py-2">{r.status}</td>
+            <td className="px-3 py-2">{r.email}</td>
+            <td className="px-3 py-2">{r.amount}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function Member({ name, role, email }: { name: string; role: string; email: string }) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="flex items-center gap-2">
+        <div className="h-8 w-8 rounded-full bg-gray-200" />
+        <div>
+          <div className="text-sm font-medium leading-none text-black">{name}</div>
+          <div className="text-[11px] text-gray-500">{email}</div>
+        </div>
+      </div>
+      <button className="text-xs px-2 py-1 rounded-md border">{role}</button>
+    </div>
+  );
+}

--- a/components/kit/Card.tsx
+++ b/components/kit/Card.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { cn } from "@/lib/utils";
+import type React from "react";
+
+export function Card(
+  { title, subtitle, action, className, children }:
+  { title?: string; subtitle?: string; action?: React.ReactNode; className?: string; children: React.ReactNode }
+) {
+  return (
+    <section className={cn("rounded-xl border bg-white border-gray-200 overflow-hidden", className)}>
+      {(title || action) && (
+        <div className="h-11 px-3 flex items-center justify-between border-b border-gray-200">
+          <div>
+            <div className="text-sm font-medium leading-none text-black">{title}</div>
+            {subtitle ? <div className="text-[11px] text-gray-500">{subtitle}</div> : null}
+          </div>
+          {action}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/components/kit/Charts.tsx
+++ b/components/kit/Charts.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+export function LineChart() {
+  const pts = [0, 8, 2, 6, 3, 5, 4, 5.2, 4.5, 6, 7, 10].map((y, i) => `${i * 20},${80 - y * 6}`).join(" ");
+  const ys = [0, 8, 2, 6, 3, 5, 4, 5.2, 4.5, 6, 7, 10];
+  return (
+    <svg viewBox="0 0 220 90" className="w-full h-full">
+      <polyline fill="none" stroke="#111111" strokeWidth="2" points={pts} />
+      {ys.map((y, i) => (
+        <circle key={i} cx={i * 20} cy={80 - y * 6} r="2" fill="#111111" />
+      ))}
+    </svg>
+  );
+}
+
+export function AreaChart() {
+  const top = [2, 7, 12, 10, 8, 9, 11, 13, 14, 16, 18, 17];
+  const bot = [1, 3, 5, 6, 5, 6, 7, 8, 8, 9, 10, 9];
+  const path = (arr: number[]) => arr.map((y, i) => `${i * 18},${100 - y * 5}`).join(" L ");
+  return (
+    <svg viewBox="0 0 220 110" className="w-full h-full">
+      <path d={`M0,${100 - bot[0] * 5} L ${path(bot)} L 220,110 L 0,110 Z`} fill="#dddddd" />
+      <path d={`M0,${100 - top[0] * 5} L ${path(top)} L 220,110 L 0,110 Z`} fill="#bbbbbb" />
+    </svg>
+  );
+}
+
+export function BarChart() {
+  const bars = [8, 12, 6, 10, 7, 14, 4, 9, 5, 12, 7, 10];
+  return (
+    <svg viewBox="0 0 240 120" className="w-full h-full">
+      {bars.map((v, i) => (
+        <rect key={i} x={i * 18 + 8} y={110 - v * 6} width="10" height={v * 6} rx="2" fill={i % 2 ? "#333333" : "#999999"} />
+      ))}
+    </svg>
+  );
+}

--- a/components/kit/StatCard.tsx
+++ b/components/kit/StatCard.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { cn } from "@/lib/utils";
+
+function MiniSpark({ trend }: { trend: "up" | "down" | "flat" }) {
+  const d = trend === "up" ? "M2,18 L8,12 L14,14 L20,6" : trend === "down" ? "M2,6 L8,12 L14,10 L20,18" : "M2,12 L20,12";
+  return (
+    <svg width="96" height="36" viewBox="0 0 22 20" className="text-gray-400">
+      <path d={d} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function StatCard(
+  { label, value, delta, trend = "flat" }:
+  { label: string; value: string; delta: string; trend?: "up" | "down" | "flat" }
+) {
+  return (
+    <div className="rounded-xl border bg-white border-gray-200 p-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-[11px] text-gray-500">{label}</div>
+          <div className="text-[22px] font-semibold leading-tight mt-1 text-black">{value}</div>
+          <div
+            className={cn(
+              "text-[11px] mt-1 inline-flex items-center gap-1",
+              trend === "down" ? "text-gray-700" : trend === "up" ? "text-gray-600" : "text-gray-500",
+            )}
+          >
+            {delta}
+          </div>
+        </div>
+        <MiniSpark trend={trend} />
+      </div>
+    </div>
+  );
+}

--- a/components/kit/TopTabs.tsx
+++ b/components/kit/TopTabs.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { cn } from "@/lib/utils";
+
+export function TopTabs({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const tabs = ["Overview", "Analytics", "Reports", "Notifications"];
+  return (
+    <div className="h-[44px] flex items-center gap-2">
+      {tabs.map((t) => (
+        <button
+          key={t}
+          onClick={() => onChange(t)}
+          className={cn(
+            "px-3 h-8 rounded-md text-sm border",
+            value === t ? "bg-black text-white border-black" : "text-gray-700 bg-white hover:bg-gray-100 border-gray-300",
+          )}
+        >
+          {t}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/nav/AdminSidebar.tsx
+++ b/components/nav/AdminSidebar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { PieChart, ListChecks, Users, Layers, BarChart2, Settings } from "lucide-react";
+import type React from "react";
+
+export default function AdminSidebar() {
+  const Item = ({ label, icon }: { label: string; icon: React.ReactNode }) => (
+    <button className="w-full flex items-center gap-2 px-2 py-2 rounded-md text-sm hover:bg-gray-50">
+      <span className="inline-flex items-center justify-center h-6 w-6 rounded-md border text-gray-600">{icon}</span>
+      <span className="text-black">{label}</span>
+    </button>
+  );
+  return (
+    <aside className="hidden md:flex flex-col shrink-0" style={{ width: 232, borderRightWidth: 1, borderRightColor: "#e5e7eb" }}>
+      <nav className="p-2 text-sm">
+        <div className="px-2 py-1 text-[11px] uppercase tracking-wide text-gray-500">General</div>
+        <div className="space-y-1">
+          <Item label="Dashboard" icon={<PieChart size={14} />} />
+          <Item label="Tasks" icon={<ListChecks size={14} />} />
+          <Item label="Users" icon={<Users size={14} />} />
+        </div>
+        <div className="px-2 py-1 mt-3 text-[11px] uppercase tracking-wide text-gray-500">Pages</div>
+        <div className="space-y-1">
+          <Item label="Auth" icon={<Layers size={14} />} />
+          <Item label="Errors" icon={<BarChart2 size={14} />} />
+        </div>
+        <div className="px-2 py-1 mt-3 text-[11px] uppercase tracking-wide text-gray-500">Other</div>
+        <div className="space-y-1">
+          <Item label="Settings" icon={<Settings size={14} />} />
+          <Item label="Developers" icon={<Layers size={14} />} />
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,3 @@
-export function cn(...inputs: Array<string | false | null | undefined>) {
-  return inputs.filter(Boolean).join(' ')
+export function cn(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
 }


### PR DESCRIPTION
## Summary
- add a viewport-locked grayscale dashboard route with top tabs and admin sidebar
- build reusable card, stat, chart, and tab primitives to support the layout
- align the shared `cn` helper with the new kit components

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74855af408324b0030199beb0e110