### PR TITLE
feat: upgrade rosie operator assistant

### DIFF
--- a/app/api/rosie/route.ts
+++ b/app/api/rosie/route.ts
@@ -1,0 +1,321 @@
+import { NextRequest, NextResponse } from 'next/server'
+import OpenAI from 'openai'
+
+import { getClient, listClients } from '@/core/clients/store'
+import { getDashboard } from '@/core/exec/store'
+import { getMediaState } from '@/core/mediaAgent/store'
+import { getProjectsByClient, listProjects } from '@/core/projects/store'
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+type RosieIntent =
+  | 'client_status'
+  | 'project_status'
+  | 'email_draft'
+  | 'pipeline_summary'
+  | 'news_search'
+  | 'general'
+
+type IntentDetection = {
+  intent: RosieIntent
+  clientId?: string
+  projectId?: string
+}
+
+const openaiApiKey = process.env.OPENAI_API_KEY
+const openai = openaiApiKey
+  ? new OpenAI({ apiKey: openaiApiKey })
+  : null
+
+export async function POST(req: NextRequest) {
+  const { messages } = (await req.json()) as { messages: ChatMessage[] }
+  const normalizedMessages = Array.isArray(messages) ? messages : []
+  const lastUser = [...normalizedMessages].reverse().find((message) => message.role === 'user')
+  const detection = detectIntent(lastUser?.content ?? '')
+  const context = buildContext(detection)
+  const prompt = buildIntentPrompt(detection)
+
+  if (!openai) {
+    const offline = buildOfflineResponse(detection, context)
+    return streamText(offline)
+  }
+
+  const systemPrompt =
+    'You are Rosie, the TRS internal assistant. You have full context of company data, clients, projects, and workflows. You help operators summarize, retrieve, and act on TRS information with precision. Respond naturally but concisely, reason about the intent before replying, and confirm before executing any irreversible actions.'
+
+  const payload = [
+    { role: 'system' as const, content: systemPrompt },
+    { role: 'system' as const, content: prompt },
+  ]
+
+  if (context) {
+    payload.push({ role: 'system' as const, content: `Context for reasoning:\n${context}` })
+  }
+
+  payload.push(...normalizedMessages)
+
+  try {
+    const stream = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      stream: true,
+      temperature: 0.2,
+      messages: payload,
+    })
+
+    const encoder = new TextEncoder()
+    const readable = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const chunk of stream) {
+            const text = chunk.choices?.[0]?.delta?.content
+            if (text) {
+              controller.enqueue(encoder.encode(text))
+            }
+          }
+        } catch (error) {
+          console.error('Rosie stream error', error)
+          controller.enqueue(encoder.encode('\n[Rosie experienced an issue while streaming the response.]'))
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+    return new NextResponse(readable, {
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  } catch (error) {
+    console.error('Rosie completion error', error)
+    return streamText('Rosie could not reach the reasoning service. Please retry in a moment.')
+  }
+}
+
+function detectIntent(query: string): IntentDetection {
+  if (!query) {
+    return { intent: 'general' }
+  }
+
+  const text = query.toLowerCase()
+  const matchedClient = matchClient(text)
+  const matchedProject = matchProject(text, matchedClient?.id)
+
+  if (/email|send|draft|outreach|update/.test(text)) {
+    return { intent: 'email_draft', clientId: matchedClient?.id }
+  }
+
+  if (/pipeline|forecast|revenue movement|coverage|risk/.test(text)) {
+    return { intent: 'pipeline_summary' }
+  }
+
+  if (/news|headlines|industry|market|intel/.test(text)) {
+    return { intent: 'news_search', clientId: matchedClient?.id }
+  }
+
+  if (matchedProject && /project|phase|milestone|architecture|implementation|where are we/.test(text)) {
+    return { intent: 'project_status', clientId: matchedClient?.id, projectId: matchedProject.id }
+  }
+
+  if (matchedClient && /status|latest|note|summary|update|health|how are we/.test(text)) {
+    return { intent: 'client_status', clientId: matchedClient.id }
+  }
+
+  return matchedClient
+    ? { intent: 'client_status', clientId: matchedClient.id }
+    : { intent: 'general' }
+}
+
+function matchClient(text: string) {
+  if (!text) return null
+  const clients = listClients()
+  return (
+    clients.find((client) => {
+      const name = client.name.toLowerCase()
+      const shortName = name.replace(/(inc|corp|corporation|llc|industries)/g, '').trim()
+      const aliases = [name, client.id.toLowerCase(), shortName, client.owner?.toLowerCase()].filter(Boolean) as string[]
+      return aliases.some((alias) => alias && alias.length > 1 && text.includes(alias))
+    }) ?? null
+  )
+}
+
+function matchProject(text: string, clientId?: string) {
+  if (!text) return null
+  const projects = listProjects()
+  return (
+    projects.find((project) => {
+      if (clientId && project.clientId !== clientId) {
+        return false
+      }
+      const name = project.name.toLowerCase()
+      const phase = project.phase?.toLowerCase()
+      return text.includes(name) || (phase && text.includes(phase))
+    }) ?? null
+  )
+}
+
+function buildIntentPrompt(detection: IntentDetection) {
+  const base = [`Detected intent: ${detection.intent}`]
+  if (detection.clientId) {
+    base.push(`Client target: ${detection.clientId}`)
+  }
+  if (detection.projectId) {
+    base.push(`Project target: ${detection.projectId}`)
+  }
+  base.push(
+    'When intent is email_draft, return a subject line and a short actionable body the operator can copy-paste. When intent is pipeline_summary or news_search, highlight the top 2-3 signals with numbers.',
+  )
+  return base.join('\n')
+}
+
+function buildContext(detection: IntentDetection) {
+  switch (detection.intent) {
+    case 'client_status':
+    case 'email_draft':
+      return detection.clientId ? buildClientContext(detection.clientId) : ''
+    case 'project_status':
+      return buildProjectContext(detection.projectId, detection.clientId)
+    case 'pipeline_summary':
+      return buildPipelineContext()
+    case 'news_search':
+      return buildNewsContext(detection.clientId)
+    default:
+      return buildGeneralContext()
+  }
+}
+
+function buildClientContext(clientId?: string) {
+  if (!clientId) return ''
+  const client = getClient(clientId)
+  if (!client) return ''
+
+  const projects = getProjectsByClient(client.id)
+  const opportunities = client.opportunities?.map((opp) => `${opp.name} (${formatCurrency(opp.amount)} • ${opp.stage}${opp.probability ? ` • win ${Math.round(opp.probability * 100)}%` : ''}${opp.nextStep ? ` • next: ${opp.nextStep} on ${opp.nextStepDate ?? 'TBD'}` : ''})`) ?? []
+  const dataStatus = client.data?.map((source) => `${source.name} (${source.category}) → ${source.status}`) ?? []
+  const contacts = client.contacts?.map((person) => `${person.name} – ${person.role}${person.power ? ` (${person.power})` : ''}`) ?? []
+  const kanban = client.kanban?.map((card) => `${card.title} [${card.status}${card.owner ? ` • ${card.owner}` : ''}]`) ?? []
+
+  return [
+    `Client overview: ${client.name} (${client.phase} phase • owner ${client.owner})`,
+    `Segment ${client.segment} • ARR ${formatCurrency(client.arr ?? 0)} • Industry ${client.industry} • Region ${client.region}`,
+    `Health ${client.health ?? 0}/100 • Churn risk ${client.churnRisk ?? 0}% • QBR ${client.qbrDate ?? 'TBD'} • Expansion ${client.isExpansion ? 'yes' : 'no'}`,
+    client.notes ? `Latest note: ${client.notes}` : '',
+    opportunities.length ? `Opportunities: ${opportunities.join('; ')}` : '',
+    contacts.length ? `Buying group: ${contacts.join('; ')}` : '',
+    dataStatus.length ? `Data sources: ${dataStatus.join('; ')}` : '',
+    projects.length
+      ? `Active projects: ${projects
+          .map((project) => `${project.name} (${project.phase} • ${project.progress}% • health ${project.health})`)
+          .join('; ')}`
+      : '',
+    kanban.length ? `Execution board: ${kanban.join('; ')}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function buildProjectContext(projectId?: string, clientId?: string) {
+  if (!projectId && !clientId) return ''
+  const projects = projectId
+    ? listProjects().filter((project) => project.id === projectId)
+    : getProjectsByClient(clientId ?? '')
+  if (!projects.length) return ''
+
+  return projects
+    .map((project) => {
+      const deliverables = project.deliverables?.join(', ')
+      return [
+        `Project ${project.name} for ${project.clientName}:`,
+        `Phase ${project.phase} • Status ${project.status} • Health ${project.health} • Progress ${project.progress}%`,
+        `Owner ${project.owner} • Start ${project.startDate} • Due ${project.dueDate}`,
+        deliverables ? `Key deliverables: ${deliverables}` : '',
+        project.notes ? `Notes: ${project.notes}` : '',
+        `Budget ${formatCurrency(project.budget ?? 0)} • Spent ${formatCurrency(project.spent ?? 0)}`,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    })
+    .join('\n\n')
+}
+
+function buildPipelineContext() {
+  const dashboard = getDashboard()
+  const ribbon = dashboard.ribbon
+  const pricing = dashboard.pricing
+  const alerts = dashboard.alerts?.slice(0, 3) ?? []
+
+  return [
+    `Pipeline coverage ${dashboard.sales.pipelineCoverageX}x • Win rate 7d ${dashboard.sales.winRate7dPct}% • Cycle time median ${dashboard.sales.cycleTimeDaysMedian} days`,
+    `Forecast horizon ${dashboard.forecast.horizonWeeks} weeks • Risk index ${ribbon.riskIndexPct}% • TRS score ${ribbon.trsScore}%`,
+    `Cash on hand ${formatCurrency(ribbon.cashOnHand)} • Runway ${ribbon.runwayDays} days • AR total ${formatCurrency(dashboard.finance.arTotal)}`,
+    pricing?.guardrailBreaches?.length
+      ? `Pricing guardrail breaches: ${pricing.guardrailBreaches
+          .map((breach) => `${breach.account} at ${breach.discountPct}% by ${breach.owner}`)
+          .join('; ')}`
+      : '',
+    alerts.length
+      ? `Alerts: ${alerts
+          .map((alert) => `${alert.kind} (${alert.severity}) – ${alert.message}`)
+          .join('; ')}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function buildNewsContext(clientId?: string) {
+  const state = getMediaState()
+  const client = clientId ? getClient(clientId) : null
+  const ideas = state.ideas.slice(0, 3).map((idea) => `${idea.title} for ${idea.persona} (${idea.stage} stage • impact ${idea.expectedImpact})`)
+  const projects = state.projects
+    .slice(0, 2)
+    .map((project) => `Project ${project.id} status ${project.status}${project.artifacts?.podcastUrl ? ` • podcast ${project.artifacts.podcastUrl}` : ''}`)
+  const distributions = state.distributions.slice(0, 2).map((entry) => `${entry.channel} published ${entry.publishedAt}`)
+
+  return [
+    client ? `Focus client: ${client.name} (${client.industry})` : '',
+    ideas.length ? `Media ideas: ${ideas.join('; ')}` : '',
+    projects.length ? `Media projects: ${projects.join('; ')}` : '',
+    distributions.length ? `Recent distribution: ${distributions.join('; ')}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function buildGeneralContext() {
+  const clients = listClients()
+  const summary = clients
+    .map((client) => `${client.name} • Phase ${client.phase} • Health ${client.health} • ARR ${formatCurrency(client.arr ?? 0)}`)
+    .join('; ')
+  return `Active clients snapshot: ${summary}`
+}
+
+function buildOfflineResponse(detection: IntentDetection, context: string) {
+  const intro = 'Rosie is currently offline, so here is a direct context pull from RevenueOS:'
+  const focus = detection.clientId ? `\nFocus client: ${getClient(detection.clientId)?.name ?? detection.clientId}` : ''
+  return `${intro}${focus}${context ? `\n\n${context}` : ''}`
+}
+
+function streamText(text: string) {
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text))
+      controller.close()
+    },
+  })
+  return new NextResponse(readable, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}
+
+function formatCurrency(value: number | undefined) {
+  const amount = typeof value === 'number' ? value : 0
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import AppShell from '@/components/layout/AppShell'
+import Rosie from '@/components/assistant/Rosie'
 
 export const metadata: Metadata = {
   title: 'TRS RevenueOS',
@@ -15,6 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Suspense fallback={<div className="min-h-screen bg-white" />}>
           <AppShell>{children}</AppShell>
         </Suspense>
+        <Rosie />
       </body>
     </html>
   )

--- a/components/assistant/Rosie.tsx
+++ b/components/assistant/Rosie.tsx
@@ -1,0 +1,315 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Bot, Loader2, MessageCircle, Send, Sparkles, X } from 'lucide-react'
+
+export type RosieRole = 'user' | 'assistant'
+
+export interface RosieMessage {
+  id: string
+  role: RosieRole
+  content: string
+  createdAt: number
+}
+
+const STORAGE_KEY = 'trs-rosie-thread-v1'
+
+const quickPrompts: { title: string; description: string; prompt: string }[] = [
+  {
+    title: 'Client pulse',
+    description: 'Check the latest context for ACME',
+    prompt: "What's the latest on Acme?",
+  },
+  {
+    title: 'Operator mode',
+    description: 'Draft an update email for Helio',
+    prompt: 'Generate a quick status email for Helio Systems.',
+  },
+  {
+    title: 'Pipeline risk',
+    description: 'Surface revenue risk this week',
+    prompt: "Summarize pipeline risk this week and call out any guardrails we broke.",
+  },
+  {
+    title: 'Industry intel',
+    description: 'Scan the financial aid market',
+    prompt: "Any news in the financial-aid space that could impact our clients?",
+  },
+]
+
+function createMessage(role: RosieRole, content: string): RosieMessage {
+  const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${role}-${Date.now()}`
+  return { id, role, content, createdAt: Date.now() }
+}
+
+export default function Rosie() {
+  const [open, setOpen] = useState(false)
+  const [messages, setMessages] = useState<RosieMessage[]>([])
+  const [input, setInput] = useState('')
+  const [isStreaming, setIsStreaming] = useState(false)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
+      const stored = JSON.parse(raw) as RosieMessage[]
+      if (Array.isArray(stored) && stored.length) {
+        setMessages(stored)
+      }
+    } catch (error) {
+      console.warn('Rosie: unable to load session', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const payload = JSON.stringify(messages)
+      window.localStorage.setItem(STORAGE_KEY, payload)
+    } catch (error) {
+      console.warn('Rosie: unable to persist session', error)
+    }
+  }, [messages])
+
+  useEffect(() => {
+    if (!open) return
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, open])
+
+  const handleToggle = useCallback(() => {
+    setOpen((state) => {
+      if (state) {
+        abortRef.current?.abort()
+        abortRef.current = null
+        setIsStreaming(false)
+      }
+      return !state
+    })
+  }, [])
+
+  const sendMessage = useCallback(
+    async (message: string) => {
+      if (!message.trim() || isStreaming) return
+      const trimmed = message.trim()
+      const userMessage = createMessage('user', trimmed)
+      setMessages((prev) => [...prev, userMessage])
+      setInput('')
+
+      const controller = new AbortController()
+      abortRef.current = controller
+      setIsStreaming(true)
+
+      try {
+        const response = await fetch('/api/rosie', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: [...messages, userMessage] }),
+          signal: controller.signal,
+        })
+
+        if (!response.ok || !response.body) {
+          throw new Error('Rosie is unavailable right now.')
+        }
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let done = false
+
+        setMessages((prev) => [...prev, createMessage('assistant', '')])
+
+        while (!done) {
+          const { value, done: streamDone } = await reader.read()
+          done = streamDone
+          const chunk = value ? decoder.decode(value, { stream: !done }) : ''
+          if (chunk) {
+            buffer += chunk
+            setMessages((prev) => {
+              if (!prev.length) return prev
+              const next = [...prev]
+              const last = next[next.length - 1]
+              if (last.role === 'assistant') {
+                next[next.length - 1] = { ...last, content: buffer }
+              }
+              return next
+            })
+          }
+        }
+      } catch (error) {
+        console.error('Rosie send error', error)
+        setMessages((prev) => {
+          const next = [...prev]
+          const last = next[next.length - 1]
+          if (last?.role === 'assistant' && !last.content) {
+            next.pop()
+          }
+          next.push(
+            createMessage(
+              'assistant',
+              'I hit a snag reaching the reasoning service. Give it another shot in a moment.',
+            ),
+          )
+          return next
+        })
+      } finally {
+        setIsStreaming(false)
+        abortRef.current = null
+      }
+    },
+    [isStreaming, messages],
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault()
+      await sendMessage(input)
+    },
+    [input, sendMessage],
+  )
+
+  const handlePromptClick = useCallback(
+    (prompt: string) => {
+      setInput(prompt)
+      setTimeout(() => {
+        void sendMessage(prompt)
+      }, 0)
+    },
+    [sendMessage],
+  )
+
+  const hasMessages = messages.length > 0
+  const statusLabel = useMemo(() => (isStreaming ? 'Thinking' : 'Ready'), [isStreaming])
+
+  return (
+    <>
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 shadow-lg transition hover:shadow-xl"
+          aria-label="Open Rosie assistant"
+        >
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-white">
+            <Bot size={16} />
+          </span>
+          Rosie
+          <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+        </button>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex justify-end">
+          <div className="absolute inset-0 bg-black/40" aria-hidden onClick={handleToggle} />
+          <section
+            className="relative z-50 flex h-full w-full flex-col bg-white shadow-2xl transition sm:max-w-md"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Rosie assistant"
+          >
+            <header className="flex h-16 items-center justify-between border-b border-gray-100 px-5">
+              <div className="flex items-center gap-2">
+                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-gray-900 text-white">
+                  <Bot size={18} />
+                </span>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Rosie — TRS Operator</p>
+                  <p className="text-xs text-gray-500">{statusLabel}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={handleToggle}
+                className="rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
+                aria-label="Close Rosie"
+              >
+                <X size={16} />
+              </button>
+            </header>
+
+            <main className="flex-1 overflow-y-auto px-5 py-4">
+              {!hasMessages && (
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Sparkles size={16} className="text-emerald-500" />
+                    Rosie is wired into RevenueOS data and actions. Try one of these to get started.
+                  </div>
+                  <div className="grid grid-cols-1 gap-3">
+                    {quickPrompts.map((item) => (
+                      <button
+                        key={item.prompt}
+                        type="button"
+                        onClick={() => handlePromptClick(item.prompt)}
+                        className="rounded-xl border border-gray-200 p-4 text-left transition hover:border-gray-300 hover:bg-gray-50"
+                      >
+                        <p className="text-sm font-semibold text-gray-900">{item.title}</p>
+                        <p className="mt-1 text-xs text-gray-500">{item.description}</p>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {hasMessages && (
+                <div className="space-y-4 text-sm text-gray-800">
+                  {messages.map((message) => (
+                    <div key={message.id} className="flex flex-col gap-1">
+                      <div className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                        <div
+                          className={`max-w-[80%] rounded-2xl px-4 py-3 ${
+                            message.role === 'user' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-900'
+                          }`}
+                        >
+                          {message.content}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                  <div ref={bottomRef} />
+                </div>
+              )}
+            </main>
+
+            <footer className="border-t border-gray-100 px-5 py-4">
+              <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex-1">
+                    <textarea
+                      value={input}
+                      onChange={(event) => setInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' && !event.shiftKey) {
+                          event.preventDefault()
+                          void sendMessage(input)
+                        }
+                      }}
+                      placeholder="Ask Rosie to retrieve context, draft an email, or run an analysis..."
+                      className="h-20 w-full resize-none rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none focus:border-gray-400 focus:ring-0"
+                      disabled={isStreaming}
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={isStreaming || !input.trim()}
+                    className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-white transition disabled:opacity-40"
+                    aria-label="Send message"
+                  >
+                    {isStreaming ? <Loader2 size={16} className="animate-spin" /> : <Send size={16} />}
+                  </button>
+                </div>
+                <div className="flex items-center justify-between text-xs text-gray-400">
+                  <div className="flex items-center gap-1">
+                    <MessageCircle size={12} />
+                    Rosie can action intents like search, summarize, or compose. She will confirm before executing changes.
+                  </div>
+                  <span>Shift + Enter for newline</span>
+                </div>
+              </form>
+            </footer>
+          </section>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add a persistent Rosie assistant UI with streaming responses, quick prompts, and session storage
- introduce an intent-aware /api/rosie endpoint that hydrates responses with client, project, and revenue context
- mount Rosie across the application layout so the operator is available on every page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e844bb8ac0832494bb6efb61f9b798