### PR TITLE
Fix Gmail API route prerender issues

### DIFF
--- a/app/api/gmail/messages/[id]/reply/route.ts
+++ b/app/api/gmail/messages/[id]/reply/route.ts
@@ -4,6 +4,8 @@ import { getGmailClient, persistOAuthCredentials, requireGmailContext } from '@/
 import { createRawEmail } from '@/lib/gmail/utils'
 import { mapGmailError } from '@/lib/gmail/errors'
 
+export const dynamic = 'force-dynamic'
+
 type RouteContext = {
   params: { id: string }
 }

--- a/app/api/gmail/messages/[id]/route.ts
+++ b/app/api/gmail/messages/[id]/route.ts
@@ -4,6 +4,8 @@ import { getGmailClient, persistOAuthCredentials, requireGmailContext } from '@/
 import { toMessageDetail } from '@/lib/gmail/messages'
 import { mapGmailError } from '@/lib/gmail/errors'
 
+export const dynamic = 'force-dynamic'
+
 type RouteContext = {
   params: { id: string }
 }

--- a/app/api/gmail/messages/route.ts
+++ b/app/api/gmail/messages/route.ts
@@ -5,6 +5,8 @@ import { getGmailClient, persistOAuthCredentials, requireGmailContext } from '@/
 import { toMessageSummary } from '@/lib/gmail/messages'
 import { mapGmailError } from '@/lib/gmail/errors'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     const { oauthClient, supabase, user, integration } = await requireGmailContext()

--- a/app/api/gmail/oauth/callback/route.ts
+++ b/app/api/gmail/oauth/callback/route.ts
@@ -10,8 +10,10 @@ import {
 
 const STATE_COOKIE = 'gmail_oauth_state'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
-  const appUrl = getAppUrl()
+  const appUrl = getAppUrl(request.nextUrl.origin)
   const url = new URL(request.url)
   const storedState = request.cookies.get(STATE_COOKIE)?.value
   const state = url.searchParams.get('state')

--- a/app/api/gmail/oauth/start/route.ts
+++ b/app/api/gmail/oauth/start/route.ts
@@ -1,16 +1,19 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 import { createOAuthClient, GMAIL_SCOPES, getAppUrl, getSupabaseUser } from '@/lib/gmail/server'
 
 const STATE_COOKIE = 'gmail_oauth_state'
 const STATE_TTL_SECONDS = 60 * 10
 
-export async function GET() {
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
   try {
     const { user } = await getSupabaseUser()
+    const appUrl = getAppUrl(request.nextUrl.origin)
 
     if (!user) {
-      const redirect = new URL('/settings/integrations?error=auth', getAppUrl())
+      const redirect = new URL('/settings/integrations?error=auth', appUrl)
       return NextResponse.redirect(redirect)
     }
 
@@ -39,7 +42,8 @@ export async function GET() {
     return response
   } catch (error) {
     console.error('Failed to initiate Gmail OAuth flow', error)
-    const redirect = new URL('/settings/integrations?error=oauth_start', getAppUrl())
+    const appUrl = getAppUrl(request.nextUrl.origin)
+    const redirect = new URL('/settings/integrations?error=oauth_start', appUrl)
     return NextResponse.redirect(redirect)
   }
 }

--- a/app/api/gmail/send/route.ts
+++ b/app/api/gmail/send/route.ts
@@ -4,6 +4,8 @@ import { getGmailClient, persistOAuthCredentials, requireGmailContext } from '@/
 import { createRawEmail } from '@/lib/gmail/utils'
 import { mapGmailError } from '@/lib/gmail/errors'
 
+export const dynamic = 'force-dynamic'
+
 type SendPayload = {
   to: string | string[]
   subject: string

--- a/lib/gmail/server.ts
+++ b/lib/gmail/server.ts
@@ -35,12 +35,32 @@ type SupabaseUserResult = {
   user: Awaited<ReturnType<SupabaseClient['auth']['getUser']>>['data']['user']
 }
 
-export function getAppUrl() {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL
-  if (!appUrl) {
-    throw new Error('NEXT_PUBLIC_APP_URL is not configured')
+function normalizeBaseUrl(url: string) {
+  if (!url) {
+    return url
   }
-  return appUrl
+
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`
+}
+
+export function getAppUrl(fallback?: string) {
+  const candidates = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.URL,
+    process.env.NEXT_PUBLIC_VERCEL_URL,
+    process.env.VERCEL_URL,
+    fallback,
+  ]
+
+  const resolved = candidates.find((value) => value && value.trim().length > 0)
+
+  if (resolved) {
+    return normalizeBaseUrl(resolved)
+  }
+
+  const defaultUrl = 'http://localhost:3000'
+  console.warn('NEXT_PUBLIC_APP_URL is not configured; defaulting to http://localhost:3000')
+  return defaultUrl
 }
 
 export function createOAuthClient() {


### PR DESCRIPTION
## Summary
- mark Gmail API routes as force dynamic to skip static rendering when using cookies
- relax app URL resolution to fall back to deployment origin when env vars are missing
- update Gmail OAuth routes to rely on the request origin during redirects

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9815da5d48324a7ecda3fd2598f49