### PR TITLE
feat: unify internal layout shell

### DIFF
--- a/app/agents/AgentsDirectory.tsx
+++ b/app/agents/AgentsDirectory.tsx
@@ -20,9 +20,9 @@ type GPTAgent = {
 };
 
 const STATUS_TONES: Record<string, { badge: string }> = {
-  Active: { badge: "bg-emerald-100 text-emerald-700" },
-  Idle: { badge: "bg-amber-100 text-amber-700" },
-  Offline: { badge: "bg-gray-200 text-gray-700" },
+  Active: { badge: "border border-gray-300 bg-white text-gray-700" },
+  Idle: { badge: "border border-gray-300 bg-white text-gray-600" },
+  Offline: { badge: "border border-gray-300 bg-white text-gray-500" },
 };
 
 const GPT_AGENTS: GPTAgent[] = [
@@ -148,7 +148,7 @@ export default function AgentsDirectory({ agents }: { agents: AgentRecord[] }) {
                   <h2 className="text-sm font-semibold text-black">{gptAgent.name}</h2>
                   <p className="mt-1 text-xs leading-relaxed text-gray-600">{gptAgent.description}</p>
                 </div>
-                <span className="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-purple-700">
+                <span className="inline-flex items-center rounded-full border border-gray-300 bg-white px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-gray-700">
                   GPT
                 </span>
               </div>
@@ -172,7 +172,7 @@ export default function AgentsDirectory({ agents }: { agents: AgentRecord[] }) {
           ))}
         </div>
       ) : filteredAgents.length === 0 ? (
-        <Card className="border-dashed bg-gray-50 p-6 text-center text-sm text-gray-600">
+        <Card className="border-dashed bg-white p-6 text-center text-sm text-gray-600">
           No agents match the current filters.
         </Card>
       ) : (
@@ -189,7 +189,7 @@ export default function AgentsDirectory({ agents }: { agents: AgentRecord[] }) {
                     <h2 className="text-sm font-semibold text-black">{agent.meta.name}</h2>
                     <p className="mt-1 text-xs leading-relaxed text-gray-600">{agent.meta.description}</p>
                   </div>
-                  <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-gray-700">
+                  <span className="inline-flex items-center rounded-full border border-gray-300 bg-white px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-gray-700">
                     {agent.meta.category}
                   </span>
                 </div>

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -6,8 +6,13 @@ export default async function AgentsHubPage() {
   const agents = await actionListAgents()
 
   return (
-    <div className="w-full px-6 py-6">
-      <AgentsDirectory agents={agents} />
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12">
+        <AgentsDirectory agents={agents} />
+      </section>
     </div>
   )
 }

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -116,15 +116,19 @@ export default function ClientsPage() {
   const churnSignals = useMemo(() => clients.filter((client) => (client.churnRisk ?? 0) >= 15), [clients])
 
   return (
-    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
-      <div className="flex flex-col gap-2">
-        <PageTitle className="text-xl font-semibold text-black">Client Portfolio</PageTitle>
-        <PageDescription className="text-sm text-gray-500">
-          Full-funnel visibility into active customers, health trends, and expansion momentum across TRS RevenueOS.
-        </PageDescription>
-      </div>
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12 space-y-3">
+        <div className="space-y-1">
+          <PageTitle className="text-xl font-semibold text-black">Client Portfolio</PageTitle>
+          <PageDescription className="text-sm text-gray-500">
+            Full-funnel visibility into active customers, health trends, and expansion momentum across TRS RevenueOS.
+          </PageDescription>
+        </div>
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
         <Card className={cn(TRS_CARD)}>
           <CardContent className="p-4 space-y-2">
             <div className={TRS_SUBTITLE}>Portfolio ARR</div>
@@ -166,13 +170,13 @@ export default function ClientsPage() {
                 </PageDescription>
               </div>
               <div className="flex flex-wrap items-center gap-2">
-                <Button variant="primary" size="sm" onClick={() => router.push("/partners")}>Sync partners</Button>
+                <Button variant="outline" size="sm" onClick={() => router.push("/partners")}>Sync partners</Button>
                 <Button variant="outline" size="sm" onClick={() => router.push("/projects")}>Open delivery board</Button>
               </div>
             </div>
 
             <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-              <div className="rounded-lg border border-gray-200 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className={TRS_SECTION_TITLE}>Health spotlight</div>
                 <ul className="mt-3 space-y-2 text-sm text-gray-700">
                   {clients
@@ -190,7 +194,7 @@ export default function ClientsPage() {
                     ))}
                 </ul>
               </div>
-              <div className="rounded-lg border border-gray-200 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className={TRS_SECTION_TITLE}>Next 30 days</div>
                 <ul className="mt-3 space-y-2 text-sm text-gray-700">
                   {upcomingQbrs.slice(0, 4).map((client) => (
@@ -206,7 +210,7 @@ export default function ClientsPage() {
                   ))}
                 </ul>
               </div>
-              <div className="rounded-lg border border-gray-200 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className={TRS_SECTION_TITLE}>Expansion focus</div>
                 <div className="mt-3 space-y-2 text-sm text-gray-700">
                   {clients
@@ -243,7 +247,7 @@ export default function ClientsPage() {
                   </div>
                 ) : (
                   outstandingInvoices.map((invoice) => (
-                    <div key={invoice.id} className="rounded-lg border border-gray-200 p-3">
+                    <div key={invoice.id} className="rounded-lg border border-gray-200 bg-white p-3">
                       <div className="flex items-center justify-between text-sm">
                         <span className="font-semibold text-black">{invoice.clientName}</span>
                         <span className="text-xs text-gray-500">{invoice.status}</span>
@@ -411,7 +415,7 @@ export default function ClientsPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-gray-700">
               {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold text-black">{client.name}</div>
@@ -439,7 +443,7 @@ export default function ClientsPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-gray-700">
               {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold text-black">{client.name}</div>
@@ -475,7 +479,7 @@ export default function ClientsPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-gray-700">
               {upcomingQbrs.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold text-black">{client.name}</div>
@@ -501,7 +505,7 @@ export default function ClientsPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-gray-700">
               {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold text-black">{client.name}</div>
@@ -536,7 +540,7 @@ export default function ClientsPage() {
                 </div>
               ) : (
                 churnSignals.map((client) => (
-                  <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                  <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                     <div className="flex items-center justify-between text-sm">
                       <span className="font-semibold text-black">{client.name}</span>
                       <Badge variant="outline">{client.churnRisk}% risk</Badge>
@@ -558,7 +562,7 @@ export default function ClientsPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-gray-700">
               {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 p-3">
+                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold text-black">{client.name}</div>
@@ -584,6 +588,7 @@ export default function ClientsPage() {
           </Card>
         </div>
       )}
+      </section>
     </div>
   )
 }

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -82,40 +82,44 @@ export default function ContentStudioPage() {
   };
 
   return (
-    <div className="w-full px-6 py-6 space-y-6">
-      <header className="flex flex-col gap-2">
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12 space-y-4">
+        <header className="flex flex-col gap-2">
         <h1 className="text-2xl font-semibold text-black">Marketing & Content</h1>
         <p className="text-sm text-gray-600">
           Create content to inspire, sell, and add value for clients, prospects, partners, and market presence.
         </p>
-      </header>
+        </header>
 
-      {activeTab === "Overview" && (
+        {activeTab === "Overview" && (
         <div className="space-y-4">
           <Card className="p-4">
             <div className="text-sm font-semibold text-black mb-4">Content Pipeline Overview</div>
             <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Total Content</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.total}</div>
                 <div className="text-[11px] text-gray-600">All pieces</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Published</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.published}</div>
-                <div className="text-[11px] text-emerald-600">Live content</div>
+                <div className="text-[11px] text-gray-600">Live content</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Scheduled</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.scheduled}</div>
-                <div className="text-[11px] text-blue-600">Ready to ship</div>
+                <div className="text-[11px] text-gray-600">Ready to ship</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">In Draft</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.draft}</div>
-                <div className="text-[11px] text-amber-600">In progress</div>
+                <div className="text-[11px] text-gray-600">In progress</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Ideas</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.ideas}</div>
                 <div className="text-[11px] text-gray-600">In backlog</div>
@@ -126,20 +130,20 @@ export default function ContentStudioPage() {
           <Card className="p-4">
             <div className="text-sm font-semibold text-black mb-4">Performance Metrics</div>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Total Views</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.views.toLocaleString()}</div>
                 <div className="text-[11px] text-gray-600">Across all content</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Engagement</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.engagement.toLocaleString()}</div>
                 <div className="text-[11px] text-gray-600">Interactions</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Conversions</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.conversions}</div>
-                <div className="text-[11px] text-emerald-600">Generated leads</div>
+                <div className="text-[11px] text-gray-600">Generated leads</div>
               </div>
             </div>
           </Card>
@@ -147,25 +151,25 @@ export default function ContentStudioPage() {
           <Card className="p-4">
             <div className="text-sm font-semibold text-black mb-4">Advertising Overview</div>
             <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Active Campaigns</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.activeCampaigns}</div>
-                <div className="text-[11px] text-emerald-600">Running now</div>
+                <div className="text-[11px] text-gray-600">Running now</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Ad Spend</div>
                 <div className="mt-1 text-2xl font-semibold text-black">${(kpis.advertising.totalSpend / 1000).toFixed(1)}k</div>
                 <div className="text-[11px] text-gray-600">of ${(kpis.advertising.totalBudget / 1000).toFixed(1)}k budget</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Avg CTR</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.avgCTR.toFixed(2)}%</div>
                 <div className="text-[11px] text-gray-600">Click-through rate</div>
               </div>
-              <div className="rounded-lg bg-gray-50 p-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3">
                 <div className="text-[11px] uppercase tracking-wide text-gray-500">Avg ROAS</div>
                 <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.avgROAS.toFixed(1)}x</div>
-                <div className="text-[11px] text-emerald-600">Return on ad spend</div>
+                <div className="text-[11px] text-gray-600">Return on ad spend</div>
               </div>
             </div>
           </Card>
@@ -185,7 +189,7 @@ export default function ContentStudioPage() {
           </div>
           <div className="mt-3 overflow-hidden rounded-lg border border-gray-200">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50 text-left text-[12px] uppercase tracking-wide text-gray-500">
+              <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
                 <tr>
                   <th className="px-3 py-2 font-medium">Title</th>
                   <th className="px-3 py-2 font-medium">Type</th>
@@ -200,7 +204,7 @@ export default function ContentStudioPage() {
                 {pipelineContent.map((item) => (
                   <tr key={item.id} className="hover:bg-gray-50">
                     <td className="px-3 py-2 font-medium text-black">
-                      <Link href={`/content/${item.id}`} className="hover:text-blue-600 hover:underline">
+                      <Link href={`/content/${item.id}`} className="hover:text-gray-600 hover:underline">
                         {item.title}
                       </Link>
                     </td>
@@ -241,7 +245,7 @@ export default function ContentStudioPage() {
                 <div className="flex items-start justify-between">
                   <div className="text-sm font-medium text-black">{idea.title}</div>
                   {idea.aiGenerated && (
-                    <span className="text-[10px] bg-purple-100 text-purple-800 px-1.5 py-0.5 rounded">AI</span>
+                    <span className="rounded border border-gray-300 px-1.5 py-0.5 text-[10px] text-gray-600">AI</span>
                   )}
                 </div>
                 <div className="mt-1 text-[12px] text-gray-600">{idea.format} • {idea.contentType}</div>
@@ -273,7 +277,7 @@ export default function ContentStudioPage() {
                 </div>
                 <div className="text-[12px] text-gray-600">Owner: {release.assignedTo || release.createdBy}</div>
                 <div className="mt-2">
-                  <span className="inline-flex items-center rounded-full bg-blue-100 text-blue-800 px-2 py-0.5 text-[11px] font-medium">
+                  <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
                     {release.purpose}
                   </span>
                 </div>
@@ -290,7 +294,7 @@ export default function ContentStudioPage() {
           <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
             {publishedContent.map((content) => (
               <Link key={content.id} href={`/content/${content.id}`} className="rounded-lg border border-gray-200 p-3 block hover:border-gray-400 transition">
-                <div className="text-sm font-medium text-black hover:text-blue-600">{content.title}</div>
+                <div className="text-sm font-medium text-black hover:text-gray-600">{content.title}</div>
                 <div className="mt-1 text-[11px] text-gray-500">{content.format} • {content.channel}</div>
                 {content.performanceMetrics && (
                   <div className="mt-2 space-y-1">
@@ -303,7 +307,7 @@ export default function ContentStudioPage() {
                   </div>
                 )}
                 <div className="mt-3">
-                  <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-2 py-0.5 text-[11px] font-medium">
+                  <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
                     Published
                   </span>
                 </div>
@@ -341,7 +345,7 @@ export default function ContentStudioPage() {
               </div>
             </div>
 
-            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
               <div className="text-sm font-medium text-black mb-2">AI Content Generator</div>
               <div className="space-y-3">
                 <textarea
@@ -384,7 +388,7 @@ export default function ContentStudioPage() {
               <div className="flex gap-2">
                 <button
                   onClick={() => setShowAgentModal(true)}
-                  className="text-xs px-3 py-1.5 rounded-md bg-purple-600 text-white hover:bg-purple-700"
+                  className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
                 >
                   AI Agent
                 </button>
@@ -398,7 +402,7 @@ export default function ContentStudioPage() {
             </div>
             <div className="mt-3 overflow-hidden rounded-lg border border-gray-200">
               <table className="w-full text-sm">
-                <thead className="bg-gray-50 text-left text-[12px] uppercase tracking-wide text-gray-500">
+                <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
                   <tr>
                     <th className="px-3 py-2 font-medium">Campaign</th>
                     <th className="px-3 py-2 font-medium">Platform</th>
@@ -417,7 +421,7 @@ export default function ContentStudioPage() {
                       <td className="px-3 py-2 text-gray-700">{campaign.platform}</td>
                       <td className="px-3 py-2">
                         <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                          campaign.status === 'Active' ? 'bg-emerald-100 text-emerald-800' :
+                          campaign.status === 'Active' ? 'border border-gray-300 bg-white text-gray-700' :
                           campaign.status === 'Paused' ? 'bg-amber-100 text-amber-800' :
                           'bg-gray-100 text-gray-800'
                         }`}>
@@ -427,7 +431,7 @@ export default function ContentStudioPage() {
                       <td className="px-3 py-2 text-gray-700">${(campaign.budget / 1000).toFixed(1)}k</td>
                       <td className="px-3 py-2 text-gray-700">${(campaign.spent / 1000).toFixed(1)}k</td>
                       <td className="px-3 py-2 text-gray-700">{campaign.metrics?.ctr?.toFixed(2)}%</td>
-                      <td className="px-3 py-2 text-emerald-600 font-medium">{campaign.metrics?.roas?.toFixed(1)}x</td>
+                      <td className="px-3 py-2 text-gray-600 font-medium">{campaign.metrics?.roas?.toFixed(1)}x</td>
                       <td className="px-3 py-2 text-gray-700">{campaign.metrics?.conversions || 0}</td>
                     </tr>
                   ))}
@@ -440,15 +444,15 @@ export default function ContentStudioPage() {
             <Card className="p-4">
               <div className="text-sm font-semibold text-black mb-3">Campaign Performance</div>
               <div className="space-y-3">
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">Total Impressions</div>
                   <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.impressions.toLocaleString()}</div>
                 </div>
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">Total Clicks</div>
                   <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.clicks.toLocaleString()}</div>
                 </div>
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">Total Conversions</div>
                   <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.conversions}</div>
                 </div>
@@ -468,7 +472,7 @@ export default function ContentStudioPage() {
                     </div>
                     <div className="w-full bg-gray-200 rounded-full h-2">
                       <div
-                        className="bg-emerald-600 h-2 rounded-full"
+                        className="bg-gray-700 h-2 rounded-full"
                         style={{ width: `${Math.min((campaign.spent / campaign.budget) * 100, 100)}%` }}
                       />
                     </div>
@@ -594,16 +598,16 @@ export default function ContentStudioPage() {
                 Tip: Be specific about your target audience, platform preferences, and campaign objectives
               </div>
             </div>
-            <div className="flex gap-2 mt-6">
+            <div className="mt-6 flex gap-2">
               <button
                 onClick={() => setShowAgentModal(false)}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50"
+                className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
               >
                 Cancel
               </button>
               <button
                 onClick={handleGenerateWithAgent}
-                className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
+                className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
               >
                 Generate with AI
               </button>
@@ -611,6 +615,7 @@ export default function ContentStudioPage() {
           </div>
         </div>
       )}
+      </section>
     </div>
   );
 }

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -24,17 +24,19 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
   const d = data;
 
   return (
-    <div className="w-full px-6 py-6 space-y-4">
-      {/* Scope controls & command bar */}
-      <div className="flex items-center justify-between">
-        <ScopeBar initial={d.scope}/>
-        <form action={exportAction}>
-          <button className="text-xs px-3 py-1.5 rounded-md border border-gray-300 hover:bg-gray-100 bg-white">Export board deck</button>
-        </form>
-      </div>
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <ScopeBar initial={d.scope}/>
+          <form action={exportAction}>
+            <button className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs hover:bg-gray-100">Export board deck</button>
+          </form>
+        </div>
 
-      {/* Tab: Overview */}
-      {activeTab === "Overview" && (
+        {activeTab === "Overview" && (
         <div className="space-y-4">
           {/* Row 1: Health Ribbon - 4 cards across */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -118,7 +120,7 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
               </div>
               <div className="p-4 text-sm space-y-3">
                 <div className="mb-2 text-[11px] text-gray-500">Discount vs Win vs Margin (stub chart)</div>
-                <div className="h-24 rounded-md border border-gray-200 flex items-center justify-center text-xs text-gray-500 bg-gray-50">Curve</div>
+                <div className="flex h-24 items-center justify-center rounded-md border border-gray-200 bg-white text-xs text-gray-600">Curve</div>
                 <div>
                   <div className="text-[12px] font-medium mb-2">Guardrail Breaches</div>
                   <ul className="text-[12px] space-y-2">
@@ -153,10 +155,9 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
             </Card>
           </div>
         </div>
-      )}
+        )}
 
-      {/* Tab: Analytics */}
-      {activeTab === "Analytics" && (
+        {activeTab === "Analytics" && (
         <Card className="p-6">
           <div className="text-center space-y-3">
             <h2 className="text-lg font-semibold text-black">Advanced Analytics</h2>
@@ -164,10 +165,9 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
             <div className="text-[11px] text-gray-500 italic">Feature coming soon</div>
           </div>
         </Card>
-      )}
+        )}
 
-      {/* Tab: Reports */}
-      {activeTab === "Reports" && (
+        {activeTab === "Reports" && (
         <Card className="p-6">
           <div className="space-y-4">
             <h2 className="text-lg font-semibold text-black">Executive Reports</h2>
@@ -175,10 +175,9 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
             <div className="text-[11px] text-gray-500 italic">Report builder coming soon</div>
           </div>
         </Card>
-      )}
+        )}
 
-      {/* Tab: Notifications */}
-      {activeTab === "Notifications" && (
+        {activeTab === "Notifications" && (
         <Card className="p-6">
           <div className="space-y-4">
             <h2 className="text-lg font-semibold text-black">Notifications & Alerts</h2>
@@ -187,7 +186,8 @@ export default function DashboardClient({ data, exportAction }: { data: ExecDash
             </div>
           </div>
         </Card>
-      )}
+        )}
+      </section>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <body className="min-h-screen bg-white text-black">
         <ThemeProvider defaultTheme="light" storageKey="trs-theme">
-          <Suspense fallback={<div className="min-h-screen bg-white dark:bg-gray-950" />}>
+          <Suspense fallback={<div className="min-h-screen bg-white" />}>
             <AppShell>{children}</AppShell>
           </Suspense>
           <Rosie />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,8 +25,12 @@ export default function MorningPage(){
   const greeting = new Date().toLocaleDateString(undefined, { weekday:"long", month:"short", day:"numeric" });
 
   return (
-    <div className="w-full h-screen overflow-y-auto">
-      <div className="p-3 space-y-3 max-w-[1800px] mx-auto">
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12">
+      <div className="mx-auto space-y-3">
         {/* Header / Context */}
         <section className="rounded-xl border border-gray-200 bg-white p-3">
           <div className="flex items-center justify-between">
@@ -113,6 +117,7 @@ export default function MorningPage(){
           <a href="/dashboard" className="text-xs px-2 py-1 rounded-md border">Open Executive Dashboard</a>
         </section>
       </div>
+      </section>
     </div>
   );
 }

--- a/app/projects/ProjectsPageClient.tsx
+++ b/app/projects/ProjectsPageClient.tsx
@@ -85,15 +85,19 @@ export default function ProjectsPageClient({
   }, [searchParams, tabs]);
 
   return (
-    <div className="w-full px-6 py-6 space-y-6">
-      <header className="flex flex-col gap-2">
+    <div
+      className="grid min-h-full gap-3 p-3"
+      style={{ gridTemplateColumns: "repeat(12,minmax(0,1fr))" }}
+    >
+      <section className="col-span-12 space-y-4">
+        <header className="flex flex-col gap-2">
         <h1 className="text-2xl font-semibold text-black">Projects Control Center</h1>
         <p className="text-sm text-gray-600">
           Coordinate delivery motions, surface risk, and keep stakeholders aligned across TRS programs.
         </p>
-      </header>
+        </header>
 
-      {activeTab === "Overview" && (
+        {activeTab === "Overview" && (
         <div className="space-y-4">
           <Card className="p-4">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -102,26 +106,26 @@ export default function ProjectsPageClient({
                 <p className="text-xs text-gray-600">Snapshot of core initiatives and momentum.</p>
               </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">Active Projects</div>
                   <div className="mt-1 text-xl font-semibold text-black">{stats.active}</div>
-                  <div className="text-[11px] text-emerald-600">Live delivery</div>
+                  <div className="text-[11px] text-gray-600">Live delivery</div>
                 </div>
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">On Track</div>
                   <div className="mt-1 text-xl font-semibold text-black">{stats.onTrack}</div>
-                  <div className="text-[11px] text-emerald-600">Healthy projects</div>
+                  <div className="text-[11px] text-gray-600">Healthy projects</div>
                 </div>
-                <div className="rounded-lg bg-gray-50 p-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
                   <div className="text-[11px] uppercase tracking-wide text-gray-500">At Risk</div>
                   <div className="mt-1 text-xl font-semibold text-black">{stats.atRisk}</div>
-                  <div className="text-[11px] text-amber-600">Requires action</div>
+                  <div className="text-[11px] text-gray-600">Requires action</div>
                 </div>
               </div>
             </div>
             <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
               <table className="w-full text-sm">
-                <thead className="bg-gray-50 text-left text-[12px] uppercase tracking-wide text-gray-500">
+                <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
                   <tr>
                     <th className="px-3 py-2 font-medium">Project</th>
                     <th className="px-3 py-2 font-medium">Client</th>
@@ -149,10 +153,10 @@ export default function ProjectsPageClient({
                       <td
                         className={`px-3 py-2 text-sm ${
                           project.health === "green"
-                            ? "text-emerald-600"
+                            ? "text-gray-600"
                             : project.health === "yellow"
-                            ? "text-amber-600"
-                            : "text-rose-600"
+                            ? "text-gray-600"
+                            : "text-gray-600"
                         }`}
                       >
                         {project.health === "green" ? "On Track" : project.health === "yellow" ? "At Risk" : "Critical"}
@@ -228,7 +232,7 @@ export default function ProjectsPageClient({
             Ask the agent to analyze timelines, forecast budget impact, or surface risk across delivery tracks.
           </p>
           <div className="mt-4 space-y-3">
-            <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+            <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
               Prompt workspace placeholder
             </div>
             <div>
@@ -248,6 +252,7 @@ export default function ProjectsPageClient({
           </div>
         </Card>
       )}
+      </section>
     </div>
   );
 }

--- a/components/kit/TopTabs.tsx
+++ b/components/kit/TopTabs.tsx
@@ -10,16 +10,16 @@ export function TopTabs({ value, onChange }: { value: string; onChange: (v: stri
   const active = tabs.includes(value) ? value : tabs[0];
 
   return (
-    <div className="h-[44px] flex items-center gap-2">
+    <div className="flex h-[44px] items-center gap-2">
       {tabs.map((t) => (
         <button
           key={t}
           onClick={() => onChange(t)}
           className={cn(
-            "px-3 h-8 rounded-md text-sm border transition-colors",
+            "h-8 rounded-md border px-3 text-sm transition-colors",
             active === t
-              ? "bg-black text-white border-black"
-              : "bg-white text-gray-700 hover:bg-gray-100 border-gray-300",
+              ? "border-gray-900 bg-white font-semibold text-black"
+              : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-black",
           )}
         >
           {t}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -3,24 +3,22 @@
 import { Suspense } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { TopTabs } from "@/components/kit/TopTabs"
-import GlobalSidebar from "@/components/nav/GlobalSidebar"
 import GlobalHeader from "@/components/nav/GlobalHeader"
+import AdminSidebar from "@/components/nav/AdminSidebar"
 import { resolveTabs } from "@/lib/tabs"
-import AppFooter from "@/components/layout/AppFooter"
-import ChatWidget from "@/components/layout/ChatWidget"
+
+const HEADER_HEIGHT = 56
+const TABS_HEIGHT = 44
 
 export default function AppShell({ children, showTabs = true }: { children: React.ReactNode; showTabs?: boolean }) {
-  const TABS_H = 44
   const pathname = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
 
   const tabs = resolveTabs(pathname)
-  const activeTab = (() => {
-    const current = searchParams.get("tab") || tabs[0]
-    return tabs.includes(current) ? current : tabs[0]
-  })()
-  const tabsVisible = showTabs && !["/", "/morning"].includes(pathname)
+  const current = searchParams.get("tab") || tabs[0]
+  const activeTab = tabs.includes(current) ? current : tabs[0]
+  const tabsVisible = showTabs
 
   const handleTabChange = (next: string) => {
     const params = new URLSearchParams(searchParams.toString())
@@ -29,24 +27,25 @@ export default function AppShell({ children, showTabs = true }: { children: Reac
   }
 
   return (
-    <div className="relative w-full min-h-screen bg-white text-gray-900">
+    <div className="w-full min-h-screen bg-white text-black">
       <GlobalHeader />
-      <div className="flex" style={{ height: "calc(100vh - 56px)" }}>
-        <GlobalSidebar />
-        <main className="flex-1 flex flex-col overflow-hidden" style={{ height: "calc(100vh - 56px)" }}>
+      <div className="flex" style={{ height: `calc(100vh - ${HEADER_HEIGHT}px)` }}>
+        <AdminSidebar />
+        <main className="flex-1 overflow-hidden">
           {tabsVisible && (
-            <div className="px-3 border-b border-gray-200 flex items-center justify-between bg-white" style={{ height: TABS_H }}>
+            <div
+              className="flex items-center justify-between border-b border-gray-200 bg-white px-3"
+              style={{ height: TABS_HEIGHT }}
+            >
               <Suspense fallback={<div className="h-[44px]" />}>
                 <TopTabs value={activeTab} onChange={handleTabChange} />
               </Suspense>
               <div className="text-xs text-gray-600">Pick a date</div>
             </div>
           )}
-          <div className="flex-1 overflow-auto bg-white">{children}</div>
-          <AppFooter />
+          <div className="h-full overflow-auto bg-white">{children}</div>
         </main>
       </div>
-      <ChatWidget />
     </div>
   )
 }

--- a/components/nav/AdminSidebar.tsx
+++ b/components/nav/AdminSidebar.tsx
@@ -1,34 +1,57 @@
-"use client";
-import { PieChart, ListChecks, Users, Layers, BarChart2, Settings } from "lucide-react";
-import type React from "react";
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { BarChart2, Briefcase, FileText, PieChart, Settings, Users } from "lucide-react"
+
+const NAV_ITEMS = [
+  { label: "Dashboard", href: "/dashboard", icon: PieChart },
+  { label: "Pipeline", href: "/pipeline", icon: BarChart2 },
+  { label: "Clients", href: "/clients", icon: Users },
+  { label: "Content", href: "/content", icon: FileText },
+  { label: "Projects", href: "/projects", icon: Briefcase },
+  { label: "Settings", href: "/settings", icon: Settings },
+]
 
 export default function AdminSidebar() {
-  const Item = ({ label, icon }: { label: string; icon: React.ReactNode }) => (
-    <button className="w-full flex items-center gap-2 px-2 py-2 rounded-md text-sm hover:bg-gray-50">
-      <span className="inline-flex items-center justify-center h-6 w-6 rounded-md border text-gray-600">{icon}</span>
-      <span className="text-black">{label}</span>
-    </button>
-  );
+  const [open, setOpen] = useState(false)
+  const pathname = usePathname()
+
   return (
-    <aside className="hidden md:flex flex-col shrink-0" style={{ width: 232, borderRightWidth: 1, borderRightColor: "#e5e7eb" }}>
-      <nav className="p-2 text-sm">
-        <div className="px-2 py-1 text-[11px] uppercase tracking-wide text-gray-500">General</div>
-        <div className="space-y-1">
-          <Item label="Dashboard" icon={<PieChart size={14} />} />
-          <Item label="Tasks" icon={<ListChecks size={14} />} />
-          <Item label="Users" icon={<Users size={14} />} />
-        </div>
-        <div className="px-2 py-1 mt-3 text-[11px] uppercase tracking-wide text-gray-500">Pages</div>
-        <div className="space-y-1">
-          <Item label="Auth" icon={<Layers size={14} />} />
-          <Item label="Errors" icon={<BarChart2 size={14} />} />
-        </div>
-        <div className="px-2 py-1 mt-3 text-[11px] uppercase tracking-wide text-gray-500">Other</div>
-        <div className="space-y-1">
-          <Item label="Settings" icon={<Settings size={14} />} />
-          <Item label="Developers" icon={<Layers size={14} />} />
-        </div>
+    <aside
+      className={`relative hidden h-full shrink-0 border-r border-gray-200 bg-white transition-all duration-200 md:flex ${
+        open ? "w-56" : "w-14"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="absolute top-3 -right-3 z-10 flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white text-xs text-gray-600 hover:bg-gray-50"
+        aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
+      >
+        ≡
+      </button>
+      <nav className="flex w-full flex-col gap-1 p-2 text-sm">
+        {NAV_ITEMS.map((item) => {
+          const Icon = item.icon
+          const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-2 rounded-md px-2 py-2 transition-colors ${
+                active ? "border border-gray-200 bg-white text-black" : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <span className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-gray-200 text-gray-600">
+                <Icon size={14} />
+              </span>
+              {open && <span className="text-sm font-medium text-black">{item.label}</span>}
+            </Link>
+          )
+        })}
       </nav>
     </aside>
-  );
+  )
 }

--- a/components/nav/GlobalHeader.tsx
+++ b/components/nav/GlobalHeader.tsx
@@ -1,33 +1,28 @@
 "use client"
 
-import { Bell, Download, Search } from "lucide-react"
-import Image from "next/image"
+import { Bell, Search } from "lucide-react"
 
 export default function GlobalHeader() {
   return (
-    <header className="border-b border-gray-200 bg-white dark:bg-gray-950 dark:border-gray-800">
-      <div className="h-16 px-3 w-full flex items-center gap-3">
-        <div className="relative flex items-center h-10">
-          <Image
-            src="/images/trs-logo.png"
-            alt="The Revenue Scientists"
-            width={312}
-            height={50}
-            className="object-contain h-10 w-auto"
-            priority
-          />
+    <header className="border-b border-gray-200 bg-white">
+      <div className="flex h-14 w-full items-center justify-between px-3">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold uppercase tracking-wide text-gray-500">TRS</span>
+          <span className="text-base font-semibold text-black">Control Center</span>
         </div>
-        <div className="ml-2 flex items-center gap-2 h-9 px-3 rounded-lg border border-gray-200 dark:border-gray-800 flex-1 max-w-xl bg-white dark:bg-gray-900">
-          <Search size={16} className="text-gray-500 dark:text-gray-400" />
-          <input placeholder="Search accounts, deals…" className="flex-1 outline-none text-sm text-gray-900 dark:text-gray-100 bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-400" />
+        <div className="flex items-center gap-2 text-sm">
+          <div className="flex h-9 w-64 items-center gap-2 rounded-md border border-gray-200 bg-white px-3 text-sm">
+            <Search size={16} className="text-gray-500" />
+            <input
+              placeholder="Search"
+              className="h-full flex-1 border-none bg-transparent text-sm text-gray-700 outline-none placeholder:text-gray-500"
+            />
+          </div>
+          <button className="flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50">
+            <Bell size={16} />
+          </button>
+          <div className="h-9 w-9 rounded-full border border-gray-200 bg-white" />
         </div>
-        <button className="h-9 px-3 rounded-lg border border-gray-200 dark:border-gray-800 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors">
-          <Download size={16} /> Download
-        </button>
-        <button className="h-9 w-9 rounded-lg border border-gray-200 dark:border-gray-800 flex items-center justify-center text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors">
-          <Bell size={16} />
-        </button>
-        <button className="h-9 w-9 rounded-full bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors" aria-label="User menu" />
       </div>
     </header>
   )

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -9,18 +9,11 @@ export type NavItem = {
 }
 
 export const MAIN_NAV: NavItem[] = [
-  { label: "Morning briefing", href: "/", icon: "Sun", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Dashboard", href: "/dashboard", icon: "LayoutDashboard", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Pipeline", href: "/pipeline", icon: "TrendingUp", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Projects", href: "/projects", icon: "Kanban", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Content", href: "/content", icon: "FileText", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Mail & Calendar", href: "/mail-calendar", icon: "Mail", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Resources", href: "/resources", icon: "BookOpen", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Agents", href: "/agents", icon: "Bot", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
-  { label: "Finance", href: "/finance", icon: "Wallet", roles: ["SuperAdmin", "Admin", "Director"] },
-  { label: "Partners", href: "/partners", icon: "Handshake", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Clients", href: "/clients", icon: "Users", roles: ["SuperAdmin", "Admin", "Director", "Member", "Client"] },
-  { label: "Feature flags", href: "/admin/flags", icon: "Sliders", roles: ["SuperAdmin", "Admin"], flag: "ops" },
+  { label: "Content", href: "/content", icon: "FileText", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
+  { label: "Projects", href: "/projects", icon: "Kanban", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
   { label: "Settings", href: "/settings", icon: "Settings", roles: ["SuperAdmin", "Admin", "Director", "Member"] },
 ]
 


### PR DESCRIPTION
## Summary
- replace the global shell with the pipeline-style header, collapsible sidebar, and neutral tab bar so every route inherits the same chrome
- trim navigation items to the core destinations and restyle tabs, header, and theme for a light-only palette
- normalize dashboard, clients, projects, content, agents, and morning pages to the shared 12-column grid with white cards and grayscale accents

## Testing
- pnpm run typecheck *(fails: repository is missing optional OpenAI and Supabase packages)*
- pnpm run build *(fails: repository is missing optional OpenAI and Supabase packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e89c71b9908324aa37d883b7d814f7