### PR TITLE
fix: align page template badge variants

### DIFF
--- a/app/pipeline/PipelineClient.tsx
+++ b/app/pipeline/PipelineClient.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { PageTemplate } from "@/components/layout/PageTemplate";
+import type { PageTemplateBadge } from "@/components/layout/PageTemplate";
 import { AddProspectModal } from "@/components/pipeline/AddProspectModal";
 import { PipelineFilters } from "@/components/pipeline/PipelineFilters";
 import { PipelineKanban } from "@/components/pipeline/PipelineKanban";
@@ -78,7 +79,7 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
     });
   }, [opportunities]);
 
-  const headerBadges = useMemo(
+  const headerBadges = useMemo<PageTemplateBadge[]>(
     () => [
       { label: "Quarterly target $1.2M" },
       {
@@ -87,7 +88,7 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
       },
       {
         label: `${recentlyMovedDeals.length} moved this week`,
-        variant: "default" as const,
+        variant: "default",
       },
     ],
     [atRiskDeals.length, recentlyMovedDeals.length],

--- a/components/settings/SettingsPageClient.tsx
+++ b/components/settings/SettingsPageClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { PageTemplate } from "@/components/layout/PageTemplate"
+import type { PageTemplateBadge } from "@/components/layout/PageTemplate"
 import { AgentManager } from "@/components/settings/AgentManager"
 import { FeatureFlags } from "@/components/settings/FeatureFlags"
 import { IntegrationsForm } from "@/components/settings/IntegrationsForm"
@@ -32,9 +33,9 @@ export function SettingsPageClient({
 
   const tabs = ["Agents", "Appearance", "Integrations", "Feature Flags", "Behavior"]
 
-  const headerBadges = useMemo(
+  const headerBadges = useMemo<PageTemplateBadge[]>(
     () => [
-      { label: `${agents.length} agents configured`, variant: "default" as const },
+      { label: `${agents.length} agents configured`, variant: "default" },
       {
         label: featureFlagServiceAvailable ? "Feature flags connected" : "Feature flags offline",
         variant: featureFlagServiceAvailable ? "success" : "outline",


### PR DESCRIPTION
## Summary
- ensure the pipeline header badges use the PageTemplateBadge variant contract
- annotate settings header badges with PageTemplateBadge to keep variant literals narrow

## Testing
- pnpm typecheck *(fails: missing @radix-ui/react-tabs and @slack/web-api type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c046b73083249149b3c0ff7b63ef