### PR TITLE
feat: scaffold supabase edge functions and tables

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -345,3 +345,27 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+[functions]
+enabled = true
+source = "./supabase/functions"
+
+[[functions.functions]]
+name = "agent-dispatch"
+verify_jwt = true
+
+[[functions.functions]]
+name = "morning-brief"
+verify_jwt = true
+
+[[functions.functions]]
+name = "exec-dashboard-refresh"
+verify_jwt = true
+
+[[functions.functions]]
+name = "content-recommend"
+verify_jwt = true
+
+[[functions.functions]]
+name = "share-space-publish"
+verify_jwt = true

--- a/supabase/functions/agent-dispatch/index.ts
+++ b/supabase/functions/agent-dispatch/index.ts
@@ -1,0 +1,115 @@
+const allowedOrigins = new Set([
+  'https://trsrevos.vercel.app',
+  'http://localhost:3000',
+]);
+
+type AgentDispatchInput = {
+  agent_key: string;
+  user_id: string;
+  organization_id: string;
+  payload: Record<string, unknown>;
+};
+
+type AgentDispatchResponse = {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+function corsHeaders(origin: string | null) {
+  const resolvedOrigin = origin && allowedOrigins.has(origin)
+    ? origin
+    : 'https://trsrevos.vercel.app';
+
+  return new Headers({
+    'Access-Control-Allow-Origin': resolvedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
+    'Access-Control-Max-Age': '86400',
+    'Content-Type': 'application/json',
+  });
+}
+
+function respond(body: AgentDispatchResponse, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+function logRequest(req: Request, functionName: string) {
+  console.info(
+    JSON.stringify({
+      event: `${functionName}:request`,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      url: req.url,
+    }),
+  );
+}
+
+function isValidInput(payload: unknown): payload is AgentDispatchInput {
+  if (!payload || typeof payload !== 'object') return false;
+  const data = payload as Record<string, unknown>;
+  return (
+    typeof data.agent_key === 'string' &&
+    typeof data.user_id === 'string' &&
+    typeof data.organization_id === 'string' &&
+    typeof data.payload === 'object'
+  );
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const headers = corsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers });
+  }
+
+  logRequest(req, 'agent-dispatch');
+
+  if (req.method !== 'POST') {
+    return respond({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('agent-dispatch:invalid-json', error);
+    return respond({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+  }
+
+  if (!isValidInput(payload)) {
+    return respond({ ok: false, error: 'Missing required fields: agent_key, user_id, organization_id, payload' }, {
+      status: 400,
+      headers,
+    });
+  }
+
+  const { agent_key, user_id, organization_id, payload: agentPayload } = payload;
+
+  console.info(
+    JSON.stringify({
+      event: 'agent-dispatch:payload-received',
+      timestamp: new Date().toISOString(),
+      agent_key,
+      user_id,
+      organization_id,
+    }),
+  );
+
+  // TODO: look up agent configuration from agent_definitions & agent_behaviors tables.
+  // Example workflow:
+  // 1. Fetch agent definition: select * from agent_definitions where agent_key = $1 and organization_id = $2.
+  // 2. Persist new run in agent_runs table with payload & status placeholder.
+  // 3. Dispatch to downstream providers (openai:gpt-4o-mini, service_webhooks) based on behaviors.
+
+  const placeholderRun = {
+    agent_key,
+    organization_id,
+    status: 'queued',
+    referenced_tables: ['agent_runs', 'agent_definitions', 'agent_behaviors', 'clients', 'projects', 'content_items', 'events'],
+    payload: agentPayload,
+  };
+
+  return respond({ ok: true, data: placeholderRun }, { status: 200, headers });
+});

--- a/supabase/functions/content-recommend/index.ts
+++ b/supabase/functions/content-recommend/index.ts
@@ -1,0 +1,113 @@
+const allowedOrigins = new Set([
+  'https://trsrevos.vercel.app',
+  'http://localhost:3000',
+]);
+
+type ContentRecommendInput = {
+  organization_id: string;
+  persona: string;
+  stage: string;
+};
+
+type ContentRecommendResponse = {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+function corsHeaders(origin: string | null) {
+  const resolvedOrigin = origin && allowedOrigins.has(origin)
+    ? origin
+    : 'https://trsrevos.vercel.app';
+
+  return new Headers({
+    'Access-Control-Allow-Origin': resolvedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
+    'Access-Control-Max-Age': '86400',
+    'Content-Type': 'application/json',
+  });
+}
+
+function respond(body: ContentRecommendResponse, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+function logRequest(req: Request, functionName: string) {
+  console.info(
+    JSON.stringify({
+      event: `${functionName}:request`,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      url: req.url,
+    }),
+  );
+}
+
+function isValidInput(payload: unknown): payload is ContentRecommendInput {
+  if (!payload || typeof payload !== 'object') return false;
+  const data = payload as Record<string, unknown>;
+  return (
+    typeof data.organization_id === 'string' &&
+    typeof data.persona === 'string' &&
+    typeof data.stage === 'string'
+  );
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const headers = corsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers });
+  }
+
+  logRequest(req, 'content-recommend');
+
+  if (req.method !== 'POST') {
+    return respond({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('content-recommend:invalid-json', error);
+    return respond({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+  }
+
+  if (!isValidInput(payload)) {
+    return respond({ ok: false, error: 'Missing required fields: organization_id, persona, stage' }, {
+      status: 400,
+      headers,
+    });
+  }
+
+  const { organization_id, persona, stage } = payload;
+
+  console.info(
+    JSON.stringify({
+      event: 'content-recommend:payload-received',
+      timestamp: new Date().toISOString(),
+      organization_id,
+      persona,
+      stage,
+    }),
+  );
+
+  // TODO: rank candidate content from content_items, content_touches, content_metrics, media_projects.
+  // Example workflow:
+  // 1. Fetch engagement telemetry for persona/stage filter.
+  // 2. Score assets using analytics pipeline and openai:gpt-4o-mini for summary generation.
+  // 3. Return ordered recommendations with rationale and next-actions.
+
+  const placeholderRecommendations = {
+    requested_persona: persona,
+    requested_stage: stage,
+    organization_id,
+    referenced_tables: ['content_items', 'content_touches', 'content_metrics', 'media_projects'],
+    items: [],
+  };
+
+  return respond({ ok: true, data: placeholderRecommendations }, { status: 200, headers });
+});

--- a/supabase/functions/exec-dashboard-refresh/index.ts
+++ b/supabase/functions/exec-dashboard-refresh/index.ts
@@ -1,0 +1,120 @@
+const allowedOrigins = new Set([
+  'https://trsrevos.vercel.app',
+  'http://localhost:3000',
+]);
+
+type ExecDashboardRefreshInput = {
+  organization_id: string;
+  time_scope: string;
+  segment_filter?: Record<string, unknown>;
+};
+
+type ExecDashboardRefreshResponse = {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+function corsHeaders(origin: string | null) {
+  const resolvedOrigin = origin && allowedOrigins.has(origin)
+    ? origin
+    : 'https://trsrevos.vercel.app';
+
+  return new Headers({
+    'Access-Control-Allow-Origin': resolvedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
+    'Access-Control-Max-Age': '86400',
+    'Content-Type': 'application/json',
+  });
+}
+
+function respond(body: ExecDashboardRefreshResponse, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+function logRequest(req: Request, functionName: string) {
+  console.info(
+    JSON.stringify({
+      event: `${functionName}:request`,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      url: req.url,
+    }),
+  );
+}
+
+function isValidInput(payload: unknown): payload is ExecDashboardRefreshInput {
+  if (!payload || typeof payload !== 'object') return false;
+  const data = payload as Record<string, unknown>;
+  return typeof data.organization_id === 'string' && typeof data.time_scope === 'string';
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const headers = corsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers });
+  }
+
+  logRequest(req, 'exec-dashboard-refresh');
+
+  if (req.method !== 'POST') {
+    return respond({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('exec-dashboard-refresh:invalid-json', error);
+    return respond({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+  }
+
+  if (!isValidInput(payload)) {
+    return respond({ ok: false, error: 'Missing required fields: organization_id, time_scope' }, {
+      status: 400,
+      headers,
+    });
+  }
+
+  const { organization_id, time_scope, segment_filter } = payload;
+
+  console.info(
+    JSON.stringify({
+      event: 'exec-dashboard-refresh:payload-received',
+      timestamp: new Date().toISOString(),
+      organization_id,
+      time_scope,
+      segment_filter,
+    }),
+  );
+
+  // TODO: recompute metrics and persist snapshots.
+  // Required tables: dashboard_snapshots, clients, opportunities, invoices, cash_flow_entries,
+  // content_touches, ad_campaigns, projects, events.
+  // Example workflow:
+  // 1. Query analytics pipeline service for the latest metrics for the requested scope.
+  // 2. Upsert into dashboard_snapshots with computed_at timestamp and metrics payload.
+  // 3. Emit events/audit trail rows for traceability.
+
+  const placeholderSnapshot = {
+    organization_id,
+    time_scope,
+    segment_filter: segment_filter ?? {},
+    referenced_tables: [
+      'dashboard_snapshots',
+      'clients',
+      'opportunities',
+      'invoices',
+      'cash_flow_entries',
+      'content_touches',
+      'ad_campaigns',
+      'projects',
+      'events',
+    ],
+  };
+
+  return respond({ ok: true, data: placeholderSnapshot }, { status: 200, headers });
+});

--- a/supabase/functions/morning-brief/index.ts
+++ b/supabase/functions/morning-brief/index.ts
@@ -1,0 +1,119 @@
+const allowedOrigins = new Set([
+  'https://trsrevos.vercel.app',
+  'http://localhost:3000',
+]);
+
+type MorningBriefInput = {
+  user_id: string;
+  organization_id: string;
+  time_horizon?: string;
+};
+
+type MorningBriefResponse = {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+function corsHeaders(origin: string | null) {
+  const resolvedOrigin = origin && allowedOrigins.has(origin)
+    ? origin
+    : 'https://trsrevos.vercel.app';
+
+  return new Headers({
+    'Access-Control-Allow-Origin': resolvedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
+    'Access-Control-Max-Age': '86400',
+    'Content-Type': 'application/json',
+  });
+}
+
+function respond(body: MorningBriefResponse, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+function logRequest(req: Request, functionName: string) {
+  console.info(
+    JSON.stringify({
+      event: `${functionName}:request`,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      url: req.url,
+    }),
+  );
+}
+
+function isValidInput(payload: unknown): payload is MorningBriefInput {
+  if (!payload || typeof payload !== 'object') return false;
+  const data = payload as Record<string, unknown>;
+  return typeof data.user_id === 'string' && typeof data.organization_id === 'string';
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const headers = corsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers });
+  }
+
+  logRequest(req, 'morning-brief');
+
+  if (req.method !== 'POST') {
+    return respond({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('morning-brief:invalid-json', error);
+    return respond({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+  }
+
+  if (!isValidInput(payload)) {
+    return respond({ ok: false, error: 'Missing required fields: user_id, organization_id' }, {
+      status: 400,
+      headers,
+    });
+  }
+
+  const { user_id, organization_id, time_horizon } = payload;
+
+  console.info(
+    JSON.stringify({
+      event: 'morning-brief:payload-received',
+      timestamp: new Date().toISOString(),
+      user_id,
+      organization_id,
+      time_horizon,
+    }),
+  );
+
+  // TODO: assemble prioritized focus plan.
+  // Required tables: daily_plans, priority_items, focus_sessions, events, clients, opportunities,
+  // cash_flow_entries, projects.
+  // Example workflow:
+  // 1. Load latest daily_plan for user & organization.
+  // 2. Compute ROI/effort scoring referencing opportunities & cash_flow_entries.
+  // 3. Persist focus_sessions skeleton entries for the returned plan.
+
+  const placeholderBrief = {
+    schedule: [],
+    diagnostics: {
+      referenced_tables: [
+        'daily_plans',
+        'priority_items',
+        'focus_sessions',
+        'events',
+        'clients',
+        'opportunities',
+        'cash_flow_entries',
+        'projects',
+      ],
+    },
+  };
+
+  return respond({ ok: true, data: placeholderBrief }, { status: 200, headers });
+});

--- a/supabase/functions/share-space-publish/index.ts
+++ b/supabase/functions/share-space-publish/index.ts
@@ -1,0 +1,103 @@
+const allowedOrigins = new Set([
+  'https://trsrevos.vercel.app',
+  'http://localhost:3000',
+]);
+
+type ShareSpacePublishInput = {
+  share_id: string;
+  include_watermark?: boolean;
+};
+
+type ShareSpacePublishResponse = {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+function corsHeaders(origin: string | null) {
+  const resolvedOrigin = origin && allowedOrigins.has(origin)
+    ? origin
+    : 'https://trsrevos.vercel.app';
+
+  return new Headers({
+    'Access-Control-Allow-Origin': resolvedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
+    'Access-Control-Max-Age': '86400',
+    'Content-Type': 'application/json',
+  });
+}
+
+function respond(body: ShareSpacePublishResponse, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+function logRequest(req: Request, functionName: string) {
+  console.info(
+    JSON.stringify({
+      event: `${functionName}:request`,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      url: req.url,
+    }),
+  );
+}
+
+function isValidInput(payload: unknown): payload is ShareSpacePublishInput {
+  if (!payload || typeof payload !== 'object') return false;
+  const data = payload as Record<string, unknown>;
+  return typeof data.share_id === 'string';
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const headers = corsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers });
+  }
+
+  logRequest(req, 'share-space-publish');
+
+  if (req.method !== 'POST') {
+    return respond({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('share-space-publish:invalid-json', error);
+    return respond({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+  }
+
+  if (!isValidInput(payload)) {
+    return respond({ ok: false, error: 'Missing required field: share_id' }, { status: 400, headers });
+  }
+
+  const { share_id, include_watermark } = payload;
+
+  console.info(
+    JSON.stringify({
+      event: 'share-space-publish:payload-received',
+      timestamp: new Date().toISOString(),
+      share_id,
+      include_watermark,
+    }),
+  );
+
+  // TODO: assemble share space bundle and record audit trail.
+  // Required tables: share_spaces, share_space_artifacts, dashboard_snapshots, content_items, projects.
+  // Example workflow:
+  // 1. Load share_space metadata and eligible artifacts.
+  // 2. Generate signed URLs / apply watermark pipeline when include_watermark is true.
+  // 3. Insert audit_log entry capturing publish action and resulting artifact manifest.
+
+  const placeholderPublish = {
+    share_id,
+    include_watermark: include_watermark ?? false,
+    referenced_tables: ['share_spaces', 'share_space_artifacts', 'dashboard_snapshots', 'content_items', 'projects', 'audit_log'],
+  };
+
+  return respond({ ok: true, data: placeholderPublish }, { status: 200, headers });
+});

--- a/supabase/migrations/20251010061001_create_opportunity_notes.sql
+++ b/supabase/migrations/20251010061001_create_opportunity_notes.sql
@@ -1,0 +1,37 @@
+-- Migration: create opportunity_notes table and policies
+
+CREATE TABLE IF NOT EXISTS public.opportunity_notes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  opportunity_id UUID NOT NULL REFERENCES public.opportunities(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_opportunity_notes_opportunity_id
+  ON public.opportunity_notes(opportunity_id);
+
+ALTER TABLE public.opportunity_notes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "opportunity_notes_select"
+  ON public.opportunity_notes
+  FOR SELECT
+  USING (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "opportunity_notes_all"
+  ON public.opportunity_notes
+  FOR ALL
+  USING (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  )
+  WITH CHECK (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  );

--- a/supabase/migrations/20251010061002_create_client_health_history.sql
+++ b/supabase/migrations/20251010061002_create_client_health_history.sql
@@ -1,0 +1,39 @@
+-- Migration: create client_health_history table and policies
+
+CREATE TABLE IF NOT EXISTS public.client_health_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id UUID NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  snapshot_date DATE NOT NULL,
+  health INTEGER,
+  churn_risk INTEGER,
+  trs_score INTEGER,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_health_history_client_date
+  ON public.client_health_history(client_id, snapshot_date DESC);
+
+ALTER TABLE public.client_health_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "client_health_history_select"
+  ON public.client_health_history
+  FOR SELECT
+  USING (
+    client_id IN (
+      SELECT id FROM public.clients
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "client_health_history_write"
+  ON public.client_health_history
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (
+    auth.role() = 'service_role' OR public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "client_health_history_update"
+  ON public.client_health_history
+  FOR UPDATE
+  USING (auth.role() = 'service_role' OR public.is_admin())
+  WITH CHECK (auth.role() = 'service_role' OR public.is_admin());

--- a/supabase/migrations/20251010061003_create_project_updates.sql
+++ b/supabase/migrations/20251010061003_create_project_updates.sql
@@ -1,0 +1,39 @@
+-- Migration: create project_updates table and policies
+
+CREATE TABLE IF NOT EXISTS public.project_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  status TEXT,
+  summary TEXT,
+  risk_level TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_updates_project_id
+  ON public.project_updates(project_id DESC, created_at DESC);
+
+ALTER TABLE public.project_updates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "project_updates_select"
+  ON public.project_updates
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "project_updates_mutate"
+  ON public.project_updates
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  );

--- a/supabase/migrations/20251010061004_create_content_metrics.sql
+++ b/supabase/migrations/20251010061004_create_content_metrics.sql
@@ -1,0 +1,39 @@
+-- Migration: create content_metrics table and policies
+
+CREATE TABLE IF NOT EXISTS public.content_metrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  content_id UUID NOT NULL REFERENCES public.content_items(id) ON DELETE CASCADE,
+  metric_date DATE NOT NULL,
+  influenced NUMERIC(12,2),
+  advanced NUMERIC(12,2),
+  closed_won NUMERIC(12,2),
+  usage_rate NUMERIC(12,2),
+  views INTEGER,
+  ctr NUMERIC(6,3),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_metrics_content_date
+  ON public.content_metrics(content_id, metric_date DESC);
+
+ALTER TABLE public.content_metrics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "content_metrics_select"
+  ON public.content_metrics
+  FOR SELECT
+  USING (
+    content_id IN (
+      SELECT id FROM public.content_items
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "content_metrics_insert"
+  ON public.content_metrics
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY IF NOT EXISTS "content_metrics_update"
+  ON public.content_metrics
+  FOR UPDATE
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/20251010061005_create_media_assets.sql
+++ b/supabase/migrations/20251010061005_create_media_assets.sql
@@ -1,0 +1,38 @@
+-- Migration: create media_assets table and policies
+
+CREATE TABLE IF NOT EXISTS public.media_assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.media_projects(id) ON DELETE CASCADE,
+  asset_type TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_project_id
+  ON public.media_assets(project_id, created_at DESC);
+
+ALTER TABLE public.media_assets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "media_assets_select"
+  ON public.media_assets
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "media_assets_all"
+  ON public.media_assets
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  );

--- a/supabase/migrations/20251010061006_create_focus_sessions.sql
+++ b/supabase/migrations/20251010061006_create_focus_sessions.sql
@@ -1,0 +1,33 @@
+-- Migration: create focus_sessions table and policies
+
+CREATE TABLE IF NOT EXISTS public.focus_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  daily_plan_id UUID NOT NULL REFERENCES public.daily_plans(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  duration_minutes INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_focus_sessions_user_day
+  ON public.focus_sessions(user_id, daily_plan_id, started_at);
+
+ALTER TABLE public.focus_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "focus_sessions_select"
+  ON public.focus_sessions
+  FOR SELECT
+  USING (
+    user_id = auth.uid() OR public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "focus_sessions_mutate"
+  ON public.focus_sessions
+  FOR ALL
+  USING (
+    user_id = auth.uid() OR public.is_admin()
+  )
+  WITH CHECK (
+    user_id = auth.uid() OR public.is_admin()
+  );

--- a/supabase/migrations/20251010061007_create_analytics_events.sql
+++ b/supabase/migrations/20251010061007_create_analytics_events.sql
@@ -1,0 +1,33 @@
+-- Migration: create analytics_events table and policies
+
+CREATE TABLE IF NOT EXISTS public.analytics_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  event_key TEXT NOT NULL,
+  payload JSONB DEFAULT '{}'::jsonb,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_org_time
+  ON public.analytics_events(organization_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_key
+  ON public.analytics_events(event_key);
+
+ALTER TABLE public.analytics_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "analytics_events_select"
+  ON public.analytics_events
+  FOR SELECT
+  USING (
+    public.is_admin() OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY IF NOT EXISTS "analytics_events_insert"
+  ON public.analytics_events
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (
+    organization_id = public.user_organization_id() OR auth.role() = 'service_role'
+  );

--- a/supabase/migrations/20251010061008_create_audit_log.sql
+++ b/supabase/migrations/20251010061008_create_audit_log.sql
@@ -1,0 +1,32 @@
+-- Migration: create audit_log table and policies
+
+CREATE TABLE IF NOT EXISTS public.audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  actor_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id UUID,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_time
+  ON public.audit_log(organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_resource
+  ON public.audit_log(resource_type, resource_id);
+
+ALTER TABLE public.audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "audit_log_select"
+  ON public.audit_log
+  FOR SELECT
+  USING (
+    public.is_admin() OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY IF NOT EXISTS "audit_log_insert"
+  ON public.audit_log
+  FOR INSERT TO service_role
+  WITH CHECK (auth.role() = 'service_role');

--- a/supabase/migrations/20251010061009_create_agent_definitions.sql
+++ b/supabase/migrations/20251010061009_create_agent_definitions.sql
@@ -1,0 +1,33 @@
+-- Migration: create agent_definitions table and policies
+
+CREATE TABLE IF NOT EXISTS public.agent_definitions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_key TEXT UNIQUE NOT NULL,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  definition JSONB NOT NULL DEFAULT '{}'::jsonb,
+  auto_runnable BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_definitions_org_key
+  ON public.agent_definitions(organization_id, agent_key);
+
+ALTER TABLE public.agent_definitions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "agent_definitions_select"
+  ON public.agent_definitions
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "agent_definitions_all"
+  ON public.agent_definitions
+  FOR ALL
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  )
+  WITH CHECK (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );

--- a/supabase/migrations/20251010061010_create_agent_behaviors.sql
+++ b/supabase/migrations/20251010061010_create_agent_behaviors.sql
@@ -1,0 +1,32 @@
+-- Migration: create agent_behaviors table and policies
+
+CREATE TABLE IF NOT EXISTS public.agent_behaviors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_key TEXT NOT NULL REFERENCES public.agent_definitions(agent_key) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  behavior JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_behaviors_org_agent
+  ON public.agent_behaviors(organization_id, agent_key);
+
+ALTER TABLE public.agent_behaviors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "agent_behaviors_select"
+  ON public.agent_behaviors
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "agent_behaviors_all"
+  ON public.agent_behaviors
+  FOR ALL
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  )
+  WITH CHECK (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );

--- a/supabase/migrations/20251010061011_create_integration_settings.sql
+++ b/supabase/migrations/20251010061011_create_integration_settings.sql
@@ -1,0 +1,27 @@
+-- Migration: create integration_settings table and policies
+
+CREATE TABLE IF NOT EXISTS public.integration_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_settings_org
+  ON public.integration_settings(organization_id);
+
+ALTER TABLE public.integration_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "integration_settings_select"
+  ON public.integration_settings
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "integration_settings_all"
+  ON public.integration_settings
+  FOR ALL
+  USING (auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin()))
+  WITH CHECK (auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin()));

--- a/supabase/migrations/20251010061012_create_share_space_artifacts.sql
+++ b/supabase/migrations/20251010061012_create_share_space_artifacts.sql
@@ -1,0 +1,38 @@
+-- Migration: create share_space_artifacts table and policies
+
+CREATE TABLE IF NOT EXISTS public.share_space_artifacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  share_id UUID NOT NULL REFERENCES public.share_spaces(id) ON DELETE CASCADE,
+  artifact_type TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_space_artifacts_share_id
+  ON public.share_space_artifacts(share_id, created_at DESC);
+
+ALTER TABLE public.share_space_artifacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "share_space_artifacts_select"
+  ON public.share_space_artifacts
+  FOR SELECT
+  USING (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "share_space_artifacts_all"
+  ON public.share_space_artifacts
+  FOR ALL
+  USING (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  )
+  WITH CHECK (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  );

--- a/supabase/migrations/20251010061013_create_dashboard_snapshots.sql
+++ b/supabase/migrations/20251010061013_create_dashboard_snapshots.sql
@@ -1,0 +1,33 @@
+-- Migration: create dashboard_snapshots table and policies
+
+CREATE TABLE IF NOT EXISTS public.dashboard_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  time_scope TEXT NOT NULL,
+  segment_filter JSONB DEFAULT '{}'::jsonb,
+  metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_snapshots_org_scope
+  ON public.dashboard_snapshots(organization_id, time_scope, computed_at DESC);
+
+ALTER TABLE public.dashboard_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "dashboard_snapshots_select"
+  ON public.dashboard_snapshots
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "dashboard_snapshots_all"
+  ON public.dashboard_snapshots
+  FOR ALL
+  USING (
+    auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin())
+  )
+  WITH CHECK (
+    auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin())
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,479 @@
+-- Generated schema additions for new Supabase tables
+-- Source: docs/supabase-architecture-plan.json
+
+-- ================================================================
+-- opportunity_notes
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.opportunity_notes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  opportunity_id UUID NOT NULL REFERENCES public.opportunities(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_opportunity_notes_opportunity_id
+  ON public.opportunity_notes(opportunity_id);
+
+ALTER TABLE public.opportunity_notes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "opportunity_notes_select"
+  ON public.opportunity_notes
+  FOR SELECT
+  USING (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "opportunity_notes_all"
+  ON public.opportunity_notes
+  FOR ALL
+  USING (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  )
+  WITH CHECK (
+    opportunity_id IN (
+      SELECT id FROM public.opportunities
+    )
+  );
+
+-- ================================================================
+-- client_health_history
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.client_health_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id UUID NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  snapshot_date DATE NOT NULL,
+  health INTEGER,
+  churn_risk INTEGER,
+  trs_score INTEGER,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_health_history_client_date
+  ON public.client_health_history(client_id, snapshot_date DESC);
+
+ALTER TABLE public.client_health_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "client_health_history_select"
+  ON public.client_health_history
+  FOR SELECT
+  USING (
+    client_id IN (
+      SELECT id FROM public.clients
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "client_health_history_write"
+  ON public.client_health_history
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (
+    auth.role() = 'service_role' OR public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "client_health_history_update"
+  ON public.client_health_history
+  FOR UPDATE
+  USING (auth.role() = 'service_role' OR public.is_admin())
+  WITH CHECK (auth.role() = 'service_role' OR public.is_admin());
+
+-- ================================================================
+-- project_updates
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.project_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  status TEXT,
+  summary TEXT,
+  risk_level TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_updates_project_id
+  ON public.project_updates(project_id DESC, created_at DESC);
+
+ALTER TABLE public.project_updates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "project_updates_select"
+  ON public.project_updates
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "project_updates_mutate"
+  ON public.project_updates
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  );
+
+-- ================================================================
+-- content_metrics
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.content_metrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  content_id UUID NOT NULL REFERENCES public.content_items(id) ON DELETE CASCADE,
+  metric_date DATE NOT NULL,
+  influenced NUMERIC(12,2),
+  advanced NUMERIC(12,2),
+  closed_won NUMERIC(12,2),
+  usage_rate NUMERIC(12,2),
+  views INTEGER,
+  ctr NUMERIC(6,3),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_metrics_content_date
+  ON public.content_metrics(content_id, metric_date DESC);
+
+ALTER TABLE public.content_metrics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "content_metrics_select"
+  ON public.content_metrics
+  FOR SELECT
+  USING (
+    content_id IN (
+      SELECT id FROM public.content_items
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "content_metrics_insert"
+  ON public.content_metrics
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY IF NOT EXISTS "content_metrics_update"
+  ON public.content_metrics
+  FOR UPDATE
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- ================================================================
+-- media_assets
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.media_assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.media_projects(id) ON DELETE CASCADE,
+  asset_type TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_project_id
+  ON public.media_assets(project_id, created_at DESC);
+
+ALTER TABLE public.media_assets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "media_assets_select"
+  ON public.media_assets
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "media_assets_all"
+  ON public.media_assets
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.media_projects
+    )
+  );
+
+-- ================================================================
+-- focus_sessions
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.focus_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  daily_plan_id UUID NOT NULL REFERENCES public.daily_plans(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  duration_minutes INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_focus_sessions_user_day
+  ON public.focus_sessions(user_id, daily_plan_id, started_at);
+
+ALTER TABLE public.focus_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "focus_sessions_select"
+  ON public.focus_sessions
+  FOR SELECT
+  USING (
+    user_id = auth.uid() OR public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "focus_sessions_mutate"
+  ON public.focus_sessions
+  FOR ALL
+  USING (
+    user_id = auth.uid() OR public.is_admin()
+  )
+  WITH CHECK (
+    user_id = auth.uid() OR public.is_admin()
+  );
+
+-- ================================================================
+-- analytics_events
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.analytics_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  event_key TEXT NOT NULL,
+  payload JSONB DEFAULT '{}'::jsonb,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_org_time
+  ON public.analytics_events(organization_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_key
+  ON public.analytics_events(event_key);
+
+ALTER TABLE public.analytics_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "analytics_events_select"
+  ON public.analytics_events
+  FOR SELECT
+  USING (
+    public.is_admin() OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY IF NOT EXISTS "analytics_events_insert"
+  ON public.analytics_events
+  FOR INSERT TO authenticated, service_role
+  WITH CHECK (
+    organization_id = public.user_organization_id() OR auth.role() = 'service_role'
+  );
+
+-- ================================================================
+-- audit_log
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  actor_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id UUID,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_org_time
+  ON public.audit_log(organization_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_resource
+  ON public.audit_log(resource_type, resource_id);
+
+ALTER TABLE public.audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "audit_log_select"
+  ON public.audit_log
+  FOR SELECT
+  USING (
+    public.is_admin() OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY IF NOT EXISTS "audit_log_insert"
+  ON public.audit_log
+  FOR INSERT TO service_role
+  WITH CHECK (auth.role() = 'service_role');
+
+-- ================================================================
+-- agent_definitions
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.agent_definitions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_key TEXT UNIQUE NOT NULL,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  definition JSONB NOT NULL DEFAULT '{}'::jsonb,
+  auto_runnable BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_definitions_org_key
+  ON public.agent_definitions(organization_id, agent_key);
+
+ALTER TABLE public.agent_definitions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "agent_definitions_select"
+  ON public.agent_definitions
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "agent_definitions_all"
+  ON public.agent_definitions
+  FOR ALL
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  )
+  WITH CHECK (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );
+
+-- ================================================================
+-- agent_behaviors
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.agent_behaviors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_key TEXT NOT NULL REFERENCES public.agent_definitions(agent_key) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  behavior JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_behaviors_org_agent
+  ON public.agent_behaviors(organization_id, agent_key);
+
+ALTER TABLE public.agent_behaviors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "agent_behaviors_select"
+  ON public.agent_behaviors
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "agent_behaviors_all"
+  ON public.agent_behaviors
+  FOR ALL
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  )
+  WITH CHECK (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );
+
+-- ================================================================
+-- integration_settings
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.integration_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_settings_org
+  ON public.integration_settings(organization_id);
+
+ALTER TABLE public.integration_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "integration_settings_select"
+  ON public.integration_settings
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() AND public.is_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "integration_settings_all"
+  ON public.integration_settings
+  FOR ALL
+  USING (auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin()))
+  WITH CHECK (auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin()));
+
+-- ================================================================
+-- share_space_artifacts
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.share_space_artifacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  share_id UUID NOT NULL REFERENCES public.share_spaces(id) ON DELETE CASCADE,
+  artifact_type TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_space_artifacts_share_id
+  ON public.share_space_artifacts(share_id, created_at DESC);
+
+ALTER TABLE public.share_space_artifacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "share_space_artifacts_select"
+  ON public.share_space_artifacts
+  FOR SELECT
+  USING (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "share_space_artifacts_all"
+  ON public.share_space_artifacts
+  FOR ALL
+  USING (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  )
+  WITH CHECK (
+    share_id IN (
+      SELECT id FROM public.share_spaces
+    )
+  );
+
+-- ================================================================
+-- dashboard_snapshots
+-- ================================================================
+CREATE TABLE IF NOT EXISTS public.dashboard_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  time_scope TEXT NOT NULL,
+  segment_filter JSONB DEFAULT '{}'::jsonb,
+  metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_snapshots_org_scope
+  ON public.dashboard_snapshots(organization_id, time_scope, computed_at DESC);
+
+ALTER TABLE public.dashboard_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "dashboard_snapshots_select"
+  ON public.dashboard_snapshots
+  FOR SELECT
+  USING (
+    organization_id = public.user_organization_id() OR public.is_super_admin()
+  );
+
+CREATE POLICY IF NOT EXISTS "dashboard_snapshots_all"
+  ON public.dashboard_snapshots
+  FOR ALL
+  USING (
+    auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin())
+  )
+  WITH CHECK (
+    auth.role() = 'service_role' OR (organization_id = public.user_organization_id() AND public.is_admin())
+  );


### PR DESCRIPTION
## Summary
- scaffold agent-dispatch, morning-brief, exec-dashboard-refresh, content-recommend, and share-space-publish edge functions with CORS, logging, and placeholder payload handling
- append schema definitions and RLS policies for new analytics, agent, and sharing tables in supabase/schema.sql and create per-table migrations
- enable the new edge functions in Supabase config for future deployment

## Testing
- supabase functions serve --env-file supabase/.env.local *(fails: Supabase CLI is not available in the execution environment)*
- supabase functions deploy --all *(fails: Supabase CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8a27a75c88324a6489fb2dff9bc7c