### PR TITLE
Fix lint warnings for activity section and login screen

### DIFF
--- a/components/pipeline/ActivitySection.tsx
+++ b/components/pipeline/ActivitySection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useEffect, useTransition, useCallback } from "react";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Badge } from "@/ui/badge";
@@ -38,15 +38,15 @@ export function ActivitySection({ opportunityId, userId }: ActivitySectionProps)
     due_date: "",
   });
 
-  // Load activities
-  useEffect(() => {
-    loadActivities();
-  }, [opportunityId]);
-
-  const loadActivities = async () => {
+  const loadActivities = useCallback(async () => {
     const data = await getOpportunityActivities(opportunityId);
     setActivities(data);
-  };
+  }, [opportunityId]);
+
+  // Load activities
+  useEffect(() => {
+    void loadActivities();
+  }, [loadActivities]);
 
   const handleAdd = () => {
     if (!formData.title.trim()) return;

--- a/components/ui/login-1.tsx
+++ b/components/ui/login-1.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import Image from "next/image"
 import { useRouter } from "next/navigation"
 import type { ChangeEvent, FormEvent } from "react"
 
@@ -117,7 +118,14 @@ export default function LoginScreen() {
       <div className="flex-1 bg-gray-50 flex items-center justify-center p-12">
         <div className="w-full max-w-md">
           <div className="text-center mb-8">
-            <img src="/images/trs_main_logo.png" alt="TRS Logo" className="w-[175px] h-[175px] mx-auto mb-4" />
+            <Image
+              src="/images/trs_main_logo.png"
+              alt="TRS Logo"
+              width={175}
+              height={175}
+              className="h-[175px] w-[175px] mx-auto mb-4"
+              priority
+            />
             <h2 className="text-3xl font-bold text-gray-900 mb-2">
               {isLogin ? "Welcome Back" : "Join Us Today"}
             </h2>


### PR DESCRIPTION
## Summary
- wrap the activity loader in a memoized callback and depend on it inside useEffect to satisfy hook linting
- replace the login logo <img> tag with the Next.js Image component for better LCP and lint compliance

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9bee86f088324a7c792377fc974b3