### PR TITLE
fix: add openai dependency for rosie api route

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "node": ">=20.11.1 <=22.x"
   },
   "dependencies": {
-    "next": "14.2.6",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "lucide-react": "0.460.0",
     "@radix-ui/react-avatar": "1.0.4",
     "@radix-ui/react-slot": "1.2.3",
-    "class-variance-authority": "0.7.0"
+    "class-variance-authority": "0.7.0",
+    "lucide-react": "0.460.0",
+    "next": "14.2.6",
+    "openai": "^6.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@types/node": "20.14.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       next:
         specifier: 14.2.6
         version: 14.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      openai:
+        specifier: ^6.2.0
+        version: 6.2.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1394,6 +1397,18 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openai@6.2.0:
+    resolution: {integrity: sha512-qqjzHls7F5xkXNGy9P1Ei1rorI5LWupUUFWP66zPU8FlZbiITX8SFcHMKNZg/NATJ0LpIZcMUFxSwQmdeQPwSw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3342,6 +3357,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openai@6.2.0: {}
 
   optionator@0.9.4:
     dependencies:


### PR DESCRIPTION
## Summary
- add the official OpenAI SDK as a runtime dependency for the Rosie API route
- type the Rosie payload using OpenAI message params to satisfy Next.js type checks

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e849f17e6c8324b99f85ce785f7982