### PR TITLE
feat: build modular multi-tab clients analytics view

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,30 +1,68 @@
-import { actionListClients } from "@/core/clients/actions";
-import { ClientsTable } from "./client-table";
+"use client";
 
-export default async function ClientsPage({
-  searchParams,
-}: {
-  searchParams: { tab?: string };
-}) {
-  const tab = searchParams?.tab ?? "Overview";
-  const data = await actionListClients();
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Card } from "@/components/kit/Card";
+import { TopTabs } from "@/components/kit/TopTabs";
+import ChurnPanel from "@/components/clients/ChurnPanel";
+import HealthPanel from "@/components/clients/HealthPanel";
+import HistoryPanel from "@/components/clients/HistoryPanel";
+import QBRPanel from "@/components/clients/QBRPanel";
+import { getClients } from "@/core/clients/store";
+
+export default function ClientsPage() {
+  const [tab, setTab] = useState("Accounts");
+  const router = useRouter();
+  const clients = useMemo(
+    () =>
+      getClients()
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [],
+  );
 
   return (
-    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
-      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="text-xl font-semibold text-black">Clients</h1>
-          <p className="text-sm text-gray-500">
-            Search, filter, and click into a client dossier to guide revenue execution.
-          </p>
-          <div className="text-xs text-gray-500">Active view: {tab}</div>
-        </div>
-        <form action="#">
-          <button className="rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-black">New Client</button>
-        </form>
-      </header>
-
-      <ClientsTable data={data} />
+    <div className="w-full p-3">
+      <TopTabs value={tab} onChange={setTab} />
+      {tab === "Accounts" && (
+        <Card className="mt-3 p-3">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 text-left text-[12px] text-gray-500">
+                <th className="px-3 py-2">Client</th>
+                <th className="px-3 py-2">Owner</th>
+                <th className="px-3 py-2">ARR</th>
+                <th className="px-3 py-2">Health</th>
+                <th className="px-3 py-2">Churn Risk</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 border-t border-gray-200">
+              {clients.map((client) => (
+                <tr
+                  key={client.id}
+                  onClick={() => router.push(`/clients/${client.id}`)}
+                  className="cursor-pointer transition hover:bg-gray-50"
+                >
+                  <td className="px-3 py-2 font-medium text-black">{client.name}</td>
+                  <td className="px-3 py-2 text-gray-700">{client.owner}</td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {client.arr != null ? `$${client.arr.toLocaleString()}` : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">{client.health}%</td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {client.churnRisk != null ? `${client.churnRisk}%` : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      )}
+      {tab === "Health" && <HealthPanel />}
+      {tab === "Churn" && <ChurnPanel />}
+      {tab === "QBR" && <QBRPanel />}
+      {tab === "History" && <HistoryPanel />}
     </div>
   );
 }

--- a/components/clients/ChurnPanel.tsx
+++ b/components/clients/ChurnPanel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Card } from "@/components/kit/Card";
+import { getClients } from "@/core/clients/store";
+
+export default function ChurnPanel() {
+  const router = useRouter();
+  const clients = getClients().filter((client) => (client.churnRisk ?? 0) > 10);
+
+  return (
+    <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}>
+      <Card className="col-span-12 p-3">
+        <div className="mb-2 text-sm font-semibold text-black">High-Risk Clients</div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-[12px] text-gray-500">
+              <th className="px-3 py-2">Client</th>
+              <th className="px-3 py-2">Owner</th>
+              <th className="px-3 py-2">Health</th>
+              <th className="px-3 py-2">Churn Risk</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 border-t border-gray-200">
+            {clients.length === 0 ? (
+              <tr>
+                <td className="px-3 py-6 text-center text-gray-500" colSpan={4}>
+                  No clients currently flagged as high risk.
+                </td>
+              </tr>
+            ) : (
+              clients.map((client) => (
+                <tr
+                  key={client.id}
+                  onClick={() => router.push(`/clients/${client.id}`)}
+                  className="cursor-pointer transition hover:bg-gray-50"
+                >
+                  <td className="px-3 py-2 font-medium text-black">{client.name}</td>
+                  <td className="px-3 py-2 text-gray-700">{client.owner}</td>
+                  <td className="px-3 py-2 text-gray-700">{client.health}%</td>
+                  <td className="px-3 py-2 text-gray-700">{client.churnRisk}%</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+}

--- a/components/clients/HealthPanel.tsx
+++ b/components/clients/HealthPanel.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Card } from "@/components/kit/Card";
+import { getClientStats } from "@/core/clients/store";
+
+export default function HealthPanel() {
+  const d = getClientStats();
+  return (
+    <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}>
+      <Card className="col-span-4 p-3">
+        <div className="text-sm font-semibold text-black">Portfolio Health</div>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          <Kpi label="Avg Health" value={`${d.avgHealth}%`} />
+          <Kpi label="At Risk" value={d.atRisk.toString()} />
+          <Kpi label="Expansions" value={d.expansions.toString()} />
+          <Kpi label="Churned" value={d.churned.toString()} />
+        </div>
+      </Card>
+      <Card className="col-span-8 p-3">
+        <div className="text-sm font-semibold text-black">Trendline (Stub)</div>
+        <div className="mt-3 flex h-[180px] items-center justify-center rounded-md border border-gray-200 text-xs text-gray-500">
+          Trend Graph Placeholder
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-2 text-center">
+      <div className="text-[11px] text-gray-500">{label}</div>
+      <div className="text-lg font-semibold text-black">{value}</div>
+    </div>
+  );
+}

--- a/components/clients/HistoryPanel.tsx
+++ b/components/clients/HistoryPanel.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Card } from "@/components/kit/Card";
+
+export default function HistoryPanel() {
+  return (
+    <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}>
+      <Card className="col-span-12 p-4">
+        <div className="mb-2 text-sm font-semibold text-black">Engagement History</div>
+        <div className="space-y-1 text-[13px] text-gray-700">
+          <p>• 09/15 – Helio Systems upgraded to Architecture phase.</p>
+          <p>• 09/12 – OmniVantage completed Compounding deployment.</p>
+          <p>• 09/08 – Northwave entered Data tuning sprint.</p>
+          <p>• 09/01 – Helio expansion approved, +$18K ARR.</p>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/clients/QBRPanel.tsx
+++ b/components/clients/QBRPanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Card } from "@/components/kit/Card";
+import { getClients } from "@/core/clients/store";
+
+export default function QBRPanel() {
+  const router = useRouter();
+  const clients = getClients().sort((a, b) => {
+    if (!a.qbrDate) return 1;
+    if (!b.qbrDate) return -1;
+    return a.qbrDate.localeCompare(b.qbrDate);
+  });
+
+  return (
+    <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}>
+      <Card className="col-span-12 p-3">
+        <div className="mb-2 text-sm font-semibold text-black">Upcoming QBRs</div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-[12px] text-gray-500">
+              <th className="px-3 py-2">Client</th>
+              <th className="px-3 py-2">Owner</th>
+              <th className="px-3 py-2">Next QBR</th>
+              <th className="px-3 py-2">Phase</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 border-t border-gray-200">
+            {clients.map((client) => (
+              <tr
+                key={client.id}
+                onClick={() => router.push(`/clients/${client.id}`)}
+                className="cursor-pointer transition hover:bg-gray-50"
+              >
+                <td className="px-3 py-2 font-medium text-black">{client.name}</td>
+                <td className="px-3 py-2 text-gray-700">{client.owner}</td>
+                <td className="px-3 py-2 text-gray-700">{client.qbrDate ?? "—"}</td>
+                <td className="px-3 py-2 text-gray-700">{client.phase}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+}

--- a/core/clients/store.ts
+++ b/core/clients/store.ts
@@ -16,6 +16,10 @@ const CLIENTS = new Map<string, Client>();
       phase: "Discovery",
       owner: "Jay",
       health: 72,
+      churnRisk: 14,
+      qbrDate: "2025-10-22",
+      status: "active",
+      isExpansion: true,
       contacts: [
         {
           id: "c1",
@@ -98,6 +102,10 @@ const CLIENTS = new Map<string, Client>();
       phase: "Algorithm",
       owner: "Morgan",
       health: 64,
+      churnRisk: 18,
+      qbrDate: "2025-11-05",
+      status: "active",
+      isExpansion: false,
       contacts: [
         { id: "g1", name: "Priya Nair", role: "VP Revenue", email: "priya@globex.com", power: "Decision" },
         { id: "g2", name: "Jordan Chu", role: "Head of Data", email: "jordan@globex.com", power: "Influencer" },
@@ -158,10 +166,136 @@ const CLIENTS = new Map<string, Client>();
       },
     });
   }
+
+  const id3 = "helio";
+  if (!CLIENTS.has(id3)) {
+    CLIENTS.set(id3, {
+      id: id3,
+      name: "Helio Systems",
+      segment: "Mid",
+      arr: 180000,
+      industry: "Energy",
+      region: "NA",
+      phase: "Architecture",
+      owner: "Taylor",
+      health: 82,
+      churnRisk: 9,
+      qbrDate: "2025-10-15",
+      status: "active",
+      isExpansion: true,
+      contacts: [
+        { id: "h1", name: "Alex Park", role: "Head of RevOps", email: "alex@helio.io", power: "Decision" },
+      ],
+      commercials: { plan: "Plus", price: 1500, termMonths: 12, discountPct: 5, paymentTerms: "Net30" },
+      invoices: [
+        { id: "inv-2001", amount: 4500, status: "Paid", paidAt: "2025-09-05" },
+      ],
+      opportunities: [
+        { id: "hopp-1", name: "Expansion package", amount: 36000, stage: "Proposal", probability: 0.6 },
+      ],
+      discovery: [
+        { id: "hq1", question: "Primary growth lever?", answer: "Usage automation" },
+      ],
+      data: [
+        { id: "hd1", name: "Billing", category: "Finance", status: "Collected" },
+        { id: "hd2", name: "NPS", category: "CS", status: "Available" },
+      ],
+      qra: {
+        pricing: ["Rollout peak pricing"],
+        offers: ["Solar bundle"],
+        retention: ["Executive business review"],
+        partners: ["Field Ops"],
+        expectedImpact: 5400,
+      },
+      kanban: [
+        { id: "hk1", title: "Usage anomaly alerts", status: "Doing", owner: "Taylor" },
+      ],
+      compounding: {
+        baselineMRR: 15000,
+        currentMRR: 16200,
+        netNew: 1200,
+        forecastQTD: 4200,
+        drivers: [{ name: "Automation add-on", delta: 600 }],
+      },
+      notes: "Architecture blueprint approved for rollout.",
+    });
+  }
+
+  const id4 = "northwave";
+  if (!CLIENTS.has(id4)) {
+    CLIENTS.set(id4, {
+      id: id4,
+      name: "Northwave Analytics",
+      segment: "SMB",
+      arr: 96000,
+      industry: "SaaS",
+      region: "NA",
+      phase: "Compounding",
+      owner: "Riley",
+      health: 58,
+      churnRisk: 22,
+      qbrDate: "2025-09-28",
+      status: "churned",
+      isExpansion: false,
+      contacts: [
+        { id: "n1", name: "Jamie Cole", role: "Founder", email: "jamie@northwave.ai", power: "Economic" },
+      ],
+      commercials: { plan: "Starter", price: 800, termMonths: 6, discountPct: 0, paymentTerms: "Net15" },
+      invoices: [
+        { id: "inv-3001", amount: 2400, status: "Overdue", dueAt: "2025-09-10" },
+      ],
+      opportunities: [
+        { id: "nopp-1", name: "Renewal", amount: 12000, stage: "Negotiation", probability: 0.3 },
+      ],
+      discovery: [
+        { id: "nq1", question: "Primary blocker?", answer: "Data trust" },
+      ],
+      data: [
+        { id: "nd1", name: "Product usage", category: "Product", status: "Missing" },
+        { id: "nd2", name: "Billing", category: "Finance", status: "Collected" },
+      ],
+      qra: {
+        pricing: ["Stabilize annual plan"],
+        offers: ["Onboarding reset"],
+        retention: ["Weekly office hours"],
+        partners: ["Success"],
+        expectedImpact: 2200,
+      },
+      kanban: [
+        { id: "nk1", title: "Data trust remediation", status: "Blocked" },
+        { id: "nk2", title: "Renewal playbook", status: "Backlog" },
+      ],
+      compounding: {
+        baselineMRR: 8000,
+        currentMRR: 7800,
+        netNew: -200,
+        forecastQTD: 600,
+        drivers: [{ name: "Churn risk", delta: -300 }],
+      },
+      notes: "Renewal slipping due to data delays.",
+    });
+  }
 })();
 
 export function listClients(): Client[] {
   return Array.from(CLIENTS.values());
+}
+
+export function getClients(): Client[] {
+  return listClients();
+}
+
+export function getClientStats() {
+  const clients = getClients();
+  const total = clients.length || 1;
+  const avgHealth = Math.round(
+    clients.reduce((sum, client) => sum + (client.health ?? 0), 0) / total,
+  );
+  const atRisk = clients.filter((client) => (client.churnRisk ?? 0) >= 15).length;
+  const expansions = clients.filter((client) => client.isExpansion).length;
+  const churned = clients.filter((client) => client.status === "churned").length;
+
+  return { avgHealth, atRisk, expansions, churned };
 }
 export function getClient(id: string): Client | null {
   return CLIENTS.get(id) ?? null;

--- a/core/clients/types.ts
+++ b/core/clients/types.ts
@@ -95,6 +95,10 @@ export type Client = {
   phase: RevOSPhase;
   owner: string;
   health: number;
+  churnRisk?: number;
+  qbrDate?: string;
+  status?: "active" | "churned";
+  isExpansion?: boolean;
   contacts: Contact[];
   commercials?: Commercials;
   invoices: Invoice[];

--- a/lib/tabs.ts
+++ b/lib/tabs.ts
@@ -3,5 +3,5 @@ export const PAGE_TABS: Record<string, string[]> = {
   "/pipeline": ["Overview", "Deals", "Commit", "Forecast", "Health"],
   "/morning": ["Today", "This Week", "Focus Blocks", "Risks"],
   "/projects": ["Active", "Backlog", "Completed"],
-  "/clients": ["Accounts", "Health", "Churn", "QBR"],
+  "/clients": ["Accounts", "Health", "Churn", "QBR", "History"],
 };


### PR DESCRIPTION
## Summary
- replace the clients landing page with a tabbed analytics layout and clickable account table
- add dedicated Health, Churn, QBR, and History panels with TRS card styling and viewport-friendly grids
- extend the client store with richer metadata and aggregate stats to power analytics views

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e76e2dec888324ba7d1160d6e4a789