### PR TITLE
fix: wrap layout shell with suspense

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import AppShell from '@/components/layout/AppShell'
 
 export const metadata: Metadata = {
@@ -11,7 +12,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="min-h-screen bg-white text-gray-900">
-        <AppShell>{children}</AppShell>
+        <Suspense fallback={<div className="min-h-screen bg-white" />}>
+          <AppShell>{children}</AppShell>
+        </Suspense>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- wrap the root layout's AppShell in a Suspense boundary so useSearchParams can render during prerender

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e7699e43108324aa26b6e957b6376d