### PR TITLE
feat: unify top tabs across core modules

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,10 +1,16 @@
 import { actionListClients } from "@/core/clients/actions";
 import { ClientsTable } from "./client-table";
+import { TopTabs } from "@/components/kit/TopTabs";
 
-export default async function ClientsPage() {
+export default async function ClientsPage({
+  searchParams,
+}: {
+  searchParams: { tab?: string };
+}) {
+  const tab = searchParams?.tab ?? "Overview";
   const data = await actionListClients();
 
-  return (
+  const body = (
     <div className="p-6 space-y-4">
       <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
@@ -19,6 +25,16 @@ export default async function ClientsPage() {
       </header>
 
       <ClientsTable data={data} />
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   );
 }

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -3,8 +3,14 @@ import { computeMetrics, getContentState } from '@/core/content/store'
 import { nextBestContent } from '@/core/content/recommender'
 import { computeMediaMetrics, getMediaState } from '@/core/mediaAgent/store'
 import { suggestMediaFromPipeline } from '@/core/mediaAgent/recommender'
+import { TopTabs } from '@/components/kit/TopTabs'
 
-export default async function ContentPage() {
+export default async function ContentPage({
+  searchParams,
+}: {
+  searchParams: { tab?: string }
+}) {
+  const tab = searchParams?.tab ?? 'Overview'
   const contentState = getContentState()
   const metrics = computeMetrics()
   const suggestions = nextBestContent()
@@ -12,7 +18,7 @@ export default async function ContentPage() {
   const mediaMetrics = computeMediaMetrics()
   const mediaIdeas = suggestMediaFromPipeline()
 
-  return (
+  const body = (
     <ContentStudio
       initialItems={contentState.items}
       initialVariants={contentState.variants}
@@ -25,5 +31,15 @@ export default async function ContentPage() {
       mediaDistributions={mediaState.distributions}
       mediaMetrics={mediaMetrics}
     />
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
+    </div>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import * as React from "react";
+import { useSearchParams } from "next/navigation";
 import { Bell, Download, Home, Search } from "lucide-react";
 import AdminSidebar from "@/components/nav/AdminSidebar";
 import { TopTabs } from "@/components/kit/TopTabs";
@@ -10,6 +11,8 @@ import { LineChart, AreaChart, BarChart } from "@/components/kit/Charts";
 const H = { header: 56, tabs: 44, gap: 12 };
 
 export default function DashboardPage() {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get("tab") ?? "Overview";
   return (
     <div className="w-full min-h-screen bg-white text-black">
       <header style={{ height: H.header }} className="border-b border-gray-200 flex items-center">
@@ -36,8 +39,11 @@ export default function DashboardPage() {
         <AdminSidebar />
         <main className="flex-1" style={{ height: `calc(100vh - ${H.header}px)` }}>
           <div className="px-3 border-b border-gray-200 flex items-center justify-between" style={{ height: H.tabs }}>
-            <TopTabs value="Overview" onChange={() => {}} />
-            <div className="text-xs text-gray-600">Pick a date</div>
+            <TopTabs />
+            <div className="text-xs text-gray-600">
+              <span className="sr-only">Current tab: {tab}</span>
+              Pick a date
+            </div>
           </div>
           <ViewportGrid />
         </main>

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/
 import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
 import { Button } from '@/ui/button'
+import { TopTabs } from '@/components/kit/TopTabs'
 
 const mockInvoices = [
   { id: '1', client: 'Acme Corp', invoiceNumber: 'INV-2025-1043', status: 'Paid', dueDate: '2025-09-30', amount: 45000, daysOverdue: 0 },
@@ -20,11 +21,16 @@ const burnMultiple = 0.65
 const nrr = 118
 const ruleOf40 = 62
 
-export default function FinancePage() {
+export default function FinancePage({
+  searchParams,
+}: {
+  searchParams: { tab?: string }
+}) {
+  const tab = searchParams?.tab ?? 'Overview'
   const totalOutstanding = mockInvoices.filter(i => i.status !== 'Paid').reduce((sum, i) => sum + i.amount, 0)
   const overdueAmount = mockInvoices.filter(i => i.status === 'Overdue').reduce((sum, i) => sum + i.amount, 0)
 
-  return (
+  const body = (
     <div className="space-y-6">
       <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
         <PageTitle>Finance</PageTitle>
@@ -217,6 +223,16 @@ export default function FinancePage() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useSearchParams } from "next/navigation"
+import { TopTabs } from "@/components/kit/TopTabs"
 import { Badge } from "@/ui/badge"
 import { Button } from "@/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
@@ -15,6 +17,8 @@ import { eventsToday } from "@/core/events/store"
 import { DailyPlan } from "@/core/dailyPlan/types"
 
 export default function HomePage() {
+  const searchParams = useSearchParams()
+  const tab = searchParams.get("tab") ?? "Overview"
   const [plan, setPlan] = useState<DailyPlan | null>(null)
   const [recap, setRecap] = useState<any>(null)
   const [loading, setLoading] = useState(false)
@@ -99,7 +103,7 @@ export default function HomePage() {
     return () => clearInterval(interval)
   }, [newsItems.length])
 
-  return (
+  const body = (
     <div className="relative space-y-8 p-6">
       {/* Hero background */}
       <div className="absolute inset-x-0 top-0 -z-10 h-[400px] overflow-hidden rounded-3xl">
@@ -346,6 +350,21 @@ export default function HomePage() {
           </Card>
         </div>
       </div>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="flex items-center gap-2">
+          <span className="sr-only">Current tab: {tab}</span>
+          <Link href="/dashboard" className="text-xs px-3 py-1.5 rounded-md border">
+            Open dashboard
+          </Link>
+        </div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   )
 }

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/
 import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
 import { Button } from '@/ui/button'
+import { TopTabs } from '@/components/kit/TopTabs'
 
 const mockPartners = [
   { id: '1', name: 'Strategic Consulting Group', tier: 'Platinum', status: 'Active', revenue: 485000, deals: 12, enablement: 95, lastActivity: '2025-10-05' },
@@ -22,8 +23,14 @@ const pipelineBySource = [
 const totalPartnerRevenue = mockPartners.reduce((sum, p) => sum + p.revenue, 0)
 const activePartners = mockPartners.filter(p => p.status === 'Active').length
 
-export default function PartnersPage() {
-  return (
+export default function PartnersPage({
+  searchParams,
+}: {
+  searchParams: { tab?: string }
+}) {
+  const tab = searchParams?.tab ?? 'Overview'
+
+  const body = (
     <div className="space-y-6">
       <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
         <PageTitle>Partners</PageTitle>
@@ -222,6 +229,16 @@ export default function PartnersPage() {
           </CardContent>
         </Card>
       </div>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   )
 }

--- a/app/pipeline/page.tsx
+++ b/app/pipeline/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useSearchParams } from "next/navigation"
 import { PageDescription, PageHeader, PageTitle } from "@/ui/page-header"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
 import { Badge } from "@/ui/badge"
@@ -8,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { emitEvent } from "@/core/events/emit"
+import { TopTabs } from "@/components/kit/TopTabs"
 
 type Deal = {
   id: string
@@ -88,6 +90,8 @@ const initialDeals: Deal[] = [
 const stages = ["Discovery", "Qualification", "Proposal", "Negotiation", "Closed Won", "Closed Lost"]
 
 export default function PipelinePage() {
+  const searchParams = useSearchParams()
+  const tab = searchParams.get("tab") ?? "Overview"
   const [deals, setDeals] = useState<Deal[]>(initialDeals)
   const [selectedDeal, setSelectedDeal] = useState<Deal | null>(null)
   const [newNote, setNewNote] = useState("")
@@ -173,7 +177,7 @@ export default function PipelinePage() {
     }
   })
 
-  return (
+  const body = (
     <div className="space-y-6 p-6">
       <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
         <PageTitle>Pipeline</PageTitle>
@@ -472,6 +476,16 @@ export default function PipelinePage() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   )
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
 import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/ui/table'
+import { TopTabs } from '@/components/kit/TopTabs'
 
 import { ProjectRow } from './project-row'
 
@@ -105,7 +106,12 @@ const mockProjects: MockProject[] = [
 
 const phaseOrder: RevosPhase[] = REVOS_PHASES
 
-export default async function ProjectsPage() {
+export default async function ProjectsPage({
+  searchParams,
+}: {
+  searchParams: { tab?: string }
+}) {
+  const tab = searchParams?.tab ?? 'Overview'
   const clients = listClients()
   const clientsById = new Map(clients.map((client) => [client.id, client]))
 
@@ -130,7 +136,7 @@ export default async function ProjectsPage() {
     return acc
   }, Object.fromEntries(phaseOrder.map((phase) => [phase, 0])) as Record<RevosPhase, number>)
 
-  return (
+  const body = (
     <div className="space-y-6">
       <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
         <PageTitle>Projects</PageTitle>
@@ -227,6 +233,16 @@ export default async function ProjectsPage() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <TopTabs />
+        <div className="text-xs text-gray-600">{tab}</div>
+      </div>
+      <main className="max-w-7xl mx-auto p-4">{body}</main>
     </div>
   )
 }

--- a/components/kit/TopTabs.tsx
+++ b/components/kit/TopTabs.tsx
@@ -1,17 +1,38 @@
 "use client";
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 
-export function TopTabs({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  const tabs = ["Overview", "Analytics", "Reports", "Notifications"];
+const DEFAULTS = ["Overview", "Analytics", "Reports", "Notifications"] as const;
+export type TabName = (typeof DEFAULTS)[number];
+
+export function TopTabs({ tabs = DEFAULTS }: { tabs?: readonly string[] }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const sp = useSearchParams();
+  const active = (sp.get("tab") || tabs[0]) as string;
+
+  const setTab = useCallback(
+    (t: string) => {
+      const next = new URLSearchParams(sp.toString());
+      next.set("tab", t);
+      router.replace(`${pathname}?${next.toString()}`, { scroll: false });
+    },
+    [router, pathname, sp],
+  );
+
   return (
     <div className="h-[44px] flex items-center gap-2">
       {tabs.map((t) => (
         <button
           key={t}
-          onClick={() => onChange(t)}
+          onClick={() => setTab(t)}
+          aria-pressed={active === t}
           className={cn(
             "px-3 h-8 rounded-md text-sm border",
-            value === t ? "bg-black text-white border-black" : "text-gray-700 bg-white hover:bg-gray-100 border-gray-300",
+            active === t
+              ? "bg-black text-white border-black"
+              : "text-gray-700 bg-white hover:bg-gray-100 border-gray-300",
           )}
         >
           {t}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -8,6 +8,7 @@ export type NavItem = {
 
 export const MAIN_NAV: NavItem[] = [
   { label: 'Morning briefing', href: '/', icon: 'Sun', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
+  { label: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Pipeline', href: '/pipeline', icon: 'TrendingUp', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'Projects', href: '/projects', icon: 'Kanban', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },
   { label: 'AI Agents', href: '/agents', icon: 'Bot', roles: ['SuperAdmin', 'Admin', 'Director', 'Member'] },


### PR DESCRIPTION
## Summary
- replace the TopTabs component with a URL-synced version shared across pages
- add the shared tabs header and dashboard link to home, dashboard, and core module routes
- expose the dashboard route in the main navigation menu

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74a5a2b4c8324a0836fe90be2af44