### PR TITLE
Align resources, mail, and settings pages with pipeline layout

### DIFF
--- a/app/mail-calendar/page.tsx
+++ b/app/mail-calendar/page.tsx
@@ -1,106 +1,159 @@
-import { Badge } from '@/ui/badge'
-import { Button } from '@/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
-import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+"use client"
+
+import { useMemo } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+import { Badge } from "@/ui/badge"
+import { Button } from "@/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
+import { PageDescription, PageTitle } from "@/ui/page-header"
+import { TRS_CARD, TRS_SECTION_TITLE } from "@/lib/style"
+import { resolveTabs } from "@/lib/tabs"
 
 const inboxThreads = [
   {
-    id: 't1',
-    sender: 'RevenueOps Alerts',
-    subject: 'Daily pipeline sync & risk summary',
-    preview: 'Highlights from RevOps: 3 deals need follow up, 1 flagged for pricing exception.',
-    receivedAt: '9:24 AM',
-    tags: ['Priority', 'Automation'],
+    id: "t1",
+    sender: "RevenueOps Alerts",
+    subject: "Daily pipeline sync & risk summary",
+    preview: "Highlights from RevOps: 3 deals need follow up, 1 flagged for pricing exception.",
+    receivedAt: "9:24 AM",
+    tags: ["Priority", "Automation"],
   },
   {
-    id: 't2',
-    sender: 'Gmail – Marketing',
-    subject: 'Launch checklist for Q4 nurture sequence',
-    preview: 'Creative brief approved. Final assets due Friday before we handoff to sequencing.',
-    receivedAt: '8:10 AM',
-    tags: ['Campaign', 'Content'],
+    id: "t2",
+    sender: "Gmail – Marketing",
+    subject: "Launch checklist for Q4 nurture sequence",
+    preview: "Creative brief approved. Final assets due Friday before we handoff to sequencing.",
+    receivedAt: "8:10 AM",
+    tags: ["Campaign", "Content"],
   },
   {
-    id: 't3',
-    sender: 'HostGator Support',
-    subject: 'DNS verification for calendar routing',
-    preview: 'TXT records validated. You can finalize calendar availability sync across providers.',
-    receivedAt: 'Yesterday',
-    tags: ['Integration'],
+    id: "t3",
+    sender: "HostGator Support",
+    subject: "DNS verification for calendar routing",
+    preview: "TXT records validated. You can finalize calendar availability sync across providers.",
+    receivedAt: "Yesterday",
+    tags: ["Integration"],
   },
 ]
 
 const calendarEvents = [
   {
-    id: 'e1',
-    title: 'Customer QBR – Northwind',
-    time: '10:30 – 11:15 AM',
-    participants: ['Alex', 'Priya', 'Northwind CS'],
-    type: 'External',
+    id: "e1",
+    title: "Customer QBR – Northwind",
+    time: "10:30 – 11:15 AM",
+    participants: ["Alex", "Priya", "Northwind CS"],
+    type: "External",
   },
   {
-    id: 'e2',
-    title: 'Pricing desk office hours',
-    time: '12:00 – 12:30 PM',
-    participants: ['GTM Ops'],
-    type: 'Internal',
+    id: "e2",
+    title: "Pricing desk office hours",
+    time: "12:00 – 12:30 PM",
+    participants: ["GTM Ops"],
+    type: "Internal",
   },
   {
-    id: 'e3',
-    title: 'Marketing <> Sales sync',
-    time: '2:00 – 2:45 PM',
-    participants: ['Demand Gen', 'Sales Leads'],
-    type: 'Collaboration',
+    id: "e3",
+    title: "Marketing <> Sales sync",
+    time: "2:00 – 2:45 PM",
+    participants: ["Demand Gen", "Sales Leads"],
+    type: "Collaboration",
   },
 ]
 
 const integrationStatus = [
-  { id: 'i1', name: 'Gmail API', description: 'Primary inbox connection for GTM leadership.', status: 'Connected' },
-  { id: 'i2', name: 'Google Calendar', description: 'Two-way sync with focus blocks and QBRs.', status: 'Connected' },
-  { id: 'i3', name: 'HostGator Mailboxes', description: 'Routing shared support and partner mailboxes.', status: 'Syncing' },
-  { id: 'i4', name: 'Zoom', description: 'Auto-attach meeting recordings to thread history.', status: 'Planned' },
+  { id: "i1", name: "Gmail API", description: "Primary inbox connection for GTM leadership.", status: "Connected" },
+  { id: "i2", name: "Google Calendar", description: "Two-way sync with focus blocks and QBRs.", status: "Connected" },
+  { id: "i3", name: "HostGator Mailboxes", description: "Routing shared support and partner mailboxes.", status: "Syncing" },
+  { id: "i4", name: "Zoom", description: "Auto-attach meeting recordings to thread history.", status: "Planned" },
+]
+
+const schedulerInsights = [
+  "Auto-send recap docs 15 minutes after meetings with transcripts and highlights.",
+  "Detect conflicts between focus blocks and external invites to suggest alternates.",
+  "Create shared agendas with AI-suggested objectives for pipeline and renewal calls.",
+]
+
+const roadmapItems = [
+  {
+    id: "r1",
+    title: "Outlook + Microsoft 365",
+    description: "Extend parity for enterprise clients running Microsoft stacks.",
+    eta: "Q1 FY26",
+  },
+  {
+    id: "r2",
+    title: "Slack highlights",
+    description: "Push high-signal email summaries into deal rooms and CS channels.",
+    eta: "In discovery",
+  },
+  {
+    id: "r3",
+    title: "Dialer intelligence",
+    description: "Attach call notes and Gong snippets to relevant threads automatically.",
+    eta: "Pilot customers",
+  },
+  {
+    id: "r4",
+    title: "Calendar analytics pack",
+    description: "Report on context switching, meeting load, and focus-time leakage.",
+    eta: "Design sprint",
+  },
+]
+
+const availabilityMetrics = [
+  { label: "Focus hours protected", value: "18 hrs", trend: "↑ 3 hrs WoW" },
+  { label: "QBR windows available", value: "6 slots", trend: "Next 14 days" },
+  { label: "Travel days detected", value: "2 leaders", trend: "Auto-blocked on calendar" },
 ]
 
 export default function MailCalendarPage() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const activeTab = useMemo(() => {
+    const current = searchParams.get("tab")
+    return current && tabs.includes(current) ? current : tabs[0]
+  }, [searchParams, tabs])
+
   return (
-    <div className="space-y-6 p-6">
-      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
-        <PageTitle>Mail &amp; Calendar</PageTitle>
-        <PageDescription>
-          Centralize email, calendar availability, and meeting intelligence so GTM teams never miss a follow-up.
-        </PageDescription>
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge variant="success">Realtime sync</Badge>
-          <Badge variant="outline">Gmail &amp; Google Calendar ready</Badge>
-          <Badge variant="default">HostGator routing supported</Badge>
-        </div>
-      </PageHeader>
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
+      <Card className={TRS_CARD}>
+        <CardContent className="space-y-4 p-4">
+          <div className="space-y-1">
+            <PageTitle className="text-lg font-semibold text-black">Mail &amp; Calendar</PageTitle>
+            <PageDescription className="text-sm text-gray-500">
+              Centralize email, calendar availability, and meeting intelligence so GTM teams never miss a follow-up.
+            </PageDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600 md:text-sm">
+            <Badge variant="success">Realtime sync</Badge>
+            <Badge variant="outline">Gmail &amp; Google Calendar ready</Badge>
+            <Badge variant="default">HostGator routing supported</Badge>
+          </div>
+        </CardContent>
+      </Card>
 
-      <Tabs defaultValue="inbox">
-        <TabsList>
-          <TabsTrigger value="inbox">Email Inbox</TabsTrigger>
-          <TabsTrigger value="calendar">Calendar</TabsTrigger>
-          <TabsTrigger value="integrations">Integrations</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="inbox" className="space-y-4 border-none p-0">
-          <Card>
-              <CardHeader>
-                <CardTitle>Today’s priorities</CardTitle>
-              <CardDescription>Threads surfaced from automation rules, sentiment analysis, and revenue triggers.</CardDescription>
+      {activeTab === "Inbox" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-black">Today’s priorities</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Threads surfaced from automation rules, sentiment analysis, and revenue triggers.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {inboxThreads.map((thread) => (
-                <div key={thread.id} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4">
+                <div key={thread.id} className="rounded-lg border border-gray-200 bg-gray-50 p-4">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
-                      <p className="text-sm font-medium text-[color:var(--color-text)]">{thread.subject}</p>
-                      <p className="text-xs text-[color:var(--color-text-muted)]">{thread.sender}</p>
+                      <p className="text-sm font-semibold text-black">{thread.subject}</p>
+                      <p className="text-xs text-gray-500">{thread.sender}</p>
                     </div>
-                    <span className="text-xs text-[color:var(--color-text-muted)]">{thread.receivedAt}</span>
+                    <span className="text-xs text-gray-500">{thread.receivedAt}</span>
                   </div>
-                  <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{thread.preview}</p>
+                  <p className="mt-2 text-sm text-gray-600">{thread.preview}</p>
                   <div className="mt-3 flex flex-wrap items-center gap-2">
                     {thread.tags.map((tag) => (
                       <Badge key={tag} variant="outline">
@@ -113,72 +166,81 @@ export default function MailCalendarPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Automation playbooks</CardTitle>
-              <CardDescription>Suggested automations to keep inbox triage tight across GTM teams.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Automation playbooks</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Suggested automations to keep inbox triage tight across GTM teams.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {[
                 {
-                  id: 'a1',
-                  title: 'Follow-up nudges',
-                  description: 'Auto-remind owners on stalled threads after 24 hours with no reply.',
-                  impact: 'Protect SLAs',
+                  id: "a1",
+                  title: "Follow-up nudges",
+                  description: "Auto-remind owners on stalled threads after 24 hours with no reply.",
+                  impact: "Protect SLAs",
                 },
                 {
-                  id: 'a2',
-                  title: 'Deal room bundling',
-                  description: 'Attach latest forecast, pricing sheet, and mutual action plan to opportunity emails.',
-                  impact: 'Faster cycles',
+                  id: "a2",
+                  title: "Deal room bundling",
+                  description: "Attach latest forecast, pricing sheet, and mutual action plan to opportunity emails.",
+                  impact: "Faster cycles",
                 },
                 {
-                  id: 'a3',
-                  title: 'Calendar insights in inbox',
-                  description: 'Embed available focus blocks or QBR windows directly into reply suggestions.',
-                  impact: 'Eliminate back-and-forth',
+                  id: "a3",
+                  title: "Calendar insights in inbox",
+                  description: "Embed available focus blocks or QBR windows directly into reply suggestions.",
+                  impact: "Eliminate back-and-forth",
                 },
                 {
-                  id: 'a4',
-                  title: 'Sentiment routing',
-                  description: 'Escalate negative sentiment threads to leadership with context and suggested replies.',
-                  impact: 'Save renewals',
+                  id: "a4",
+                  title: "Sentiment routing",
+                  description: "Escalate negative sentiment threads to leadership with context and suggested replies.",
+                  impact: "Save renewals",
                 },
               ].map((play) => (
-                <div key={play.id} className="flex flex-col rounded-lg border border-[color:var(--color-outline)] p-4">
-                  <div className="flex items-start justify-between">
+                <div key={play.id} className="flex flex-col rounded-lg border border-gray-200 p-4">
+                  <div className="flex items-start justify-between gap-3">
                     <div>
-                      <p className="text-sm font-semibold text-[color:var(--color-text)]">{play.title}</p>
-                      <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{play.description}</p>
+                      <p className="text-sm font-semibold text-black">{play.title}</p>
+                      <p className="mt-1 text-sm text-gray-600">{play.description}</p>
                     </div>
                     <Badge variant="success">{play.impact}</Badge>
                   </div>
-                  <Button variant="outline" className="mt-4 self-start">
+                  <Button variant="outline" className="mt-4 self-start text-sm">
                     Configure
                   </Button>
                 </div>
               ))}
             </CardContent>
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="calendar" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Calendar" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Upcoming schedule</CardTitle>
-              <CardDescription>Key meetings synchronized from Google Calendar and focus block priorities.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Upcoming schedule</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Key meetings synchronized from Google Calendar and focus block priorities.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {calendarEvents.map((event) => (
-                <div key={event.id} className="flex flex-col gap-2 rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4 md:flex-row md:items-center md:justify-between">
+                <div
+                  key={event.id}
+                  className="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 md:flex-row md:items-center md:justify-between"
+                >
                   <div>
-                    <p className="text-sm font-medium text-[color:var(--color-text)]">{event.title}</p>
-                    <p className="text-xs text-[color:var(--color-text-muted)]">{event.participants.join(', ')}</p>
+                    <p className="text-sm font-semibold text-black">{event.title}</p>
+                    <p className="text-xs text-gray-500">{event.participants.join(", ")}</p>
                   </div>
-                  <div className="flex flex-wrap items-center gap-3 text-sm">
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
                     <Badge variant="outline">{event.type}</Badge>
-                    <span className="text-[color:var(--color-text-muted)]">{event.time}</span>
-                    <Button variant="outline" size="sm">
+                    <span>{event.time}</span>
+                    <Button variant="outline" size="sm" className="text-xs">
                       Open details
                     </Button>
                   </div>
@@ -188,66 +250,73 @@ export default function MailCalendarPage() {
           </Card>
 
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <Card>
+            <Card className={TRS_CARD}>
               <CardHeader>
-                <CardTitle>Availability intelligence</CardTitle>
-                <CardDescription>Surface shared free blocks, travel windows, and focus hours per leader.</CardDescription>
+                <CardTitle className="text-lg font-semibold text-black">Availability intelligence</CardTitle>
+                <CardDescription className="text-sm text-gray-500">
+                  Surface shared free blocks, travel windows, and focus hours per leader.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {[
-                  { label: 'Focus hours protected', value: '18 hrs', trend: '↑ 3 hrs WoW' },
-                  { label: 'QBR windows available', value: '6 slots', trend: 'Next 14 days' },
-                  { label: 'Travel days detected', value: '2 leaders', trend: 'Auto-blocked on calendar' },
-                ].map((metric) => (
-                  <div key={metric.label} className="rounded-lg border border-dashed border-[color:var(--color-outline)] p-3">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="font-medium text-[color:var(--color-text)]">{metric.label}</span>
-                      <span className="text-[color:var(--color-text-muted)]">{metric.trend}</span>
+                {availabilityMetrics.map((metric) => (
+                  <div key={metric.label} className="rounded-lg border border-dashed border-gray-200 p-3">
+                    <div className="flex items-center justify-between text-sm text-gray-600">
+                      <span className={TRS_SECTION_TITLE}>{metric.label}</span>
+                      <span>{metric.trend}</span>
                     </div>
-                    <p className="mt-1 text-lg font-semibold text-[color:var(--color-text)]">{metric.value}</p>
+                    <p className="mt-1 text-lg font-semibold text-black">{metric.value}</p>
                   </div>
                 ))}
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className={TRS_CARD}>
               <CardHeader>
-                <CardTitle>Scheduler automations</CardTitle>
-                <CardDescription>Recommended workflows to align invites, agenda prep, and follow-ups.</CardDescription>
+                <CardTitle className="text-lg font-semibold text-black">Scheduler automations</CardTitle>
+                <CardDescription className="text-sm text-gray-500">
+                  Recommended workflows to align invites, agenda prep, and follow-ups.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {[
-                  'Auto-send recap docs 15 minutes after meetings with transcripts and highlights.',
-                  'Detect conflicts between focus blocks and external invites to suggest alternates.',
-                  'Create shared agendas with AI-suggested objectives for pipeline and renewal calls.',
-                ].map((insight, index) => (
-                  <div key={index} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/40 p-3 text-sm text-[color:var(--color-text)]">
+                {schedulerInsights.map((insight) => (
+                  <div key={insight} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
                     {insight}
                   </div>
                 ))}
               </CardContent>
             </Card>
           </div>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="integrations" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Integrations" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Integration status</CardTitle>
-              <CardDescription>Connection health across email, calendar, conferencing, and workspace tools.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Integration status</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Connection health across email, calendar, conferencing, and workspace tools.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               {integrationStatus.map((integration) => (
-                <div key={integration.id} className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-outline)] p-4 md:flex-row md:items-center md:justify-between">
+                <div
+                  key={integration.id}
+                  className="flex flex-col gap-3 rounded-lg border border-gray-200 p-4 md:flex-row md:items-center md:justify-between"
+                >
                   <div>
-                    <p className="text-sm font-medium text-[color:var(--color-text)]">{integration.name}</p>
-                    <p className="text-xs text-[color:var(--color-text-muted)]">{integration.description}</p>
+                    <p className="text-sm font-semibold text-black">{integration.name}</p>
+                    <p className="text-xs text-gray-500">{integration.description}</p>
                   </div>
                   <div className="flex items-center gap-3">
-                    <Badge variant={integration.status === 'Connected' ? 'success' : integration.status === 'Syncing' ? 'warning' : 'outline'}>
+                    <Badge
+                      variant={
+                        integration.status === "Connected" ? "success" : integration.status === "Syncing" ? "warning" : "outline"
+                      }
+                    >
                       {integration.status}
                     </Badge>
-                    <Button variant="outline" size="sm">
+                    <Button variant="outline" size="sm" className="text-xs">
                       Manage
                     </Button>
                   </div>
@@ -256,50 +325,27 @@ export default function MailCalendarPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Next up</CardTitle>
-              <CardDescription>Planned integrations and roadmap items for unified comms.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Next up</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Planned integrations and roadmap items for unified comms.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {[
-                {
-                  id: 'r1',
-                  title: 'Outlook + Microsoft 365',
-                  description: 'Extend parity for enterprise clients running Microsoft stacks.',
-                  eta: 'Q1 FY26',
-                },
-                {
-                  id: 'r2',
-                  title: 'Slack highlights',
-                  description: 'Push high-signal email summaries into deal rooms and CS channels.',
-                  eta: 'In discovery',
-                },
-                {
-                  id: 'r3',
-                  title: 'Dialer intelligence',
-                  description: 'Attach call notes and Gong snippets to relevant threads automatically.',
-                  eta: 'Pilot customers',
-                },
-                {
-                  id: 'r4',
-                  title: 'Calendar analytics pack',
-                  description: 'Report on context switching, meeting load, and focus-time leakage.',
-                  eta: 'Design sprint',
-                },
-              ].map((item) => (
-                <div key={item.id} className="flex flex-col justify-between rounded-lg border border-[color:var(--color-outline)] p-4">
+              {roadmapItems.map((item) => (
+                <div key={item.id} className="flex flex-col justify-between rounded-lg border border-gray-200 p-4">
                   <div>
-                    <p className="text-sm font-semibold text-[color:var(--color-text)]">{item.title}</p>
-                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{item.description}</p>
+                    <p className="text-sm font-semibold text-black">{item.title}</p>
+                    <p className="mt-1 text-sm text-gray-600">{item.description}</p>
                   </div>
-                  <div className="mt-3 text-xs text-[color:var(--color-text-muted)]">ETA: {item.eta}</div>
+                  <div className="mt-3 text-xs text-gray-500">ETA: {item.eta}</div>
                 </div>
               ))}
             </CardContent>
           </Card>
-        </TabsContent>
-      </Tabs>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,87 +1,124 @@
-import { Badge } from '@/ui/badge'
-import { Button } from '@/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
-import { PageDescription, PageHeader, PageTitle } from '@/ui/page-header'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+"use client"
+
+import { useMemo } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+import { Badge } from "@/ui/badge"
+import { Button } from "@/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
+import { PageDescription, PageTitle } from "@/ui/page-header"
+import { TRS_CARD } from "@/lib/style"
+import { resolveTabs } from "@/lib/tabs"
 
 const pricingScenarios = [
-  { tier: 'Starter', list: 8500, floor: 7200, discountGuard: '15% max', packaging: 'Seats + usage' },
-  { tier: 'Growth', list: 18500, floor: 16000, discountGuard: '12% max', packaging: 'Seats + workflow pack' },
-  { tier: 'Enterprise', list: 42000, floor: 38000, discountGuard: '10% max', packaging: 'Seats + governance + support' },
+  { tier: "Starter", list: 8500, floor: 7200, discountGuard: "15% max", packaging: "Seats + usage" },
+  { tier: "Growth", list: 18500, floor: 16000, discountGuard: "12% max", packaging: "Seats + workflow pack" },
+  { tier: "Enterprise", list: 42000, floor: 38000, discountGuard: "10% max", packaging: "Seats + governance + support" },
 ]
 
 const revenueDrivers = [
-  { id: 'rd1', name: 'Net new ARR', amount: 185000, change: '+12% MoM' },
-  { id: 'rd2', name: 'Expansion ARR', amount: 95000, change: '+6% MoM' },
-  { id: 'rd3', name: 'Contraction ARR', amount: -45000, change: '-2% MoM' },
-  { id: 'rd4', name: 'Churn ARR', amount: -115000, change: '+1% MoM' },
+  { id: "rd1", name: "Net new ARR", amount: 185000, change: "+12% MoM" },
+  { id: "rd2", name: "Expansion ARR", amount: 95000, change: "+6% MoM" },
+  { id: "rd3", name: "Contraction ARR", amount: -45000, change: "-2% MoM" },
+  { id: "rd4", name: "Churn ARR", amount: -115000, change: "+1% MoM" },
 ]
 
 const profitMetrics = [
-  { id: 'pm1', name: 'Gross margin', value: '78%', benchmark: 'Top quartile SaaS' },
-  { id: 'pm2', name: 'Magic number', value: '1.3x', benchmark: 'Efficient growth' },
-  { id: 'pm3', name: 'CAC payback', value: '13.5 months', benchmark: 'Target < 15 months' },
-  { id: 'pm4', name: 'Rule of 40', value: '62', benchmark: 'Above target' },
+  { id: "pm1", name: "Gross margin", value: "78%", benchmark: "Top quartile SaaS" },
+  { id: "pm2", name: "Magic number", value: "1.3x", benchmark: "Efficient growth" },
+  { id: "pm3", name: "CAC payback", value: "13.5 months", benchmark: "Target < 15 months" },
+  { id: "pm4", name: "Rule of 40", value: "62", benchmark: "Above target" },
 ]
 
+const coverageMetrics = [
+  { label: "Total quota capacity", value: "$9.2M", detail: "12 AEs · 2.3x pipeline coverage" },
+  { label: "In-quarter commit", value: "$3.4M", detail: "65% probability weighted" },
+  { label: "Stretch scenario", value: "$4.1M", detail: "Requires 3 net-new logo wins" },
+]
+
+const cashFlowItems = [
+  "Headcount pacing vs plan",
+  "Vendor consolidation savings",
+  "Capital efficiency by cohort",
+]
+
+const marginIdeas = [
+  "Shift implementation to partners for enterprise tier",
+  "Launch usage alerts to prevent overage credits",
+  "Automate onboarding to reduce services cost",
+]
+
+const scenarioPacks = [
+  { title: "Base", summary: "Plan of record, current hiring, pipeline confidence." },
+  { title: "Upside", summary: "Requires 2 strategic wins + PLG conversion lift." },
+  { title: "Downside", summary: "Models churn risk, slip deals, and cost controls." },
+]
+
+const whatIfLevers = ["AE ramp time", "Enterprise discount rate", "Partner-sourced pipeline"]
+
 export default function ResourcesPage() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const activeTab = useMemo(() => {
+    const current = searchParams.get("tab")
+    return current && tabs.includes(current) ? current : tabs[0]
+  }, [searchParams, tabs])
+
   return (
-    <div className="space-y-6 p-6">
-      <PageHeader className="rounded-xl border border-[color:var(--color-outline)]">
-        <PageTitle>Resources &amp; Calculators</PageTitle>
-        <PageDescription>
-          Finance-ready calculators to pressure test pricing, revenue, profit, and board-ready scenarios in minutes.
-        </PageDescription>
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge variant="outline">Prebuilt GTM formulas</Badge>
-          <Badge variant="success">Live benchmarks</Badge>
-          <Badge variant="default">Downloadable templates</Badge>
-        </div>
-      </PageHeader>
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
+      <Card className={TRS_CARD}>
+        <CardContent className="space-y-4 p-4">
+          <div className="space-y-1">
+            <PageTitle className="text-lg font-semibold text-black">Resources &amp; Calculators</PageTitle>
+            <PageDescription className="text-sm text-gray-500">
+              Finance-ready calculators to pressure test pricing, revenue, profit, and board-ready scenarios in minutes.
+            </PageDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600 md:text-sm">
+            <Badge variant="outline">Prebuilt GTM formulas</Badge>
+            <Badge variant="success">Live benchmarks</Badge>
+            <Badge variant="default">Downloadable templates</Badge>
+          </div>
+        </CardContent>
+      </Card>
 
-      <Tabs defaultValue="pricing">
-        <TabsList className="flex flex-wrap">
-          <TabsTrigger value="pricing">Pricing</TabsTrigger>
-          <TabsTrigger value="revenue">Revenue</TabsTrigger>
-          <TabsTrigger value="financial">Financial Plan</TabsTrigger>
-          <TabsTrigger value="profit">Profitability</TabsTrigger>
-          <TabsTrigger value="scenarios">Board Scenarios</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="pricing" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Pricing" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Guardrail calculator</CardTitle>
-              <CardDescription>Set floor prices, packaging guardrails, and instant impact to ARR and margin.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Guardrail calculator</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Set floor prices, packaging guardrails, and instant impact to ARR and margin.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-4">
-                <p className="text-sm text-[color:var(--color-text)]">
-                  Adjust list price and discount allowances to visualize net ARR impact. Export recommendations for sales playbooks in one click.
-                </p>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+                Adjust list price and discount allowances to visualize net ARR impact. Export recommendations for sales playbooks
+                in one click.
               </div>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 {pricingScenarios.map((scenario) => (
-                  <div key={scenario.tier} className="flex flex-col rounded-lg border border-[color:var(--color-outline)] p-4">
+                  <div key={scenario.tier} className="flex flex-col rounded-lg border border-gray-200 p-4">
                     <div className="flex items-center justify-between">
-                      <p className="text-sm font-semibold text-[color:var(--color-text)]">{scenario.tier}</p>
+                      <p className="text-sm font-semibold text-black">{scenario.tier}</p>
                       <Badge variant="outline">{scenario.packaging}</Badge>
                     </div>
-                    <dl className="mt-3 space-y-2 text-sm text-[color:var(--color-text)]">
-                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                    <dl className="mt-3 space-y-2 text-sm text-gray-700">
+                      <div className="flex items-center justify-between text-xs text-gray-500">
                         <dt>List price</dt>
                         <dd>${scenario.list.toLocaleString()}</dd>
                       </div>
-                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                      <div className="flex items-center justify-between text-xs text-gray-500">
                         <dt>Floor price</dt>
                         <dd>${scenario.floor.toLocaleString()}</dd>
                       </div>
-                      <div className="flex items-center justify-between text-xs text-[color:var(--color-text-muted)]">
+                      <div className="flex items-center justify-between text-xs text-gray-500">
                         <dt>Discount guardrail</dt>
                         <dd>{scenario.discountGuard}</dd>
                       </div>
                     </dl>
-                    <Button variant="outline" className="mt-4">
+                    <Button variant="outline" className="mt-4 self-start text-sm">
                       Export playbook
                     </Button>
                   </div>
@@ -90,167 +127,180 @@ export default function ResourcesPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Packaging experiments</CardTitle>
-              <CardDescription>Compare usage-based vs seat-based packaging to find the optimal blend.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Packaging experiments</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Compare usage-based vs seat-based packaging to find the optimal blend.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
-                <p className="text-sm font-medium text-[color:var(--color-text)]">Usage-first</p>
-                <p className="text-sm text-[color:var(--color-text-muted)]">
+              <div className="space-y-3 rounded-lg border border-gray-200 p-4">
+                <p className="text-sm font-medium text-black">Usage-first</p>
+                <p className="text-sm text-gray-600">
                   Meter core AI generation and automations. Seat add-ons unlock analytics and governance modules.
                 </p>
                 <Badge variant="success">Recommended</Badge>
               </div>
-              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
-                <p className="text-sm font-medium text-[color:var(--color-text)]">Seat-first</p>
-                <p className="text-sm text-[color:var(--color-text-muted)]">
+              <div className="space-y-3 rounded-lg border border-gray-200 p-4">
+                <p className="text-sm font-medium text-black">Seat-first</p>
+                <p className="text-sm text-gray-600">
                   Predictable ARR but lower margin. Layer usage overages when activation crosses 120% of plan.
                 </p>
                 <Badge variant="outline">In testing</Badge>
               </div>
             </CardContent>
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="revenue" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Revenue" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Revenue bridge</CardTitle>
-              <CardDescription>Understand what is driving ARR movement across segments and motions.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Revenue bridge</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Understand what is driving ARR movement across segments and motions.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 {revenueDrivers.map((driver) => (
-                  <div key={driver.id} className="rounded-lg border border-[color:var(--color-outline)] p-4">
-                    <p className="text-sm font-medium text-[color:var(--color-text)]">{driver.name}</p>
-                    <p className={`mt-2 text-2xl font-semibold ${
-                      driver.amount >= 0
-                        ? 'text-[color:var(--color-positive)]'
-                        : 'text-[color:var(--color-negative)]'
-                    }`}>
+                  <div key={driver.id} className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-sm font-medium text-black">{driver.name}</p>
+                    <p className={`mt-2 text-2xl font-semibold ${driver.amount >= 0 ? "text-emerald-600" : "text-rose-600"}`}>
                       ${Math.abs(driver.amount / 1000).toFixed(0)}K
                     </p>
-                    <p className="text-xs text-[color:var(--color-text-muted)]">{driver.change}</p>
+                    <p className="text-xs text-gray-500">{driver.change}</p>
                   </div>
                 ))}
               </div>
-              <div className="rounded-lg border border-dashed border-[color:var(--color-outline)] p-4 text-sm text-[color:var(--color-text)]">
-                Model net new pipeline coverage, expansion playbooks, and churn saves with scenario toggles. Export to RevOps dashboards instantly.
+              <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-700">
+                Model net new pipeline coverage, expansion playbooks, and churn saves with scenario toggles. Export to RevOps
+                dashboards instantly.
               </div>
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Coverage calculator</CardTitle>
-              <CardDescription>Blend quota capacity, attainment, and forecast confidence to project outcomes.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Coverage calculator</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Blend quota capacity, attainment, and forecast confidence to project outcomes.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              {[
-                { label: 'Total quota capacity', value: '$9.2M', detail: '12 AEs · 2.3x pipeline coverage' },
-                { label: 'In-quarter commit', value: '$3.4M', detail: '65% probability weighted' },
-                { label: 'Stretch scenario', value: '$4.1M', detail: 'Requires 3 net-new logo wins' },
-              ].map((metric) => (
-                <div key={metric.label} className="rounded-lg border border-[color:var(--color-outline)] p-4">
-                  <p className="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">{metric.label}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[color:var(--color-text)]">{metric.value}</p>
-                  <p className="mt-1 text-xs text-[color:var(--color-text-muted)]">{metric.detail}</p>
+              {coverageMetrics.map((metric) => (
+                <div key={metric.label} className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-gray-500">{metric.label}</p>
+                  <p className="mt-2 text-2xl font-semibold text-black">{metric.value}</p>
+                  <p className="mt-1 text-xs text-gray-500">{metric.detail}</p>
                 </div>
               ))}
             </CardContent>
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="financial" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Financial Plan" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Financial runway</CardTitle>
-              <CardDescription>Plan burn, runway, and investment pacing with CFO-grade controls.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Financial runway</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Plan burn, runway, and investment pacing with CFO-grade controls.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
-                <p className="text-sm font-medium text-[color:var(--color-text)]">Base plan</p>
-                <p className="text-3xl font-semibold text-[color:var(--color-text)]">18.5 months</p>
-                <p className="text-xs text-[color:var(--color-text-muted)]">Runway based on current burn rate of $185K/mo</p>
+              <div className="space-y-3 rounded-lg border border-gray-200 p-4">
+                <p className="text-sm font-medium text-black">Base plan</p>
+                <p className="text-3xl font-semibold text-black">18.5 months</p>
+                <p className="text-xs text-gray-500">Runway based on current burn rate of $185K/mo</p>
               </div>
-              <div className="space-y-3 rounded-lg border border-[color:var(--color-outline)] p-4">
-                <p className="text-sm font-medium text-[color:var(--color-text)]">Efficiency scenario</p>
-                <p className="text-3xl font-semibold text-[color:var(--color-positive)]">21.3 months</p>
-                <p className="text-xs text-[color:var(--color-text-muted)]">Assumes 8% opex reduction + 6% ARR uplift</p>
+              <div className="space-y-3 rounded-lg border border-gray-200 p-4">
+                <p className="text-sm font-medium text-black">Efficiency scenario</p>
+                <p className="text-3xl font-semibold text-emerald-600">21.3 months</p>
+                <p className="text-xs text-gray-500">Assumes 8% opex reduction + 6% ARR uplift</p>
               </div>
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Cash flow planner</CardTitle>
-              <CardDescription>Align hiring plans, vendor spend, and capital strategy.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Cash flow planner</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Align hiring plans, vendor spend, and capital strategy.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {["Headcount pacing vs plan","Vendor consolidation savings","Capital efficiency by cohort"].map((item) => (
-                <div key={item} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-3 text-sm text-[color:var(--color-text)]">
+              {cashFlowItems.map((item) => (
+                <div key={item} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
                   {item}
                 </div>
               ))}
-              <Button variant="outline" className="self-start">
+              <Button variant="outline" className="self-start text-sm">
                 Open planner workspace
               </Button>
             </CardContent>
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="profit" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Profit" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Profitability snapshot</CardTitle>
-              <CardDescription>Track margin, CAC payback, and capital efficiency benchmarks.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Profitability snapshot</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Track margin, CAC payback, and capital efficiency benchmarks.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {profitMetrics.map((metric) => (
-                <div key={metric.id} className="rounded-lg border border-[color:var(--color-outline)] p-4">
-                  <p className="text-sm font-medium text-[color:var(--color-text)]">{metric.name}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[color:var(--color-text)]">{metric.value}</p>
-                  <p className="text-xs text-[color:var(--color-text-muted)]">{metric.benchmark}</p>
+                <div key={metric.id} className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm font-medium text-black">{metric.name}</p>
+                  <p className="mt-2 text-2xl font-semibold text-black">{metric.value}</p>
+                  <p className="text-xs text-gray-500">{metric.benchmark}</p>
                 </div>
               ))}
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Margin improvement ideas</CardTitle>
-              <CardDescription>Quick wins sourced from GTM, product, and finance collaboration.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Margin improvement ideas</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Quick wins sourced from GTM, product, and finance collaboration.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {["Shift implementation to partners for enterprise tier","Launch usage alerts to prevent overage credits","Automate onboarding to reduce services cost"].map((idea) => (
-                <div key={idea} className="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-surface-muted)]/30 p-3 text-sm text-[color:var(--color-text)]">
+              {marginIdeas.map((idea) => (
+                <div key={idea} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
                   {idea}
                 </div>
               ))}
             </CardContent>
           </Card>
-        </TabsContent>
+        </div>
+      )}
 
-        <TabsContent value="scenarios" className="space-y-4 border-none p-0">
-          <Card>
+      {activeTab === "Board Scenarios" && (
+        <div className="space-y-4">
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>Board-ready packs</CardTitle>
-              <CardDescription>Assemble scenario outputs with commentary, risks, and actions in seconds.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">Board-ready packs</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Assemble scenario outputs with commentary, risks, and actions in seconds.
+              </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              {[
-                { title: 'Base', summary: 'Plan of record, current hiring, pipeline confidence.' },
-                { title: 'Upside', summary: 'Requires 2 strategic wins + PLG conversion lift.' },
-                { title: 'Downside', summary: 'Models churn risk, slip deals, and cost controls.' },
-              ].map((pack) => (
-                <div key={pack.title} className="flex flex-col justify-between rounded-lg border border-[color:var(--color-outline)] p-4">
+              {scenarioPacks.map((pack) => (
+                <div key={pack.title} className="flex flex-col justify-between rounded-lg border border-gray-200 p-4">
                   <div>
-                    <p className="text-sm font-semibold text-[color:var(--color-text)]">{pack.title}</p>
-                    <p className="mt-1 text-sm text-[color:var(--color-text-muted)]">{pack.summary}</p>
+                    <p className="text-sm font-semibold text-black">{pack.title}</p>
+                    <p className="mt-1 text-sm text-gray-600">{pack.summary}</p>
                   </div>
-                  <Button variant="outline" className="mt-4">
+                  <Button variant="outline" className="mt-4 self-start text-sm">
                     Generate pack
                   </Button>
                 </div>
@@ -258,22 +308,24 @@ export default function ResourcesPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle>What-if levers</CardTitle>
-              <CardDescription>Toggle hiring, win rates, and pricing to see multi-quarter impact.</CardDescription>
+              <CardTitle className="text-lg font-semibold text-black">What-if levers</CardTitle>
+              <CardDescription className="text-sm text-gray-500">
+                Toggle hiring, win rates, and pricing to see multi-quarter impact.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {["AE ramp time","Enterprise discount rate","Partner-sourced pipeline"].map((lever) => (
-                <div key={lever} className="flex items-center justify-between rounded-lg border border-[color:var(--color-outline)] p-3 text-sm text-[color:var(--color-text)]">
+              {whatIfLevers.map((lever) => (
+                <div key={lever} className="flex items-center justify-between rounded-lg border border-gray-200 p-3 text-sm text-gray-700">
                   <span>{lever}</span>
                   <Badge variant="outline">Interactive</Badge>
                 </div>
               ))}
             </CardContent>
           </Card>
-        </TabsContent>
-      </Tabs>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,18 +1,8 @@
 "use client"
 
 import { useMemo, useState, type InputHTMLAttributes } from "react"
-import {
-  Cpu,
-  Database,
-  Eye,
-  Key,
-  RefreshCw,
-  Save,
-  Settings,
-  ToggleLeft,
-  ToggleRight,
-  Wrench,
-} from "lucide-react"
+import { usePathname, useSearchParams } from "next/navigation"
+import { Cpu, Database, Eye, Key, RefreshCw, Save, Settings, Wrench } from "lucide-react"
 
 import { Button } from "@/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card"
@@ -27,20 +17,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/ui/sheet"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs"
 import { cn } from "@/lib/utils"
 import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style"
-
-type FeatureFlagKey = "kanban" | "auditChecklist" | "workforce" | "analytics" | "reports"
-
-type FeatureFlagGroup = {
-  label: string
-  items: Array<{
-    id: FeatureFlagKey
-    name: string
-    description: string
-  }>
-}
+import { resolveTabs } from "@/lib/tabs"
 
 type Agent = {
   id: string
@@ -53,31 +32,6 @@ type Agent = {
   lastCommit: string
   config: string
 }
-
-type TabKey = "Appearance" | "Integrations" | "AI Config" | "Agents" | "Feature Flags" | "Diagnostics"
-
-const featureGroups: FeatureFlagGroup[] = [
-  {
-    label: "Interface",
-    items: [
-      { id: "kanban", name: "Kanban Workbench", description: "Deal workflow visibility for GTM teams" },
-      { id: "reports", name: "Executive Reports", description: "RevenueOS dashboards & board packets" },
-    ],
-  },
-  {
-    label: "Automation",
-    items: [
-      { id: "auditChecklist", name: "Audit Checklist", description: "AI validation flows for compliance" },
-      { id: "workforce", name: "Workforce Planning", description: "Capacity models & staffing alerts" },
-    ],
-  },
-  {
-    label: "Analytics",
-    items: [
-      { id: "analytics", name: "Rev Intelligence", description: "Predictive scoring + cohort trends" },
-    ],
-  },
-]
 
 const initialAgents: Agent[] = [
   {
@@ -147,17 +101,14 @@ const initialAgents: Agent[] = [
   },
 ]
 
-const tabs: TabKey[] = ["Appearance", "Integrations", "AI Config", "Agents", "Feature Flags", "Diagnostics"]
-
 export default function ControlCenterPage() {
-  const [activeTab, setActiveTab] = useState<TabKey>("Agents")
-  const [featureFlags, setFeatureFlags] = useState<Record<FeatureFlagKey, boolean>>({
-    kanban: true,
-    auditChecklist: true,
-    workforce: false,
-    analytics: true,
-    reports: false,
-  })
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const activeTab = useMemo(() => {
+    const current = searchParams.get("tab")
+    return current && tabs.includes(current) ? current : tabs[0]
+  }, [searchParams, tabs])
   const [agents, setAgents] = useState<Agent[]>(initialAgents)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(initialAgents[0]?.id ?? null)
   const [editingAgent, setEditingAgent] = useState<Agent | null>(initialAgents[0] ?? null)
@@ -178,13 +129,6 @@ export default function ControlCenterPage() {
     }
   }, [editingAgent])
 
-  const toggleFlag = (flag: FeatureFlagKey) => {
-    setFeatureFlags((prev) => ({
-      ...prev,
-      [flag]: !prev[flag],
-    }))
-  }
-
   const handleSelectAgent = (agent: Agent) => {
     setSelectedAgentId(agent.id)
     setEditingAgent(agent)
@@ -204,403 +148,357 @@ export default function ControlCenterPage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col bg-white">
-      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-6 pb-10 pt-8">
-        <header className="flex items-center justify-between">
-          <div>
-            <div className="flex items-center gap-2 text-black">
-              <Settings size={20} />
-              <PageTitle className="text-2xl font-semibold text-black">TRS Control Center</PageTitle>
+    <>
+      <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
+        <Card className={TRS_CARD}>
+          <CardContent className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="flex items-center gap-2 text-black">
+                <Settings size={20} />
+                <PageTitle className="text-2xl font-semibold text-black">TRS Control Center</PageTitle>
+              </div>
+              <PageDescription className="mt-1 text-sm text-gray-500">
+                Operate RevenueOS without code — configure appearance, AI agents, integrations, and platform governance.
+              </PageDescription>
             </div>
-            <PageDescription className="mt-1 text-xs text-gray-500">
-              Operate RevenueOS without code — configure appearance, AI agents, integrations, and platform governance.
-            </PageDescription>
-          </div>
-          <div className="flex flex-col items-end gap-1 text-right">
-            <span className="text-xs font-medium text-gray-500">Environment</span>
-            <span className="text-sm font-semibold text-black">Production</span>
-          </div>
-        </header>
+            <div className="flex flex-col items-end gap-1 text-right text-gray-500">
+              <span className="text-xs font-medium">Environment</span>
+              <span className="text-sm font-semibold text-black">Production</span>
+            </div>
+          </CardContent>
+        </Card>
 
-        <Tabs className="flex-1" defaultValue={activeTab} value={activeTab} onValueChange={(next) => setActiveTab(next as TabKey)}>
-          <TabsList className="flex-wrap justify-between gap-2">
-            {tabs.map((tab) => (
-              <TabsTrigger key={tab} value={tab} className="rounded-lg px-4 py-2 text-sm">
-                {tab}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+        {activeTab === "Appearance" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">
+                  <Eye size={16} /> Theme &amp; Layout
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <div className="grid gap-4 text-sm text-gray-600">
+                  <div className="flex items-center justify-between">
+                    <span className={TRS_SECTION_TITLE}>Mode</span>
+                    <div className="flex gap-2">
+                      <Button variant="outline" size="sm" className="rounded-lg px-4 text-xs font-medium text-black">
+                        Light
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className="rounded-lg bg-gray-900 px-4 text-xs font-medium text-white hover:bg-gray-800"
+                      >
+                        Dark
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="grid gap-2">
+                    <span className={TRS_SECTION_TITLE}>Accent Preview</span>
+                    <div className="flex gap-3">
+                      <div className="h-10 flex-1 rounded-lg bg-black shadow-inner" />
+                      <div className="h-10 flex-1 rounded-lg bg-gray-900/80" />
+                    </div>
+                  </div>
+                  <div className="grid gap-2">
+                    <span className={TRS_SECTION_TITLE}>UI Density</span>
+                    <Select defaultValue="comfortable" className="w-48">
+                      <option value="comfortable">Comfortable</option>
+                      <option value="compact">Compact</option>
+                      <option value="expanded">Expanded</option>
+                    </Select>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
 
-          <TabsContent value="Appearance" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">
-                    <Eye size={16} /> Theme &amp; Layout
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <div className="grid gap-4 text-sm text-gray-600">
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">Brand Controls</CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <div className="grid gap-4 text-sm text-gray-600">
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Logotype</span>
+                    <Input placeholder="https://cdn.trs.ai/logo.svg" className="w-full" />
+                    <span className={TRS_SUBTITLE}>Rendered across dashboards and outbound comms.</span>
+                  </div>
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Accent Color</span>
+                    <Input type="color" defaultValue="#111827" className="h-10 w-24 rounded-md border border-gray-200" />
+                    <span className={TRS_SUBTITLE}>Preview updates live on marketing experiences.</span>
+                  </div>
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Surface Frosting</span>
+                    <Select defaultValue="subtle" className="w-48">
+                      <option value="none">None</option>
+                      <option value="subtle">Subtle</option>
+                      <option value="strong">Strong</option>
+                    </Select>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Integrations" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <IntegrationCard
+              title="OpenAI Platform"
+              description="Primary model provider for Rosie and Revenue Copilots."
+              fields={[
+                { label: "API Key", placeholder: "sk-live-**********" },
+                { label: "Org ID", placeholder: "org_****" },
+              ]}
+            />
+            <IntegrationCard
+              title="Anthropic"
+              description="Secondary models for pricing intelligence."
+              fields={[{ label: "API Key", placeholder: "live-key-********" }]}
+            />
+            <IntegrationCard
+              title="Google Workspace"
+              description="Calendar + Meet orchestration."
+              fields={[
+                { label: "Service Account", placeholder: "revenue-os@trs.iam.gserviceaccount.com" },
+                { label: "Calendar ID", placeholder: "trs.ai_343434@group.calendar.google.com" },
+              ]}
+            />
+            <IntegrationCard
+              title="Supabase"
+              description="Operational data warehouse for RevenueOS."
+              fields={[
+                { label: "Project URL", placeholder: "https://trs.supabase.co" },
+                { label: "Anon Key", placeholder: "sb-live-********" },
+              ]}
+            />
+            <IntegrationCard
+              title="Email Delivery"
+              description="SMTP + domain alignment for outbound automations."
+              fields={[
+                { label: "SMTP Host", placeholder: "smtp.postmarkapp.com" },
+                { label: "Username", placeholder: "api@trs.ai" },
+                { label: "Password", placeholder: "••••••••" },
+              ]}
+            />
+            <IntegrationCard
+              title="Data Connectors"
+              description="Sync CRM and ERP systems into RevenueOS."
+              fields={[
+                { label: "Salesforce Instance", placeholder: "trs.lightning.force.com" },
+                { label: "NetSuite Token", placeholder: "token-********" },
+              ]}
+            />
+          </div>
+        )}
+
+        {activeTab === "AI Config" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">
+                  <Cpu size={16} /> Global Defaults
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <div className="grid gap-4 text-sm text-gray-600">
+                  <SelectField label="Tone" options={["Analytical", "Direct", "Empathetic", "Executive"]} />
+                  <SelectField label="Response Depth" options={["Summary", "Detailed", "Action Plan"]} />
+                  <SelectField label="Execution Mode" options={["Manual", "Scheduled", "Reactive"]} />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">Guardrails</CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <div className="grid gap-4 text-sm text-gray-600">
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Escalation Threshold</span>
+                    <Input type="number" defaultValue={0.7} min={0} max={1} step={0.05} className="w-32" />
+                    <span className={TRS_SUBTITLE}>Trigger human review when confidence dips.</span>
+                  </div>
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Max Tokens / Response</span>
+                    <Input type="number" defaultValue={1200} className="w-32" />
+                    <span className={TRS_SUBTITLE}>Hard stop for long-form generation.</span>
+                  </div>
+                  <div className="grid gap-1">
+                    <span className={TRS_SECTION_TITLE}>Allowed Integrations</span>
+                    <Select multiple className="h-28 w-full">
+                      <option>CRM</option>
+                      <option>ERP</option>
+                      <option>Billing</option>
+                      <option>Attribution</option>
+                    </Select>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Agents" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr,1.2fr]">
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-4">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">
+                  <Wrench size={16} /> AI Agents
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-4">
+                <div className="space-y-3">
+                  {agents.map((agent) => {
+                    const isActive = agent.id === selectedAgentId
+                    return (
+                      <button
+                        key={agent.id}
+                        type="button"
+                        onClick={() => handleSelectAgent(agent)}
+                        className={cn(
+                          "w-full rounded-lg border px-4 py-3 text-left transition",
+                          isActive ? "border-black bg-gray-50" : "border-gray-200 hover:bg-gray-50",
+                        )}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-black">{agent.name}</p>
+                            <p className="text-xs text-gray-500">{agent.role}</p>
+                          </div>
+                          <span className="text-xs font-medium text-gray-500">{agent.mode}</span>
+                        </div>
+                        <div className="mt-2 flex items-center justify-between text-[11px] text-gray-400">
+                          <span>{agent.model}</span>
+                          <span>Last build {agent.lastBuild}</span>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-4">
+                <CardTitle className="text-lg text-black">Configuration</CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-4">
+                {!selectedAgent && <p className="text-sm text-gray-500">Select an agent to configure.</p>}
+                {selectedAgent && editingAgent && (
+                  <div className="flex h-full flex-col gap-4">
+                    <div className="grid grid-cols-2 gap-4 text-sm">
+                      <LabeledInput
+                        label="Name"
+                        value={editingAgent.name}
+                        onChange={(event) => setEditingAgent({ ...editingAgent, name: event.target.value })}
+                      />
+                      <LabeledInput
+                        label="Model"
+                        value={editingAgent.model}
+                        onChange={(event) => setEditingAgent({ ...editingAgent, model: event.target.value })}
+                      />
+                      <LabeledInput
+                        label="Temperature"
+                        type="number"
+                        step={0.1}
+                        min={0}
+                        max={1}
+                        value={editingAgent.temperature}
+                        onChange={(event) =>
+                          setEditingAgent({ ...editingAgent, temperature: Number(event.target.value) })
+                        }
+                      />
+                      <LabeledInput
+                        label="Role"
+                        value={editingAgent.role}
+                        onChange={(event) => setEditingAgent({ ...editingAgent, role: event.target.value })}
+                      />
+                      <div className="col-span-2">
+                        <span className={TRS_SECTION_TITLE}>Prompt &amp; Logic JSON</span>
+                        <textarea
+                          value={editingAgent.config}
+                          onChange={(event) => setEditingAgent({ ...editingAgent, config: event.target.value })}
+                          className="mt-2 h-48 w-full rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs text-gray-800 focus-visible:border-black focus-visible:outline-none"
+                        />
+                        {!configIsValid && (
+                          <p className="mt-1 text-xs text-red-500">JSON is invalid — please fix before saving.</p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between text-xs text-gray-500">
+                      <span>Last build {selectedAgent.lastBuild}</span>
+                      <span>Commit {selectedAgent.lastCommit}</span>
+                    </div>
                     <div className="flex items-center justify-between">
-                      <span className={TRS_SECTION_TITLE}>Mode</span>
                       <div className="flex gap-2">
-                        <Button variant="outline" size="sm" className="rounded-lg px-4 text-xs font-medium text-black">
-                          Light
-                        </Button>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          className="rounded-lg bg-gray-900 px-4 text-xs font-medium text-white hover:bg-gray-800"
-                        >
-                          Dark
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="grid gap-2">
-                      <span className={TRS_SECTION_TITLE}>Accent Preview</span>
-                      <div className="flex gap-3">
-                        <div className="h-10 flex-1 rounded-lg bg-black shadow-inner" />
-                        <div className="h-10 flex-1 rounded-lg bg-gray-900/80" />
-                      </div>
-                    </div>
-                    <div className="grid gap-2">
-                      <span className={TRS_SECTION_TITLE}>UI Density</span>
-                      <Select defaultValue="comfortable" className="w-48">
-                        <option value="comfortable">Comfortable</option>
-                        <option value="compact">Compact</option>
-                        <option value="expanded">Expanded</option>
-                      </Select>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">Brand Controls</CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <div className="grid gap-4 text-sm text-gray-600">
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Logotype</span>
-                      <Input placeholder="https://cdn.trs.ai/logo.svg" className="w-full" />
-                      <span className={TRS_SUBTITLE}>Rendered across dashboards and outbound comms.</span>
-                    </div>
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Accent Color</span>
-                      <Input type="color" defaultValue="#111827" className="h-10 w-24 rounded-md border border-gray-200" />
-                      <span className={TRS_SUBTITLE}>Preview updates live on marketing experiences.</span>
-                    </div>
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Surface Frosting</span>
-                      <Select defaultValue="subtle" className="w-48">
-                        <option value="none">None</option>
-                        <option value="subtle">Subtle</option>
-                        <option value="strong">Strong</option>
-                      </Select>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="Integrations" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              <IntegrationCard
-                title="OpenAI Platform"
-                description="Primary model provider for Rosie and Revenue Copilots."
-                fields={[
-                  { label: "API Key", placeholder: "sk-live-**********" },
-                  { label: "Org ID", placeholder: "org_****" },
-                ]}
-              />
-              <IntegrationCard
-                title="Anthropic"
-                description="Secondary models for pricing intelligence."
-                fields={[{ label: "API Key", placeholder: "live-key-********" }]}
-              />
-              <IntegrationCard
-                title="Google Workspace"
-                description="Calendar + Meet orchestration."
-                fields={[
-                  { label: "Service Account", placeholder: "revenue-os@trs.iam.gserviceaccount.com" },
-                  { label: "Calendar ID", placeholder: "trs.ai_343434@group.calendar.google.com" },
-                ]}
-              />
-              <IntegrationCard
-                title="Supabase"
-                description="Operational data warehouse for RevenueOS."
-                fields={[
-                  { label: "Project URL", placeholder: "https://trs.supabase.co" },
-                  { label: "Anon Key", placeholder: "sb-live-********" },
-                ]}
-              />
-              <IntegrationCard
-                title="Email Delivery"
-                description="SMTP + domain alignment for outbound automations."
-                fields={[
-                  { label: "SMTP Host", placeholder: "smtp.postmarkapp.com" },
-                  { label: "Username", placeholder: "api@trs.ai" },
-                  { label: "Password", placeholder: "••••••••" },
-                ]}
-              />
-              <IntegrationCard
-                title="Data Connectors"
-                description="Sync CRM and ERP systems into RevenueOS."
-                fields={[
-                  { label: "Salesforce Instance", placeholder: "trs.lightning.force.com" },
-                  { label: "NetSuite Token", placeholder: "token-********" },
-                ]}
-              />
-            </div>
-          </TabsContent>
-
-          <TabsContent value="AI Config" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">
-                    <Cpu size={16} /> Global Defaults
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <div className="grid gap-4 text-sm text-gray-600">
-                    <SelectField label="Tone" options={["Analytical", "Direct", "Empathetic", "Executive"]} />
-                    <SelectField label="Response Depth" options={["Summary", "Detailed", "Action Plan"]} />
-                    <SelectField label="Execution Mode" options={["Manual", "Scheduled", "Reactive"]} />
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">Guardrails</CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <div className="grid gap-4 text-sm text-gray-600">
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Escalation Threshold</span>
-                      <Input type="number" defaultValue={0.7} min={0} max={1} step={0.05} className="w-32" />
-                      <span className={TRS_SUBTITLE}>Trigger human review when confidence dips.</span>
-                    </div>
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Max Tokens / Response</span>
-                      <Input type="number" defaultValue={1200} className="w-32" />
-                      <span className={TRS_SUBTITLE}>Hard stop for long-form generation.</span>
-                    </div>
-                    <div className="grid gap-1">
-                      <span className={TRS_SECTION_TITLE}>Allowed Integrations</span>
-                      <Select multiple className="h-28 w-full">
-                        <option>CRM</option>
-                        <option>ERP</option>
-                        <option>Billing</option>
-                        <option>Attribution</option>
-                      </Select>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="Agents" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr,1.2fr]">
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-4">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">
-                    <Wrench size={16} /> AI Agents
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-4">
-                  <div className="space-y-3">
-                    {agents.map((agent) => {
-                      const isActive = agent.id === selectedAgentId
-                      return (
-                        <button
-                          key={agent.id}
-                          type="button"
-                          onClick={() => handleSelectAgent(agent)}
-                          className={cn(
-                            "w-full rounded-lg border px-4 py-3 text-left transition",
-                            isActive ? "border-black bg-gray-50" : "border-gray-200 hover:bg-gray-50",
-                          )}
-                        >
-                          <div className="flex items-center justify-between">
-                            <div>
-                              <p className="text-sm font-semibold text-black">{agent.name}</p>
-                              <p className="text-xs text-gray-500">{agent.role}</p>
-                            </div>
-                            <span className="text-xs font-medium text-gray-500">{agent.mode}</span>
-                          </div>
-                          <div className="mt-2 flex items-center justify-between text-[11px] text-gray-400">
-                            <span>{agent.model}</span>
-                            <span>Last build {agent.lastBuild}</span>
-                          </div>
-                        </button>
-                      )
-                    })}
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-4">
-                  <CardTitle className="text-lg text-black">Configuration</CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-4">
-                  {!selectedAgent && <p className="text-sm text-gray-500">Select an agent to configure.</p>}
-                  {selectedAgent && editingAgent && (
-                    <div className="flex h-full flex-col gap-4">
-                      <div className="grid grid-cols-2 gap-4 text-sm">
-                        <LabeledInput
-                          label="Name"
-                          value={editingAgent.name}
-                          onChange={(event) => setEditingAgent({ ...editingAgent, name: event.target.value })}
-                        />
-                        <LabeledInput
-                          label="Model"
-                          value={editingAgent.model}
-                          onChange={(event) => setEditingAgent({ ...editingAgent, model: event.target.value })}
-                        />
-                        <LabeledInput
-                          label="Temperature"
-                          type="number"
-                          step={0.1}
-                          min={0}
-                          max={1}
-                          value={editingAgent.temperature}
-                          onChange={(event) =>
-                            setEditingAgent({ ...editingAgent, temperature: Number(event.target.value) })
-                          }
-                        />
-                        <LabeledInput
-                          label="Role"
-                          value={editingAgent.role}
-                          onChange={(event) => setEditingAgent({ ...editingAgent, role: event.target.value })}
-                        />
-                        <div className="col-span-2">
-                          <span className={TRS_SECTION_TITLE}>Prompt &amp; Logic JSON</span>
-                          <textarea
-                            value={editingAgent.config}
-                            onChange={(event) => setEditingAgent({ ...editingAgent, config: event.target.value })}
-                            className="mt-2 h-48 w-full rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs text-gray-800 focus-visible:border-black focus-visible:outline-none"
-                          />
-                          {!configIsValid && (
-                            <p className="mt-1 text-xs text-red-500">JSON is invalid — please fix before saving.</p>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex items-center justify-between text-xs text-gray-500">
-                        <span>Last build {selectedAgent.lastBuild}</span>
-                        <span>Commit {selectedAgent.lastCommit}</span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <div className="flex gap-2">
-                          <Button
-                            type="button"
-                            variant="primary"
-                            size="sm"
-                            className="rounded-lg px-4"
-                            disabled={!configIsValid}
-                            onClick={handleSaveAgent}
-                          >
-                            <Save size={14} /> Save Configuration
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="rounded-lg px-4"
-                            onClick={() => handleRebuildAgent(selectedAgent.id)}
-                          >
-                            <RefreshCw size={14} /> Rebuild
-                          </Button>
-                        </div>
                         <Button
                           type="button"
-                          variant="ghost"
+                          variant="primary"
                           size="sm"
-                          className="rounded-lg text-xs text-gray-500"
-                          onClick={() => setDrawerAgent(selectedAgent)}
+                          className="rounded-lg px-4"
+                          disabled={!configIsValid}
+                          onClick={handleSaveAgent}
                         >
-                          Inspect build
+                          <Save size={14} /> Save Configuration
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="rounded-lg px-4"
+                          onClick={() => handleRebuildAgent(selectedAgent.id)}
+                        >
+                          <RefreshCw size={14} /> Rebuild
                         </Button>
                       </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="rounded-lg text-xs text-gray-500"
+                        onClick={() => setDrawerAgent(selectedAgent)}
+                      >
+                        Inspect build
+                      </Button>
                     </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
 
-          <TabsContent value="Feature Flags" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              {featureGroups.map((group) => (
-                <Card key={group.label} className={TRS_CARD}>
-                  <CardHeader className="border-b border-gray-200 px-6 py-4">
-                    <CardTitle className="flex items-center gap-2 text-lg text-black">{group.label}</CardTitle>
-                  </CardHeader>
-                  <CardContent className="px-6 py-4">
-                    <div className="space-y-4">
-                      {group.items.map((flag) => {
-                        const enabled = featureFlags[flag.id]
-                        return (
-                          <div key={flag.id} className="flex items-center justify-between">
-                            <div>
-                              <p className="text-sm font-medium text-black">{flag.name}</p>
-                              <p className="text-xs text-gray-500">{flag.description}</p>
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => toggleFlag(flag.id)}
-                              className="flex h-8 w-14 items-center justify-center rounded-full border border-gray-200 bg-white"
-                            >
-                              {enabled ? (
-                                <ToggleRight size={22} className="text-emerald-600" />
-                              ) : (
-                                <ToggleLeft size={22} className="text-gray-400" />
-                              )}
-                            </button>
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="Diagnostics" className="border-none p-0">
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">
-                    <Database size={16} /> Platform Health
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <DiagnosticRow label="System Uptime" value="99.97%" />
-                  <DiagnosticRow label="API Latency" value="105 ms" />
-                  <DiagnosticRow label="Token Usage" value="4,990 / day" />
-                  <DiagnosticRow label="Queue Backlog" value="0 tasks" />
-                </CardContent>
-              </Card>
-              <Card className={TRS_CARD}>
-                <CardHeader className="border-b border-gray-200 px-6 py-5">
-                  <CardTitle className="flex items-center gap-2 text-lg text-black">Build Info</CardTitle>
-                </CardHeader>
-                <CardContent className="px-6 py-5">
-                  <DiagnosticRow label="Current Release" value="2025.10.09" />
-                  <DiagnosticRow label="Next Scheduled Rebuild" value="Oct 15, 2025" />
-                  <DiagnosticRow label="Last Rebuild Duration" value="2m 43s" />
-                  <DiagnosticRow label="Node Version" value="18.18.0" />
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-        </Tabs>
+        {activeTab === "Diagnostics" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">
+                  <Database size={16} /> Platform Health
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <DiagnosticRow label="System Uptime" value="99.97%" />
+                <DiagnosticRow label="API Latency" value="105 ms" />
+                <DiagnosticRow label="Token Usage" value="4,990 / day" />
+                <DiagnosticRow label="Queue Backlog" value="0 tasks" />
+              </CardContent>
+            </Card>
+            <Card className={TRS_CARD}>
+              <CardHeader className="border-b border-gray-200 px-6 py-5">
+                <CardTitle className="flex items-center gap-2 text-lg text-black">Build Info</CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 py-5">
+                <DiagnosticRow label="Current Release" value="2025.10.09" />
+                <DiagnosticRow label="Next Scheduled Rebuild" value="Oct 15, 2025" />
+                <DiagnosticRow label="Last Rebuild Duration" value="2m 43s" />
+                <DiagnosticRow label="Node Version" value="18.18.0" />
+              </CardContent>
+            </Card>
+          </div>
+        )}
       </div>
 
       <Sheet open={!!drawerAgent} onOpenChange={(open) => !open && setDrawerAgent(null)}>
@@ -664,7 +562,7 @@ export default function ControlCenterPage() {
           </SheetFooter>
         </SheetContent>
       </Sheet>
-    </main>
+    </>
   )
 }
 

--- a/lib/tabs.ts
+++ b/lib/tabs.ts
@@ -9,6 +9,7 @@ export const PAGE_TABS: Record<string, string[]> = {
   "/agents": ["All", "Projects", "Content", "Clients", "GPT Agents"],
   "/mail-calendar": ["Inbox", "Calendar", "Integrations"],
   "/resources": ["Pricing", "Revenue", "Financial Plan", "Profit", "Board Scenarios"],
+  "/settings": ["Agents", "Appearance", "Integrations", "AI Config", "Diagnostics"],
   "/clients": ["Overview", "Accounts", "Engagement", "Renewals", "Signals"],
   "/clients/[id]": ["Overview", "Projects", "RevenueOS", "Data", "Strategy", "Results"],
   "/partners/[id]": ["Overview", "Introductions", "Initiatives", "Notes", "Resources"],


### PR DESCRIPTION
## Summary
- restyle the resources and mail calendar routes to reuse the pipeline card layout driven by global tabs
- overhaul the settings page to depend on shared tabs, drop the duplicate tab bar, and remove feature flag controls
- add the settings tab mapping so the top nav reflects the available sections

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e852e95a408324b6a5ade4d3f4a151