### PR TITLE
feat: add mail & calendar and resources workspaces

### DIFF
--- a/app/mail-calendar/page.tsx
+++ b/app/mail-calendar/page.tsx
@@ -1,0 +1,305 @@
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+
+const inboxThreads = [
+  {
+    id: 't1',
+    sender: 'RevenueOps Alerts',
+    subject: 'Daily pipeline sync & risk summary',
+    preview: 'Highlights from RevOps: 3 deals need follow up, 1 flagged for pricing exception.',
+    receivedAt: '9:24 AM',
+    tags: ['Priority', 'Automation'],
+  },
+  {
+    id: 't2',
+    sender: 'Gmail – Marketing',
+    subject: 'Launch checklist for Q4 nurture sequence',
+    preview: 'Creative brief approved. Final assets due Friday before we handoff to sequencing.',
+    receivedAt: '8:10 AM',
+    tags: ['Campaign', 'Content'],
+  },
+  {
+    id: 't3',
+    sender: 'HostGator Support',
+    subject: 'DNS verification for calendar routing',
+    preview: 'TXT records validated. You can finalize calendar availability sync across providers.',
+    receivedAt: 'Yesterday',
+    tags: ['Integration'],
+  },
+]
+
+const calendarEvents = [
+  {
+    id: 'e1',
+    title: 'Customer QBR – Northwind',
+    time: '10:30 – 11:15 AM',
+    participants: ['Alex', 'Priya', 'Northwind CS'],
+    type: 'External',
+  },
+  {
+    id: 'e2',
+    title: 'Pricing desk office hours',
+    time: '12:00 – 12:30 PM',
+    participants: ['GTM Ops'],
+    type: 'Internal',
+  },
+  {
+    id: 'e3',
+    title: 'Marketing <> Sales sync',
+    time: '2:00 – 2:45 PM',
+    participants: ['Demand Gen', 'Sales Leads'],
+    type: 'Collaboration',
+  },
+]
+
+const integrationStatus = [
+  { id: 'i1', name: 'Gmail API', description: 'Primary inbox connection for GTM leadership.', status: 'Connected' },
+  { id: 'i2', name: 'Google Calendar', description: 'Two-way sync with focus blocks and QBRs.', status: 'Connected' },
+  { id: 'i3', name: 'HostGator Mailboxes', description: 'Routing shared support and partner mailboxes.', status: 'Syncing' },
+  { id: 'i4', name: 'Zoom', description: 'Auto-attach meeting recordings to thread history.', status: 'Planned' },
+]
+
+export default function MailCalendarPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Mail &amp; Calendar</PageTitle>
+        <PageDescription>
+          Centralize email, calendar availability, and meeting intelligence so GTM teams never miss a follow-up.
+        </PageDescription>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge variant="success">Realtime sync</Badge>
+          <Badge variant="outline">Gmail &amp; Google Calendar ready</Badge>
+          <Badge variant="default">HostGator routing supported</Badge>
+        </div>
+      </PageHeader>
+
+      <Tabs defaultValue="inbox">
+        <TabsList>
+          <TabsTrigger value="inbox">Email Inbox</TabsTrigger>
+          <TabsTrigger value="calendar">Calendar</TabsTrigger>
+          <TabsTrigger value="integrations">Integrations</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="inbox" className="space-y-4 border-none p-0">
+          <Card>
+              <CardHeader>
+                <CardTitle>Today’s priorities</CardTitle>
+              <CardDescription>Threads surfaced from automation rules, sentiment analysis, and revenue triggers.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {inboxThreads.map((thread) => (
+                <div key={thread.id} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-medium text-[color:var(--color-text)]">{thread.subject}</p>
+                      <p className="text-xs text-[color:var(--color-text-muted)]">{thread.sender}</p>
+                    </div>
+                    <span className="text-xs text-[color:var(--color-text-muted)]">{thread.receivedAt}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{thread.preview}</p>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    {thread.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Automation playbooks</CardTitle>
+              <CardDescription>Suggested automations to keep inbox triage tight across GTM teams.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {[
+                {
+                  id: 'a1',
+                  title: 'Follow-up nudges',
+                  description: 'Auto-remind owners on stalled threads after 24 hours with no reply.',
+                  impact: 'Protect SLAs',
+                },
+                {
+                  id: 'a2',
+                  title: 'Deal room bundling',
+                  description: 'Attach latest forecast, pricing sheet, and mutual action plan to opportunity emails.',
+                  impact: 'Faster cycles',
+                },
+                {
+                  id: 'a3',
+                  title: 'Calendar insights in inbox',
+                  description: 'Embed available focus blocks or QBR windows directly into reply suggestions.',
+                  impact: 'Eliminate back-and-forth',
+                },
+                {
+                  id: 'a4',
+                  title: 'Sentiment routing',
+                  description: 'Escalate negative sentiment threads to leadership with context and suggested replies.',
+                  impact: 'Save renewals',
+                },
+              ].map((play) => (
+                <div key={play.id} className="flex flex-col rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-[color:var(--color-text)]">{play.title}</p>
+                      <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{play.description}</p>
+                    </div>
+                    <Badge variant="success">{play.impact}</Badge>
+                  </div>
+                  <Button variant="outline" className="mt-4 self-start">
+                    Configure
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="calendar" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Upcoming schedule</CardTitle>
+              <CardDescription>Key meetings synchronized from Google Calendar and focus block priorities.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {calendarEvents.map((event) => (
+                <div key={event.id} className="flex flex-col gap-2 rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-[color:var(--color-text)]">{event.title}</p>
+                    <p className="text-xs text-[color:var(--color-text-muted)]">{event.participants.join(', ')}</p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm">
+                    <Badge variant="outline">{event.type}</Badge>
+                    <span className="text-[color:var(--color-text-muted)]">{event.time}</span>
+                    <Button variant="outline" size="sm">
+                      Open details
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Availability intelligence</CardTitle>
+                <CardDescription>Surface shared free blocks, travel windows, and focus hours per leader.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {[
+                  { label: 'Focus hours protected', value: '18 hrs', trend: '↑ 3 hrs WoW' },
+                  { label: 'QBR windows available', value: '6 slots', trend: 'Next 14 days' },
+                  { label: 'Travel days detected', value: '2 leaders', trend: 'Auto-blocked on calendar' },
+                ].map((metric) => (
+                  <div key={metric.label} className="rounded-lg border border-dashed border-[color:var(--color-outline)] p-3">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="font-medium text-[color:var(--color-text)]">{metric.label}</span>
+                      <span className="text-[color:var(--color-text-muted)]">{metric.trend}</span>
+                    </div>
+                    <p className="mt-1 text-lg font-semibold text-[color:var(--color-text)]">{metric.value}</p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Scheduler automations</CardTitle>
+                <CardDescription>Recommended workflows to align invites, agenda prep, and follow-ups.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {[
+                  'Auto-send recap docs 15 minutes after meetings with transcripts and highlights.',
+                  'Detect conflicts between focus blocks and external invites to suggest alternates.',
+                  'Create shared agendas with AI-suggested objectives for pipeline and renewal calls.',
+                ].map((insight, index) => (
+                  <div key={index} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/40 p-3 text-sm text-[color:var(--color-text)]">
+                    {insight}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="integrations" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Integration status</CardTitle>
+              <CardDescription>Connection health across email, calendar, conferencing, and workspace tools.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {integrationStatus.map((integration) => (
+                <div key={integration.id} className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-outline)] p-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-[color:var(--color-text)]">{integration.name}</p>
+                    <p className="text-xs text-[color:var(--color-text-muted)]">{integration.description}</p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge variant={integration.status === 'Connected' ? 'success' : integration.status === 'Syncing' ? 'warning' : 'outline'}>
+                      {integration.status}
+                    </Badge>
+                    <Button variant="outline" size="sm">
+                      Manage
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Next up</CardTitle>
+              <CardDescription>Planned integrations and roadmap items for unified comms.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {[
+                {
+                  id: 'r1',
+                  title: 'Outlook + Microsoft 365',
+                  description: 'Extend parity for enterprise clients running Microsoft stacks.',
+                  eta: 'Q1 FY26',
+                },
+                {
+                  id: 'r2',
+                  title: 'Slack highlights',
+                  description: 'Push high-signal email summaries into deal rooms and CS channels.',
+                  eta: 'In discovery',
+                },
+                {
+                  id: 'r3',
+                  title: 'Dialer intelligence',
+                  description: 'Attach call notes and Gong snippets to relevant threads automatically.',
+                  eta: 'Pilot customers',
+                },
+                {
+                  id: 'r4',
+                  title: 'Calendar analytics pack',
+                  description: 'Report on context switching, meeting load, and focus-time leakage.',
+                  eta: 'Design sprint',
+                },
+              ].map((item) => (
+                <div key={item.id} className="flex flex-col justify-between rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <div>
+                    <p className="text-sm font-semibold text-[color:var(--color-text)]">{item.title}</p>
+                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{item.description}</p>
+                  </div>
+                  <div className="mt-3 text-xs text-[color:var(--color-text-muted)]">ETA: {item.eta}</div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,0 +1,279 @@
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+
+const pricingScenarios = [
+  { tier: 'Starter', list: 8500, floor: 7200, discountGuard: '15% max', packaging: 'Seats + usage' },
+  { tier: 'Growth', list: 18500, floor: 16000, discountGuard: '12% max', packaging: 'Seats + workflow pack' },
+  { tier: 'Enterprise', list: 42000, floor: 38000, discountGuard: '10% max', packaging: 'Seats + governance + support' },
+]
+
+const revenueDrivers = [
+  { id: 'rd1', name: 'Net new ARR', amount: 185000, change: '+12% MoM' },
+  { id: 'rd2', name: 'Expansion ARR', amount: 95000, change: '+6% MoM' },
+  { id: 'rd3', name: 'Contraction ARR', amount: -45000, change: '-2% MoM' },
+  { id: 'rd4', name: 'Churn ARR', amount: -115000, change: '+1% MoM' },
+]
+
+const profitMetrics = [
+  { id: 'pm1', name: 'Gross margin', value: '78%', benchmark: 'Top quartile SaaS' },
+  { id: 'pm2', name: 'Magic number', value: '1.3x', benchmark: 'Efficient growth' },
+  { id: 'pm3', name: 'CAC payback', value: '13.5 months', benchmark: 'Target < 15 months' },
+  { id: 'pm4', name: 'Rule of 40', value: '62', benchmark: 'Above target' },
+]
+
+export default function ResourcesPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
+        <PageTitle>Resources &amp; Calculators</PageTitle>
+        <PageDescription>
+          Finance-ready calculators to pressure test pricing, revenue, profit, and board-ready scenarios in minutes.
+        </PageDescription>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge variant="outline">Prebuilt GTM formulas</Badge>
+          <Badge variant="success">Live benchmarks</Badge>
+          <Badge variant="default">Downloadable templates</Badge>
+        </div>
+      </PageHeader>
+
+      <Tabs defaultValue="pricing">
+        <TabsList className="flex flex-wrap">
+          <TabsTrigger value="pricing">Pricing</TabsTrigger>
+          <TabsTrigger value="revenue">Revenue</TabsTrigger>
+          <TabsTrigger value="financial">Financial Plan</TabsTrigger>
+          <TabsTrigger value="profit">Profitability</TabsTrigger>
+          <TabsTrigger value="scenarios">Board Scenarios</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="pricing" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Guardrail calculator</CardTitle>
+              <CardDescription>Set floor prices, packaging guardrails, and instant impact to ARR and margin.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4">
+                <p className="text-sm text-[color:var(--color-text)]">
+                  Adjust list price and discount allowances to visualize net ARR impact. Export recommendations for sales playbooks in one click.
+                </p>
+              </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                {pricingScenarios.map((scenario) => (
+                  <div key={scenario.tier} className="flex flex-col rounded-lg border border-[color:var(--color-outline)] p-4">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-[color:var(--color-text)]">{scenario.tier}</p>
+                      <Badge variant="outline">{scenario.packaging}</Badge>
+                    </div>
+                    <dl className="mt-3 space-y-2 text-sm text-[color:var(--color-text)]">
+                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                        <dt>List price</dt>
+                        <dd>${scenario.list.toLocaleString()}</dd>
+                      </div>
+                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                        <dt>Floor price</dt>
+                        <dd>${scenario.floor.toLocaleString()}</dd>
+                      </div>
+                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                        <dt>Discount guardrail</dt>
+                        <dd>{scenario.discountGuard}</dd>
+                      </div>
+                    </dl>
+                    <Button variant="outline" className="mt-4">
+                      Export playbook
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Packaging experiments</CardTitle>
+              <CardDescription>Compare usage-based vs seat-based packaging to find the optimal blend.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
+                <p className="text-sm font-medium text-[color:var(--color-text)]">Usage-first</p>
+                <p className="text-sm text-[color:var(--color-text-muted)]">
+                  Meter core AI generation and automations. Seat add-ons unlock analytics and governance modules.
+                </p>
+                <Badge variant="success">Recommended</Badge>
+              </div>
+              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
+                <p className="text-sm font-medium text-[color:var(--color-text)]">Seat-first</p>
+                <p className="text-sm text-[color:var(--color-text-muted)]">
+                  Predictable ARR but lower margin. Layer usage overages when activation crosses 120% of plan.
+                </p>
+                <Badge variant="outline">In testing</Badge>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="revenue" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Revenue bridge</CardTitle>
+              <CardDescription>Understand what is driving ARR movement across segments and motions.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {revenueDrivers.map((driver) => (
+                  <div key={driver.id} className="rounded-lg border border-[color:var(--color-outline)] p-4">
+                    <p className="text-sm font-medium text-[color:var(--color-text)]">{driver.name}</p>
+                    <p className={`mt-2 text-2xl font-semibold ${
+                      driver.amount >= 0
+                        ? 'text-[color:var(--color-positive)]'
+                        : 'text-[color:var(--color-negative)]'
+                    }`}>
+                      ${Math.abs(driver.amount / 1000).toFixed(0)}K
+                    </p>
+                    <p className="text-xs text-[color:var(--color-text-muted)]">{driver.change}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-lg border border-dashed border-[color:var(--color-outline)] p-4 text-sm text-[color:var(--color-text)]">
+                Model net new pipeline coverage, expansion playbooks, and churn saves with scenario toggles. Export to RevOps dashboards instantly.
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Coverage calculator</CardTitle>
+              <CardDescription>Blend quota capacity, attainment, and forecast confidence to project outcomes.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {[
+                { label: 'Total quota capacity', value: '$9.2M', detail: '12 AEs · 2.3x pipeline coverage' },
+                { label: 'In-quarter commit', value: '$3.4M', detail: '65% probability weighted' },
+                { label: 'Stretch scenario', value: '$4.1M', detail: 'Requires 3 net-new logo wins' },
+              ].map((metric) => (
+                <div key={metric.label} className="rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">{metric.label}</p>
+                  <p className="mt-2 text-2xl font-semibold text-[color:var(--color-text)]">{metric.value}</p>
+                  <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">{metric.detail}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="financial" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Financial runway</CardTitle>
+              <CardDescription>Plan burn, runway, and investment pacing with CFO-grade controls.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
+                <p className="text-sm font-medium text-[color:var(--color-text)]">Base plan</p>
+                <p className="text-3xl font-semibold text-[color:var(--color-text)]">18.5 months</p>
+                <p className="text-xs text-[color:var(--color-text-muted)]">Runway based on current burn rate of $185K/mo</p>
+              </div>
+              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
+                <p className="text-sm font-medium text-[color:var(--color-text)]">Efficiency scenario</p>
+                <p className="text-3xl font-semibold text-[color:var(--color-positive)]">21.3 months</p>
+                <p className="text-xs text-[color:var(--color-text-muted)]">Assumes 8% opex reduction + 6% ARR uplift</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Cash flow planner</CardTitle>
+              <CardDescription>Align hiring plans, vendor spend, and capital strategy.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {["Headcount pacing vs plan","Vendor consolidation savings","Capital efficiency by cohort"].map((item) => (
+                <div key={item} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-3 text-sm text-[color:var(--color-text)]">
+                  {item}
+                </div>
+              ))}
+              <Button variant="outline" className="self-start">
+                Open planner workspace
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="profit" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Profitability snapshot</CardTitle>
+              <CardDescription>Track margin, CAC payback, and capital efficiency benchmarks.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {profitMetrics.map((metric) => (
+                <div key={metric.id} className="rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <p className="text-sm font-medium text-[color:var(--color-text)]">{metric.name}</p>
+                  <p className="mt-2 text-2xl font-semibold text-[color:var(--color-text)]">{metric.value}</p>
+                  <p className="text-xs text-[color:var(--color-text-muted)]">{metric.benchmark}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Margin improvement ideas</CardTitle>
+              <CardDescription>Quick wins sourced from GTM, product, and finance collaboration.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {["Shift implementation to partners for enterprise tier","Launch usage alerts to prevent overage credits","Automate onboarding to reduce services cost"].map((idea) => (
+                <div key={idea} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-3 text-sm text-[color:var(--color-text)]">
+                  {idea}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="scenarios" className="space-y-4 border-none p-0">
+          <Card>
+            <CardHeader>
+              <CardTitle>Board-ready packs</CardTitle>
+              <CardDescription>Assemble scenario outputs with commentary, risks, and actions in seconds.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {[
+                { title: 'Base', summary: 'Plan of record, current hiring, pipeline confidence.' },
+                { title: 'Upside', summary: 'Requires 2 strategic wins + PLG conversion lift.' },
+                { title: 'Downside', summary: 'Models churn risk, slip deals, and cost controls.' },
+              ].map((pack) => (
+                <div key={pack.title} className="flex flex-col justify-between rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <div>
+                    <p className="text-sm font-semibold text-[color:var(--color-text)]">{pack.title}</p>
+                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{pack.summary}</p>
+                  </div>
+                  <Button variant="outline" className="mt-4">
+                    Generate pack
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>What-if levers</CardTitle>
+              <CardDescription>Toggle hiring, win rates, and pricing to see multi-quarter impact.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {["AE ramp time","Enterprise discount rate","Partner-sourced pipeline"].map((lever) => (
+                <div key={lever} className="flex items-center justify-between rounded-lg border border-[color:var(--color-outline)] p-3 text-sm text-[color:var(--color-text)]">
+                  <span>{lever}</span>
+                  <Badge variant="outline">Interactive</Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -14,6 +14,8 @@ export const MAIN_NAV: NavItem[] = [
   { label: "Pipeline", href: "/pipeline", icon: "TrendingUp", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Projects", href: "/projects", icon: "Kanban", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Content", href: "/content", icon: "FileText", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
+  { label: "Mail & Calendar", href: "/mail-calendar", icon: "Mail", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
+  { label: "Resources", href: "/resources", icon: "BookOpen", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Agents", href: "/agents", icon: "Bot", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Finance", href: "/finance", icon: "Wallet", roles: ["SuperAdmin", "Admin", "Director"] },
   { label: "Partners", href: "/partners", icon: "Handshake", roles: ["SuperAdmin", "Admin", "Director", "Member"] },

--- a/lib/tabs.ts
+++ b/lib/tabs.ts
@@ -7,6 +7,8 @@ export const PAGE_TABS: Record<string, string[]> = {
   "/projects": ["Overview", "Active", "Forecast", "Agent"],
   "/content": ["Pipeline", "Ideas", "Scheduled", "Performance"],
   "/agents": ["All", "Projects", "Content", "Clients", "GPT Agents"],
+  "/mail-calendar": ["Inbox", "Calendar", "Integrations"],
+  "/resources": ["Pricing", "Revenue", "Financial Plan", "Profit", "Board Scenarios"],
   "/clients": ["Overview", "Accounts", "Engagement", "Renewals", "Signals"],
   "/clients/[id]": ["Overview", "Projects", "RevenueOS", "Data", "Strategy", "Results"],
   "/partners/[id]": ["Overview", "Introductions", "Initiatives", "Notes", "Resources"],


### PR DESCRIPTION
## Summary
- add a Mail & Calendar workspace with inbox, calendar, and integration tabs
- create a resources hub with pricing, revenue, financial, profit, and board scenario calculators
- register the new routes in the main navigation and global tab resolver

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e84026b75c8324adaf84ef42a042c2