### PR TITLE
Fix lucide icon lookup typing in admin sidebar

### DIFF
--- a/components/nav/AdminSidebar.tsx
+++ b/components/nav/AdminSidebar.tsx
@@ -32,7 +32,8 @@ export default function AdminSidebar() {
         {MAIN_NAV.map((item) => {
           if (!canSee(DEFAULT_ROLE, item.roles)) return null
 
-          const Icon = (Icons as Record<string, LucideIcon>)[item.icon] || Icons.Circle
+          const iconKey = item.icon as keyof typeof Icons
+          const Icon = (Icons[iconKey] as LucideIcon | undefined) ?? Icons.Circle
           const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
           return (
             <Link


### PR DESCRIPTION
## Summary
- adjust AdminSidebar icon lookup to avoid incompatible lucide-react index typing
- fall back to the Circle icon when a named icon is unavailable

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e8adbcf5f083248d8451f67f22e899