### PR TITLE
feat: unify page tab navigation

### DIFF
--- a/app/clients/[id]/ClientDetailView.tsx
+++ b/app/clients/[id]/ClientDetailView.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
 import ClientTabs from "@/components/clients/ClientTabs";
+import { PageTabs } from "@/components/layout/PageTabs";
 import { resolveTabs } from "@/lib/tabs";
 import { getContentPiecesByClient } from "@/core/content/store";
 import type {
@@ -49,7 +50,19 @@ export default function ClientDetailView({
     return current && tabs.includes(current) ? current : tabs[0];
   }, [searchParams, tabs]);
 
-  const clientContent = useMemo(() => getContentPiecesByClient(client.id), [client.id]);
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
+  const clientContent = useMemo(
+    () => getContentPiecesByClient(client.id),
+    [client.id],
+  );
 
   return (
     <div className="flex h-full flex-col bg-white">
@@ -57,10 +70,15 @@ export default function ClientDetailView({
         <header className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="space-y-2">
-              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Client Profile</div>
-              <h1 className="text-2xl font-semibold text-black">{client.name}</h1>
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Client Profile
+              </div>
+              <h1 className="text-2xl font-semibold text-black">
+                {client.name}
+              </h1>
               <p className="text-sm text-gray-600">
-                {client.segment} • {client.industry ?? "—"} • Owner {client.owner}
+                {client.segment} • {client.industry ?? "—"} • Owner{" "}
+                {client.owner}
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2 text-sm">
@@ -80,6 +98,8 @@ export default function ClientDetailView({
               "Command center view of deliverables, financial performance, and revenue programs for this account."}
           </p>
         </header>
+
+        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
 
         <div className="flex min-h-0 flex-1">
           <ClientTabs

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,58 +1,97 @@
-"use client"
+"use client";
 
-import { useMemo, useState } from "react"
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { Badge } from "@/ui/badge"
-import { Button } from "@/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { Input } from "@/ui/input"
-import { PageDescription, PageTitle } from "@/ui/page-header"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/ui/table"
-import { cn } from "@/lib/utils"
-import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style"
-import { resolveTabs } from "@/lib/tabs"
-import { getClients, getClientStats } from "@/core/clients/store"
+import { PageTabs } from "@/components/layout/PageTabs";
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import { Input } from "@/ui/input";
+import { PageDescription, PageTitle } from "@/ui/page-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/table";
+import { cn } from "@/lib/utils";
+import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style";
+import { resolveTabs } from "@/lib/tabs";
+import { getClients, getClientStats } from "@/core/clients/store";
 
 const healthLabel = (value: number) => {
-  if (value >= 80) return { label: "Healthy", tone: "success" as const }
-  if (value >= 60) return { label: "Monitoring", tone: "default" as const }
-  return { label: "At risk", tone: "outline" as const }
-}
+  if (value >= 80) return { label: "Healthy", tone: "success" as const };
+  if (value >= 60) return { label: "Monitoring", tone: "default" as const };
+  return { label: "At risk", tone: "outline" as const };
+};
 
-const formatCurrency = (value?: number) => (value != null ? `$${value.toLocaleString()}` : "—")
+const formatCurrency = (value?: number) =>
+  value != null ? `$${value.toLocaleString()}` : "—";
 
 export default function ClientsPage() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
 
-  const router = useRouter()
-  const clients = useMemo(() => getClients(), [])
-  const stats = useMemo(() => getClientStats(), [])
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
 
-  const [search, setSearch] = useState("")
-  const [segmentFilter, setSegmentFilter] = useState("all")
-  const [ownerFilter, setOwnerFilter] = useState("all")
-  const [sortBy, setSortBy] = useState("arr-desc")
+  const router = useRouter();
+  const clients = useMemo(() => getClients(), []);
+  const stats = useMemo(() => getClientStats(), []);
 
-  const segments = useMemo(() => Array.from(new Set(clients.map((client) => client.segment))), [clients])
-  const owners = useMemo(() => Array.from(new Set(clients.map((client) => client.owner))), [clients])
+  const [search, setSearch] = useState("");
+  const [segmentFilter, setSegmentFilter] = useState("all");
+  const [ownerFilter, setOwnerFilter] = useState("all");
+  const [sortBy, setSortBy] = useState("arr-desc");
 
-  const totalArr = clients.reduce((sum, client) => sum + (client.arr ?? 0), 0)
+  const segments = useMemo(
+    () => Array.from(new Set(clients.map((client) => client.segment))),
+    [clients],
+  );
+  const owners = useMemo(
+    () => Array.from(new Set(clients.map((client) => client.owner))),
+    [clients],
+  );
+
+  const totalArr = clients.reduce((sum, client) => sum + (client.arr ?? 0), 0);
   const expansionPipeline = clients.reduce(
-    (sum, client) => sum + client.opportunities.reduce((value, opportunity) => value + (opportunity.amount ?? 0), 0),
+    (sum, client) =>
+      sum +
+      client.opportunities.reduce(
+        (value, opportunity) => value + (opportunity.amount ?? 0),
+        0,
+      ),
     0,
-  )
+  );
   const upcomingQbrs = clients
     .filter((client) => client.qbrDate)
-    .sort((a, b) => new Date(a.qbrDate ?? "").getTime() - new Date(b.qbrDate ?? "").getTime())
-  const outstandingInvoices = clients
-    .flatMap((client) =>
+    .sort(
+      (a, b) =>
+        new Date(a.qbrDate ?? "").getTime() -
+        new Date(b.qbrDate ?? "").getTime(),
+    );
+  const outstandingInvoices = clients.flatMap(
+    (client) =>
       client.invoices
         ?.filter((invoice) => invoice.status !== "Paid")
         .map((invoice) => ({
@@ -60,203 +99,687 @@ export default function ClientsPage() {
           clientName: client.name,
           clientId: client.id,
         })) ?? [],
-    )
+  );
 
   const filteredClients = useMemo(() => {
-    let list = clients
+    let list = clients;
 
     if (search.trim()) {
-      const term = search.trim().toLowerCase()
+      const term = search.trim().toLowerCase();
       list = list.filter(
         (client) =>
           client.name.toLowerCase().includes(term) ||
           (client.industry ?? "").toLowerCase().includes(term) ||
           (client.owner ?? "").toLowerCase().includes(term),
-      )
+      );
     }
 
     if (segmentFilter !== "all") {
-      list = list.filter((client) => client.segment === segmentFilter)
+      list = list.filter((client) => client.segment === segmentFilter);
     }
 
     if (ownerFilter !== "all") {
-      list = list.filter((client) => client.owner === ownerFilter)
+      list = list.filter((client) => client.owner === ownerFilter);
     }
 
     return [...list].sort((a, b) => {
       switch (sortBy) {
         case "arr-asc":
-          return (a.arr ?? 0) - (b.arr ?? 0)
+          return (a.arr ?? 0) - (b.arr ?? 0);
         case "health-desc":
-          return (b.health ?? 0) - (a.health ?? 0)
+          return (b.health ?? 0) - (a.health ?? 0);
         case "health-asc":
-          return (a.health ?? 0) - (b.health ?? 0)
+          return (a.health ?? 0) - (b.health ?? 0);
         case "name-asc":
-          return a.name.localeCompare(b.name)
+          return a.name.localeCompare(b.name);
         case "name-desc":
-          return b.name.localeCompare(a.name)
+          return b.name.localeCompare(a.name);
         default:
-          return (b.arr ?? 0) - (a.arr ?? 0)
+          return (b.arr ?? 0) - (a.arr ?? 0);
       }
-    })
-  }, [clients, search, segmentFilter, ownerFilter, sortBy])
+    });
+  }, [clients, search, segmentFilter, ownerFilter, sortBy]);
 
   const dataCoverage = useMemo(() => {
-    const totals = { collected: 0, available: 0, missing: 0 }
+    const totals = { collected: 0, available: 0, missing: 0 };
     clients.forEach((client) => {
       client.data.forEach((source) => {
-        if (source.status === "Collected") totals.collected += 1
-        else if (source.status === "Available") totals.available += 1
-        else totals.missing += 1
-      })
-    })
-    return totals
-  }, [clients])
+        if (source.status === "Collected") totals.collected += 1;
+        else if (source.status === "Available") totals.available += 1;
+        else totals.missing += 1;
+      });
+    });
+    return totals;
+  }, [clients]);
 
-  const churnSignals = useMemo(() => clients.filter((client) => (client.churnRisk ?? 0) >= 15), [clients])
+  const churnSignals = useMemo(
+    () => clients.filter((client) => (client.churnRisk ?? 0) >= 15),
+    [clients],
+  );
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
       <section className="space-y-3">
         <div className="space-y-1">
-          <PageTitle className="text-xl font-semibold text-black">Client Portfolio</PageTitle>
+          <PageTitle className="text-xl font-semibold text-black">
+            Client Portfolio
+          </PageTitle>
           <PageDescription className="text-sm text-gray-500">
-            Full-funnel visibility into active customers, health trends, and expansion momentum across TRS RevenueOS.
+            Full-funnel visibility into active customers, health trends, and
+            expansion momentum across TRS RevenueOS.
           </PageDescription>
         </div>
 
+        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
-        <Card className={cn(TRS_CARD)}>
-          <CardContent className="p-4 space-y-2">
-            <div className={TRS_SUBTITLE}>Portfolio ARR</div>
-            <div className="text-2xl font-semibold text-black">{formatCurrency(totalArr)}</div>
-            <div className="text-xs text-gray-600">Across {clients.length} active clients</div>
-          </CardContent>
-        </Card>
-        <Card className={cn(TRS_CARD)}>
-          <CardContent className="p-4 space-y-2">
-            <div className={TRS_SUBTITLE}>Average Health</div>
-            <div className="text-2xl font-semibold text-black">{stats.avgHealth}%</div>
-            <div className="text-xs text-gray-600">{stats.atRisk} accounts monitored closely</div>
-          </CardContent>
-        </Card>
-        <Card className={cn(TRS_CARD)}>
-          <CardContent className="p-4 space-y-2">
-            <div className={TRS_SUBTITLE}>Expansion Pipeline</div>
-            <div className="text-2xl font-semibold text-black">{formatCurrency(expansionPipeline)}</div>
-            <div className="text-xs text-gray-600">{stats.expansions} active expansion motions</div>
-          </CardContent>
-        </Card>
-        <Card className={cn(TRS_CARD)}>
-          <CardContent className="p-4 space-y-2">
-            <div className={TRS_SUBTITLE}>Upcoming QBRs</div>
-            <div className="text-2xl font-semibold text-black">{upcomingQbrs.slice(0, 3).length}</div>
-            <div className="text-xs text-gray-600">within the next 45 days</div>
-          </CardContent>
-        </Card>
-      </div>
+          <Card className={cn(TRS_CARD)}>
+            <CardContent className="p-4 space-y-2">
+              <div className={TRS_SUBTITLE}>Portfolio ARR</div>
+              <div className="text-2xl font-semibold text-black">
+                {formatCurrency(totalArr)}
+              </div>
+              <div className="text-xs text-gray-600">
+                Across {clients.length} active clients
+              </div>
+            </CardContent>
+          </Card>
+          <Card className={cn(TRS_CARD)}>
+            <CardContent className="p-4 space-y-2">
+              <div className={TRS_SUBTITLE}>Average Health</div>
+              <div className="text-2xl font-semibold text-black">
+                {stats.avgHealth}%
+              </div>
+              <div className="text-xs text-gray-600">
+                {stats.atRisk} accounts monitored closely
+              </div>
+            </CardContent>
+          </Card>
+          <Card className={cn(TRS_CARD)}>
+            <CardContent className="p-4 space-y-2">
+              <div className={TRS_SUBTITLE}>Expansion Pipeline</div>
+              <div className="text-2xl font-semibold text-black">
+                {formatCurrency(expansionPipeline)}
+              </div>
+              <div className="text-xs text-gray-600">
+                {stats.expansions} active expansion motions
+              </div>
+            </CardContent>
+          </Card>
+          <Card className={cn(TRS_CARD)}>
+            <CardContent className="p-4 space-y-2">
+              <div className={TRS_SUBTITLE}>Upcoming QBRs</div>
+              <div className="text-2xl font-semibold text-black">
+                {upcomingQbrs.slice(0, 3).length}
+              </div>
+              <div className="text-xs text-gray-600">
+                within the next 45 days
+              </div>
+            </CardContent>
+          </Card>
+        </div>
 
-      {activeTab === "Overview" && (
-        <div className="space-y-4">
-          <Card className={cn(TRS_CARD, "p-4 space-y-4")}> 
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div className="space-y-1">
-                <PageTitle className="text-lg font-semibold text-black">Customer Health Command Center</PageTitle>
-                <PageDescription className="text-sm text-gray-500">
-                  Blend renewal signals, enablement gaps, and expansion bets into one decisive view.
-                </PageDescription>
+        {activeTab === "Overview" && (
+          <div className="space-y-4">
+            <Card className={cn(TRS_CARD, "p-4 space-y-4")}>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                  <PageTitle className="text-lg font-semibold text-black">
+                    Customer Health Command Center
+                  </PageTitle>
+                  <PageDescription className="text-sm text-gray-500">
+                    Blend renewal signals, enablement gaps, and expansion bets
+                    into one decisive view.
+                  </PageDescription>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => router.push("/partners")}
+                  >
+                    Sync partners
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => router.push("/projects")}
+                  >
+                    Open delivery board
+                  </Button>
+                </div>
               </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button variant="outline" size="sm" onClick={() => router.push("/partners")}>Sync partners</Button>
-                <Button variant="outline" size="sm" onClick={() => router.push("/projects")}>Open delivery board</Button>
-              </div>
-            </div>
 
-            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-              <div className="rounded-lg border border-gray-200 bg-white p-3">
-                <div className={TRS_SECTION_TITLE}>Health spotlight</div>
-                <ul className="mt-3 space-y-2 text-sm text-gray-700">
-                  {clients
-                    .slice()
-                    .sort((a, b) => (a.health ?? 0) - (b.health ?? 0))
-                    .slice(0, 3)
-                    .map((client) => (
-                      <li key={client.id} className="flex items-center justify-between">
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
+                  <div className={TRS_SECTION_TITLE}>Health spotlight</div>
+                  <ul className="mt-3 space-y-2 text-sm text-gray-700">
+                    {clients
+                      .slice()
+                      .sort((a, b) => (a.health ?? 0) - (b.health ?? 0))
+                      .slice(0, 3)
+                      .map((client) => (
+                        <li
+                          key={client.id}
+                          className="flex items-center justify-between"
+                        >
+                          <div>
+                            <div className="font-medium text-black">
+                              {client.name}
+                            </div>
+                            <div className="text-xs text-gray-500">
+                              Owner {client.owner}
+                            </div>
+                          </div>
+                          <Badge variant={healthLabel(client.health ?? 0).tone}>
+                            {client.health}%
+                          </Badge>
+                        </li>
+                      ))}
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
+                  <div className={TRS_SECTION_TITLE}>Next 30 days</div>
+                  <ul className="mt-3 space-y-2 text-sm text-gray-700">
+                    {upcomingQbrs.slice(0, 4).map((client) => (
+                      <li
+                        key={client.id}
+                        className="flex items-center justify-between"
+                      >
                         <div>
-                          <div className="font-medium text-black">{client.name}</div>
-                          <div className="text-xs text-gray-500">Owner {client.owner}</div>
-                        </div>
-                        <Badge variant={healthLabel(client.health ?? 0).tone}>{client.health}%</Badge>
-                      </li>
-                    ))}
-                </ul>
-              </div>
-              <div className="rounded-lg border border-gray-200 bg-white p-3">
-                <div className={TRS_SECTION_TITLE}>Next 30 days</div>
-                <ul className="mt-3 space-y-2 text-sm text-gray-700">
-                  {upcomingQbrs.slice(0, 4).map((client) => (
-                    <li key={client.id} className="flex items-center justify-between">
-                      <div>
-                        <div className="font-medium text-black">{client.name}</div>
-                        <div className="text-xs text-gray-500">QBR • {client.phase}</div>
-                      </div>
-                      <span className="text-xs text-gray-600">
-                        {new Date(client.qbrDate ?? "").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="rounded-lg border border-gray-200 bg-white p-3">
-                <div className={TRS_SECTION_TITLE}>Expansion focus</div>
-                <div className="mt-3 space-y-2 text-sm text-gray-700">
-                  {clients
-                    .filter((client) => client.isExpansion)
-                    .slice(0, 3)
-                    .map((client) => (
-                      <div key={client.id} className="flex items-center justify-between">
-                        <div>
-                          <div className="font-medium text-black">{client.name}</div>
+                          <div className="font-medium text-black">
+                            {client.name}
+                          </div>
                           <div className="text-xs text-gray-500">
-                            {client.opportunities[0]?.stage ?? "Discovery"} • {client.opportunities[0]?.name ?? "Expansion"}
+                            QBR • {client.phase}
                           </div>
                         </div>
                         <span className="text-xs text-gray-600">
-                          {formatCurrency(client.opportunities[0]?.amount)}
+                          {new Date(client.qbrDate ?? "").toLocaleDateString(
+                            "en-US",
+                            { month: "short", day: "numeric" },
+                          )}
                         </span>
-                      </div>
+                      </li>
                     ))}
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-gray-200 bg-white p-3">
+                  <div className={TRS_SECTION_TITLE}>Expansion focus</div>
+                  <div className="mt-3 space-y-2 text-sm text-gray-700">
+                    {clients
+                      .filter((client) => client.isExpansion)
+                      .slice(0, 3)
+                      .map((client) => (
+                        <div
+                          key={client.id}
+                          className="flex items-center justify-between"
+                        >
+                          <div>
+                            <div className="font-medium text-black">
+                              {client.name}
+                            </div>
+                            <div className="text-xs text-gray-500">
+                              {client.opportunities[0]?.stage ?? "Discovery"} •{" "}
+                              {client.opportunities[0]?.name ?? "Expansion"}
+                            </div>
+                          </div>
+                          <span className="text-xs text-gray-600">
+                            {formatCurrency(client.opportunities[0]?.amount)}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
                 </div>
               </div>
-            </div>
-          </Card>
+            </Card>
 
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+              <Card className={cn(TRS_CARD)}>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium">
+                    Outstanding invoices
+                  </CardTitle>
+                  <CardDescription>
+                    Cash flow watchlist across the portfolio.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {outstandingInvoices.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-600">
+                      No invoices outstanding.
+                    </div>
+                  ) : (
+                    outstandingInvoices.map((invoice) => (
+                      <div
+                        key={invoice.id}
+                        className="rounded-lg border border-gray-200 bg-white p-3"
+                      >
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="font-semibold text-black">
+                            {invoice.clientName}
+                          </span>
+                          <span className="text-xs text-gray-500">
+                            {invoice.status}
+                          </span>
+                        </div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          Invoice {invoice.id}
+                        </div>
+                        <div className="mt-2 flex items-center justify-between text-sm text-gray-700">
+                          <span>{formatCurrency(invoice.amount)}</span>
+                          {invoice.dueAt && (
+                            <span>
+                              Due{" "}
+                              {new Date(invoice.dueAt).toLocaleDateString(
+                                "en-US",
+                                { month: "short", day: "numeric" },
+                              )}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card className={cn(TRS_CARD)}>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium">
+                    Data coverage
+                  </CardTitle>
+                  <CardDescription>
+                    Ensure every client powers the RevOS decision loop.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-3">
+                    {["collected", "available", "missing"].map((band) => (
+                      <div key={band} className="flex items-center gap-3">
+                        <div className="w-20 text-xs font-semibold uppercase text-gray-400">
+                          {band}
+                        </div>
+                        <div className="flex-1">
+                          <div className="h-2 rounded-full bg-gray-100">
+                            <div
+                              className={`h-full ${
+                                band === "collected"
+                                  ? "bg-gray-900"
+                                  : band === "available"
+                                    ? "bg-gray-700"
+                                    : "bg-gray-500"
+                              }`}
+                              style={{
+                                width: `${
+                                  dataCoverage.collected +
+                                  dataCoverage.available +
+                                  dataCoverage.missing
+                                    ? (dataCoverage[
+                                        band as keyof typeof dataCoverage
+                                      ] /
+                                        (dataCoverage.collected +
+                                          dataCoverage.available +
+                                          dataCoverage.missing)) *
+                                      100
+                                    : 0
+                                }%`,
+                              }}
+                            />
+                          </div>
+                        </div>
+                        <div className="w-10 text-right text-xs text-gray-500">
+                          {dataCoverage[band as keyof typeof dataCoverage]}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-sm text-gray-600">
+                    Rally data integrations ahead of QBRs so every renewal
+                    conversation is grounded in performance proof.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        )}
+
+        {activeTab === "Accounts" && (
+          <Card className={cn(TRS_CARD)}>
+            <CardHeader>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <CardTitle>Client accounts</CardTitle>
+                  <CardDescription>
+                    Sort by health, ARR, or owner to plan your touchpoints.
+                  </CardDescription>
+                </div>
+                <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                  <Input
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search by name, owner, or industry"
+                    className="h-9 md:w-72"
+                  />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <select
+                      value={segmentFilter}
+                      onChange={(event) => setSegmentFilter(event.target.value)}
+                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
+                    >
+                      <option value="all">All Segments</option>
+                      {segments.map((segment) => (
+                        <option key={segment} value={segment}>
+                          {segment}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      value={ownerFilter}
+                      onChange={(event) => setOwnerFilter(event.target.value)}
+                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
+                    >
+                      <option value="all">All Owners</option>
+                      {owners.map((owner) => (
+                        <option key={owner} value={owner}>
+                          {owner}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      value={sortBy}
+                      onChange={(event) => setSortBy(event.target.value)}
+                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
+                    >
+                      <option value="arr-desc">ARR (High to Low)</option>
+                      <option value="arr-asc">ARR (Low to High)</option>
+                      <option value="health-desc">Health (High to Low)</option>
+                      <option value="health-asc">Health (Low to High)</option>
+                      <option value="name-asc">Name (A-Z)</option>
+                      <option value="name-desc">Name (Z-A)</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Client</TableHead>
+                    <TableHead>Owner</TableHead>
+                    <TableHead>Segment</TableHead>
+                    <TableHead>Phase</TableHead>
+                    <TableHead className="text-right">ARR</TableHead>
+                    <TableHead className="text-right">Health</TableHead>
+                    <TableHead className="text-right">Churn Risk</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredClients.map((client) => (
+                    <TableRow
+                      key={client.id}
+                      className="cursor-pointer transition hover:bg-gray-50"
+                      onClick={() => router.push(`/clients/${client.id}`)}
+                    >
+                      <TableCell>
+                        <div className="font-medium text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {client.industry ?? "—"}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-700">
+                        {client.owner}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-700">
+                        {client.segment}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-700">
+                        {client.phase}
+                      </TableCell>
+                      <TableCell className="text-right font-medium text-black">
+                        {formatCurrency(client.arr)}
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-gray-700">
+                        {client.health}%
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-gray-700">
+                        {client.churnRisk != null
+                          ? `${client.churnRisk}%`
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTab === "Engagement" && (
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
             <Card className={cn(TRS_CARD)}>
               <CardHeader>
-                <CardTitle className="text-sm font-medium">Outstanding invoices</CardTitle>
-                <CardDescription>Cash flow watchlist across the portfolio.</CardDescription>
+                <CardTitle className="text-sm font-medium">
+                  Discovery & enablement
+                </CardTitle>
+                <CardDescription>
+                  Progress through the RevOS methodology.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-700">
+                {clients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-semibold text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          Phase {client.phase}
+                        </div>
+                      </div>
+                      <Badge
+                        variant={
+                          client.discovery.some((qa) => qa.answer)
+                            ? "success"
+                            : "outline"
+                        }
+                      >
+                        {client.discovery.some((qa) => qa.answer)
+                          ? "In motion"
+                          : "Pending"}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 text-xs text-gray-500">
+                      {client.discovery.filter((qa) => qa.answer).length}{" "}
+                      answered • {client.discovery.length} prompts
+                    </div>
+                    <div className="mt-2 text-xs text-gray-600">
+                      Top lever:{" "}
+                      {client.discovery.find((qa) => qa.answer)?.answer ??
+                        "To be defined"}
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className={cn(TRS_CARD)}>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">
+                  Product adoption signals
+                </CardTitle>
+                <CardDescription>
+                  Key drivers fueling retention and growth.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-700">
+                {clients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-semibold text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          Net new this quarter
+                        </div>
+                      </div>
+                      <span className="text-sm font-medium text-black">
+                        {formatCurrency(client.compounding?.netNew)}
+                      </span>
+                    </div>
+                    <div className="mt-2 text-xs text-gray-500">
+                      Baseline MRR{" "}
+                      {formatCurrency(client.compounding?.baselineMRR)} →
+                      Current {formatCurrency(client.compounding?.currentMRR)}
+                    </div>
+                    <ul className="mt-2 space-y-1 text-xs text-gray-600">
+                      {client.compounding?.drivers.map((driver) => (
+                        <li key={driver.name}>
+                          • {driver.name}: +{formatCurrency(driver.delta)}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Renewals" && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <Card className={cn(TRS_CARD)}>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">
+                  Renewal calendar
+                </CardTitle>
+                <CardDescription>
+                  QBRs and contract checkpoints on deck.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-700">
+                {upcomingQbrs.map((client) => (
+                  <div
+                    key={client.id}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-semibold text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          Owner {client.owner}
+                        </div>
+                      </div>
+                      <span className="text-xs text-gray-600">
+                        {new Date(client.qbrDate ?? "").toLocaleDateString(
+                          "en-US",
+                          { month: "short", day: "numeric" },
+                        )}
+                      </span>
+                    </div>
+                    <div className="mt-2 text-xs text-gray-500">
+                      Plan {client.commercials?.plan ?? "—"}
+                    </div>
+                    <div className="mt-2 text-xs text-gray-600">
+                      Next step:{" "}
+                      {client.opportunities[0]?.nextStep ?? "Confirm agenda"}
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className={cn(TRS_CARD)}>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">
+                  Commercial posture
+                </CardTitle>
+                <CardDescription>
+                  Pricing, term, and approval guardrails at a glance.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-700">
+                {clients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-semibold text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          Term {client.commercials?.termMonths ?? "—"} months
+                        </div>
+                      </div>
+                      <span className="text-xs text-gray-600">
+                        Discount {client.commercials?.discountPct ?? 0}%
+                      </span>
+                    </div>
+                    <div className="mt-2 text-xs text-gray-500">
+                      Approvals:{" "}
+                      {client.commercials?.approvals?.join(", ") ?? "N/A"}
+                    </div>
+                    <div className="mt-2 text-xs text-gray-600">
+                      Payment terms:{" "}
+                      {client.commercials?.paymentTerms ?? "Standard"}
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Signals" && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <Card className={cn(TRS_CARD)}>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">
+                  Churn watchlist
+                </CardTitle>
+                <CardDescription>
+                  Accounts requiring proactive outreach.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {outstandingInvoices.length === 0 ? (
+                {churnSignals.length === 0 ? (
                   <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-600">
-                    No invoices outstanding.
+                    No high-risk accounts. Keep the momentum.
                   </div>
                 ) : (
-                  outstandingInvoices.map((invoice) => (
-                    <div key={invoice.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                  churnSignals.map((client) => (
+                    <div
+                      key={client.id}
+                      className="rounded-lg border border-gray-200 bg-white p-3"
+                    >
                       <div className="flex items-center justify-between text-sm">
-                        <span className="font-semibold text-black">{invoice.clientName}</span>
-                        <span className="text-xs text-gray-500">{invoice.status}</span>
+                        <span className="font-semibold text-black">
+                          {client.name}
+                        </span>
+                        <Badge variant="outline">
+                          {client.churnRisk}% risk
+                        </Badge>
                       </div>
-                      <div className="mt-1 text-xs text-gray-500">Invoice {invoice.id}</div>
-                      <div className="mt-2 flex items-center justify-between text-sm text-gray-700">
-                        <span>{formatCurrency(invoice.amount)}</span>
-                        {invoice.dueAt && (
-                          <span>
-                            Due {new Date(invoice.dueAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-                          </span>
-                        )}
+                      <div className="mt-1 text-xs text-gray-500">
+                        Owner {client.owner}
+                      </div>
+                      <div className="mt-2 text-xs text-gray-600">
+                        Latest note: {client.notes ?? "Schedule executive sync"}
                       </div>
                     </div>
                   ))
@@ -266,326 +789,49 @@ export default function ClientsPage() {
 
             <Card className={cn(TRS_CARD)}>
               <CardHeader>
-                <CardTitle className="text-sm font-medium">Data coverage</CardTitle>
-                <CardDescription>Ensure every client powers the RevOS decision loop.</CardDescription>
+                <CardTitle className="text-sm font-medium">
+                  Partner leverage
+                </CardTitle>
+                <CardDescription>
+                  Who can help reinforce retention stories.
+                </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-3">
-                  {["collected", "available", "missing"].map((band) => (
-                    <div key={band} className="flex items-center gap-3">
-                      <div className="w-20 text-xs font-semibold uppercase text-gray-400">{band}</div>
-                      <div className="flex-1">
-                        <div className="h-2 rounded-full bg-gray-100">
-                          <div
-                            className={`h-full ${
-                              band === "collected" ? "bg-gray-900" : band === "available" ? "bg-gray-700" : "bg-gray-500"
-                            }`}
-                            style={{
-                              width: `${
-                                dataCoverage.collected + dataCoverage.available + dataCoverage.missing
-                                  ? (dataCoverage[band as keyof typeof dataCoverage] /
-                                      (dataCoverage.collected + dataCoverage.available + dataCoverage.missing)) *
-                                    100
-                                  : 0
-                              }%`,
-                            }}
-                          />
+              <CardContent className="space-y-3 text-sm text-gray-700">
+                {clients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-semibold text-black">
+                          {client.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          Partners: {client.qra?.partners?.join(", ") ?? "TBD"}
                         </div>
                       </div>
-                      <div className="w-10 text-right text-xs text-gray-500">
-                        {dataCoverage[band as keyof typeof dataCoverage]}
-                      </div>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-3 text-xs"
+                        onClick={() => router.push(`/partners?tab=Directory`)}
+                      >
+                        Explore partners
+                      </Button>
                     </div>
-                  ))}
-                </div>
-                <p className="text-sm text-gray-600">
-                  Rally data integrations ahead of QBRs so every renewal conversation is grounded in performance proof.
-                </p>
+                    <div className="mt-2 text-xs text-gray-600">
+                      Retention plays:{" "}
+                      {client.qra?.retention?.join(", ") ??
+                        "Add retention plan"}
+                    </div>
+                  </div>
+                ))}
               </CardContent>
             </Card>
           </div>
-        </div>
-      )}
-
-      {activeTab === "Accounts" && (
-        <Card className={cn(TRS_CARD)}>
-          <CardHeader>
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <CardTitle>Client accounts</CardTitle>
-                <CardDescription>Sort by health, ARR, or owner to plan your touchpoints.</CardDescription>
-              </div>
-              <div className="flex flex-col gap-2 md:flex-row md:items-center">
-                <Input
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  placeholder="Search by name, owner, or industry"
-                  className="h-9 md:w-72"
-                />
-                <div className="flex flex-wrap items-center gap-2">
-                  <select
-                    value={segmentFilter}
-                    onChange={(event) => setSegmentFilter(event.target.value)}
-                    className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                  >
-                    <option value="all">All Segments</option>
-                    {segments.map((segment) => (
-                      <option key={segment} value={segment}>
-                        {segment}
-                      </option>
-                    ))}
-                  </select>
-                  <select
-                    value={ownerFilter}
-                    onChange={(event) => setOwnerFilter(event.target.value)}
-                    className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                  >
-                    <option value="all">All Owners</option>
-                    {owners.map((owner) => (
-                      <option key={owner} value={owner}>
-                        {owner}
-                      </option>
-                    ))}
-                  </select>
-                  <select
-                    value={sortBy}
-                    onChange={(event) => setSortBy(event.target.value)}
-                    className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                  >
-                    <option value="arr-desc">ARR (High to Low)</option>
-                    <option value="arr-asc">ARR (Low to High)</option>
-                    <option value="health-desc">Health (High to Low)</option>
-                    <option value="health-asc">Health (Low to High)</option>
-                    <option value="name-asc">Name (A-Z)</option>
-                    <option value="name-desc">Name (Z-A)</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="overflow-hidden">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Client</TableHead>
-                  <TableHead>Owner</TableHead>
-                  <TableHead>Segment</TableHead>
-                  <TableHead>Phase</TableHead>
-                  <TableHead className="text-right">ARR</TableHead>
-                  <TableHead className="text-right">Health</TableHead>
-                  <TableHead className="text-right">Churn Risk</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredClients.map((client) => (
-                  <TableRow
-                    key={client.id}
-                    className="cursor-pointer transition hover:bg-gray-50"
-                    onClick={() => router.push(`/clients/${client.id}`)}
-                  >
-                    <TableCell>
-                      <div className="font-medium text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">{client.industry ?? "—"}</div>
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-700">{client.owner}</TableCell>
-                    <TableCell className="text-sm text-gray-700">{client.segment}</TableCell>
-                    <TableCell className="text-sm text-gray-700">{client.phase}</TableCell>
-                    <TableCell className="text-right font-medium text-black">{formatCurrency(client.arr)}</TableCell>
-                    <TableCell className="text-right text-sm text-gray-700">{client.health}%</TableCell>
-                    <TableCell className="text-right text-sm text-gray-700">
-                      {client.churnRisk != null ? `${client.churnRisk}%` : "—"}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
-      )}
-
-      {activeTab === "Engagement" && (
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Discovery & enablement</CardTitle>
-              <CardDescription>Progress through the RevOS methodology.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-gray-700">
-              {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-semibold text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">Phase {client.phase}</div>
-                    </div>
-                    <Badge variant={client.discovery.some((qa) => qa.answer) ? "success" : "outline"}>
-                      {client.discovery.some((qa) => qa.answer) ? "In motion" : "Pending"}
-                    </Badge>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-500">
-                    {client.discovery.filter((qa) => qa.answer).length} answered • {client.discovery.length} prompts
-                  </div>
-                  <div className="mt-2 text-xs text-gray-600">
-                    Top lever: {client.discovery.find((qa) => qa.answer)?.answer ?? "To be defined"}
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Product adoption signals</CardTitle>
-              <CardDescription>Key drivers fueling retention and growth.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-gray-700">
-              {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-semibold text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">Net new this quarter</div>
-                    </div>
-                    <span className="text-sm font-medium text-black">
-                      {formatCurrency(client.compounding?.netNew)}
-                    </span>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-500">
-                    Baseline MRR {formatCurrency(client.compounding?.baselineMRR)} → Current
-                    {" "}
-                    {formatCurrency(client.compounding?.currentMRR)}
-                  </div>
-                  <ul className="mt-2 space-y-1 text-xs text-gray-600">
-                    {client.compounding?.drivers.map((driver) => (
-                      <li key={driver.name}>• {driver.name}: +{formatCurrency(driver.delta)}</li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
-      )}
-
-      {activeTab === "Renewals" && (
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Renewal calendar</CardTitle>
-              <CardDescription>QBRs and contract checkpoints on deck.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-gray-700">
-              {upcomingQbrs.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-semibold text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">Owner {client.owner}</div>
-                    </div>
-                    <span className="text-xs text-gray-600">
-                      {new Date(client.qbrDate ?? "").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-                    </span>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-500">Plan {client.commercials?.plan ?? "—"}</div>
-                  <div className="mt-2 text-xs text-gray-600">
-                    Next step: {client.opportunities[0]?.nextStep ?? "Confirm agenda"}
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Commercial posture</CardTitle>
-              <CardDescription>Pricing, term, and approval guardrails at a glance.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-gray-700">
-              {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-semibold text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">Term {client.commercials?.termMonths ?? "—"} months</div>
-                    </div>
-                    <span className="text-xs text-gray-600">Discount {client.commercials?.discountPct ?? 0}%</span>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-500">
-                    Approvals: {client.commercials?.approvals?.join(", ") ?? "N/A"}
-                  </div>
-                  <div className="mt-2 text-xs text-gray-600">
-                    Payment terms: {client.commercials?.paymentTerms ?? "Standard"}
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
-      )}
-
-      {activeTab === "Signals" && (
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Churn watchlist</CardTitle>
-              <CardDescription>Accounts requiring proactive outreach.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {churnSignals.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-600">
-                  No high-risk accounts. Keep the momentum.
-                </div>
-              ) : (
-                churnSignals.map((client) => (
-                  <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="font-semibold text-black">{client.name}</span>
-                      <Badge variant="outline">{client.churnRisk}% risk</Badge>
-                    </div>
-                    <div className="mt-1 text-xs text-gray-500">Owner {client.owner}</div>
-                    <div className="mt-2 text-xs text-gray-600">
-                      Latest note: {client.notes ?? "Schedule executive sync"}
-                    </div>
-                  </div>
-                ))
-              )}
-            </CardContent>
-          </Card>
-
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <CardTitle className="text-sm font-medium">Partner leverage</CardTitle>
-              <CardDescription>Who can help reinforce retention stories.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-gray-700">
-              {clients.map((client) => (
-                <div key={client.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-semibold text-black">{client.name}</div>
-                      <div className="text-xs text-gray-500">
-                        Partners: {client.qra?.partners?.join(", ") ?? "TBD"}
-                      </div>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-7 px-3 text-xs"
-                      onClick={() => router.push(`/partners?tab=Directory`)}
-                    >
-                      Explore partners
-                    </Button>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-600">
-                    Retention plays: {client.qra?.retention?.join(", ") ?? "Add retention plan"}
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
-      )}
+        )}
       </section>
     </div>
-  )
+  );
 }

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
+import { PageTabs } from "@/components/layout/PageTabs";
 import { Card } from "@/components/kit/Card";
 import { resolveTabs } from "@/lib/tabs";
 import { cn } from "@/lib/utils";
 import { TRS_CARD, TRS_SUBTITLE } from "@/lib/style";
-import { listContentPieces, listAdCampaigns, getMarketingKPIs, createAdCampaign } from "@/core/content/store";
+import {
+  listContentPieces,
+  listAdCampaigns,
+  getMarketingKPIs,
+  createAdCampaign,
+} from "@/core/content/store";
 import type { CreateAdCampaignInput } from "@/core/content/types";
 
 export default function ContentStudioPage() {
@@ -20,6 +26,15 @@ export default function ContentStudioPage() {
     return current && tabs.includes(current) ? current : tabs[0];
   }, [searchParams, tabs]);
 
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
   const contentPieces = useMemo(() => listContentPieces(), []);
   const [adCampaigns, setAdCampaigns] = useState(() => listAdCampaigns());
   const kpis = useMemo(() => getMarketingKPIs(), []);
@@ -27,22 +42,28 @@ export default function ContentStudioPage() {
   const [showCampaignModal, setShowCampaignModal] = useState(false);
   const [showAgentModal, setShowAgentModal] = useState(false);
   const [campaignForm, setCampaignForm] = useState<CreateAdCampaignInput>({
-    name: '',
-    platform: 'LinkedIn',
-    objective: 'Lead Generation',
-    status: 'Draft',
+    name: "",
+    platform: "LinkedIn",
+    objective: "Lead Generation",
+    status: "Draft",
     budget: 0,
     spent: 0,
-    startDate: '',
-    targetAudience: '',
-    createdBy: 'User',
+    startDate: "",
+    targetAudience: "",
+    createdBy: "User",
   });
-  const [agentPrompt, setAgentPrompt] = useState('');
+  const [agentPrompt, setAgentPrompt] = useState("");
 
-  const pipelineContent = contentPieces.filter(p => p.status === 'Draft' || p.status === 'Review');
-  const scheduledContent = contentPieces.filter(p => p.status === 'Scheduled');
-  const ideaContent = contentPieces.filter(p => p.status === 'Idea');
-  const publishedContent = contentPieces.filter(p => p.status === 'Published');
+  const pipelineContent = contentPieces.filter(
+    (p) => p.status === "Draft" || p.status === "Review",
+  );
+  const scheduledContent = contentPieces.filter(
+    (p) => p.status === "Scheduled",
+  );
+  const ideaContent = contentPieces.filter((p) => p.status === "Idea");
+  const publishedContent = contentPieces.filter(
+    (p) => p.status === "Published",
+  );
 
   const handleCreateCampaign = () => {
     if (campaignForm.name && campaignForm.targetAudience) {
@@ -50,15 +71,15 @@ export default function ContentStudioPage() {
       setAdCampaigns([...adCampaigns, newCampaign]);
       setShowCampaignModal(false);
       setCampaignForm({
-        name: '',
-        platform: 'LinkedIn',
-        objective: 'Lead Generation',
-        status: 'Draft',
+        name: "",
+        platform: "LinkedIn",
+        objective: "Lead Generation",
+        status: "Draft",
         budget: 0,
         spent: 0,
-        startDate: '',
-        targetAudience: '',
-        createdBy: 'User',
+        startDate: "",
+        targetAudience: "",
+        createdBy: "User",
       });
     }
   };
@@ -67,19 +88,19 @@ export default function ContentStudioPage() {
     if (agentPrompt) {
       const campaignInput: CreateAdCampaignInput = {
         name: `AI Generated: ${agentPrompt.substring(0, 50)}...`,
-        platform: 'Multi-Channel',
-        objective: 'Brand Awareness',
-        status: 'Draft',
+        platform: "Multi-Channel",
+        objective: "Brand Awareness",
+        status: "Draft",
         budget: 5000,
         spent: 0,
         startDate: new Date().toISOString(),
-        targetAudience: 'AI-selected audience',
-        createdBy: 'AI Agent',
+        targetAudience: "AI-selected audience",
+        createdBy: "AI Agent",
       };
       const generatedCampaign = createAdCampaign(campaignInput);
       setAdCampaigns([...adCampaigns, generatedCampaign]);
       setShowAgentModal(false);
-      setAgentPrompt('');
+      setAgentPrompt("");
     }
   };
 
@@ -87,533 +108,772 @@ export default function ContentStudioPage() {
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
       <section className="space-y-4">
         <header className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold text-black">Marketing & Content</h1>
-        <p className="text-sm text-gray-600">
-          Create content to inspire, sell, and add value for clients, prospects, partners, and market presence.
-        </p>
+          <h1 className="text-2xl font-semibold text-black">
+            Marketing & Content
+          </h1>
+          <p className="text-sm text-gray-600">
+            Create content to inspire, sell, and add value for clients,
+            prospects, partners, and market presence.
+          </p>
         </header>
 
+        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
         {activeTab === "Overview" && (
-        <div className="space-y-4">
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="text-sm font-semibold text-black mb-4">Content Pipeline Overview</div>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Total Content</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.total}</div>
-                <div className="text-[11px] text-gray-600">All pieces</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Published</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.published}</div>
-                <div className="text-[11px] text-gray-600">Live content</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Scheduled</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.scheduled}</div>
-                <div className="text-[11px] text-gray-600">Ready to ship</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>In Draft</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.draft}</div>
-                <div className="text-[11px] text-gray-600">In progress</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Ideas</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.ideas}</div>
-                <div className="text-[11px] text-gray-600">In backlog</div>
-              </div>
-            </div>
-          </Card>
-
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="text-sm font-semibold text-black mb-4">Performance Metrics</div>
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Total Views</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.views.toLocaleString()}</div>
-                <div className="text-[11px] text-gray-600">Across all content</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Engagement</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.engagement.toLocaleString()}</div>
-                <div className="text-[11px] text-gray-600">Interactions</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Conversions</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.content.conversions}</div>
-                <div className="text-[11px] text-gray-600">Generated leads</div>
-              </div>
-            </div>
-          </Card>
-
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="text-sm font-semibold text-black mb-4">Advertising Overview</div>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Active Campaigns</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.activeCampaigns}</div>
-                <div className="text-[11px] text-gray-600">Running now</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Ad Spend</div>
-                <div className="mt-1 text-2xl font-semibold text-black">${(kpis.advertising.totalSpend / 1000).toFixed(1)}k</div>
-                <div className="text-[11px] text-gray-600">of ${(kpis.advertising.totalBudget / 1000).toFixed(1)}k budget</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Avg CTR</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.avgCTR.toFixed(2)}%</div>
-                <div className="text-[11px] text-gray-600">Click-through rate</div>
-              </div>
-              <div className={cn(TRS_CARD, "p-3")}>
-                <div className={TRS_SUBTITLE}>Avg ROAS</div>
-                <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.avgROAS.toFixed(1)}x</div>
-                <div className="text-[11px] text-gray-600">Return on ad spend</div>
-              </div>
-            </div>
-          </Card>
-        </div>
-      )}
-
-      {activeTab === "Pipeline" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="flex items-center justify-between mb-4">
-            <div>
-              <div className="text-sm font-semibold text-black">Active Content Flow</div>
-              <p className="text-[13px] text-gray-600">Content in Draft and Review stages</p>
-            </div>
-            <button className="text-xs px-3 py-1.5 rounded-md border border-gray-300 hover:bg-gray-100 bg-white">
-              + New Content
-            </button>
-          </div>
-          <div className="mt-3 overflow-hidden rounded-lg border border-gray-200">
-            <table className="w-full text-sm">
-              <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
-                <tr>
-                  <th className="px-3 py-2 font-medium">Title</th>
-                  <th className="px-3 py-2 font-medium">Type</th>
-                  <th className="px-3 py-2 font-medium">Format</th>
-                  <th className="px-3 py-2 font-medium">Status</th>
-                  <th className="px-3 py-2 font-medium">Owner</th>
-                  <th className="px-3 py-2 font-medium">Due Date</th>
-                  <th className="px-3 py-2 font-medium">Purpose</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
-                {pipelineContent.map((item) => (
-                  <tr key={item.id} className="hover:bg-gray-50">
-                    <td className="px-3 py-2 font-medium text-black">
-                      <Link href={`/content/${item.id}`} className="hover:text-gray-600 hover:underline">
-                        {item.title}
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2 text-gray-700">{item.contentType}</td>
-                    <td className="px-3 py-2 text-gray-700">{item.format}</td>
-                    <td className="px-3 py-2">
-                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                        item.status === 'Review' ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-800'
-                      }`}>
-                        {item.status}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 text-gray-700">{item.createdBy}</td>
-                    <td className="px-3 py-2 text-gray-700">{item.dueDate ? new Date(item.dueDate).toLocaleDateString() : '—'}</td>
-                    <td className="px-3 py-2 text-gray-700">{item.purpose}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </Card>
-      )}
-
-      {activeTab === "Ideas" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="flex items-center justify-between mb-4">
-            <div>
-              <div className="text-sm font-semibold text-black">Content Ideas</div>
-              <p className="text-[13px] text-gray-600">AI-generated ideas based on sales trends and market conditions</p>
-            </div>
-            <button className="text-xs px-3 py-1.5 rounded-md bg-black text-white hover:bg-gray-800">
-              Generate Ideas
-            </button>
-          </div>
-          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-            {ideaContent.map((idea) => (
-              <div key={idea.id} className="rounded-lg border border-gray-200 p-3 hover:border-gray-400 transition">
-                <div className="flex items-start justify-between">
-                  <div className="text-sm font-medium text-black">{idea.title}</div>
-                  {idea.aiGenerated && (
-                    <span className="rounded border border-gray-300 px-1.5 py-0.5 text-[10px] text-gray-600">AI</span>
-                  )}
-                </div>
-                <div className="mt-1 text-[12px] text-gray-600">{idea.format} • {idea.contentType}</div>
-                <div className="mt-2 text-[12px] text-gray-500">{idea.description}</div>
-                <div className="mt-2 text-[11px] text-gray-500">Purpose: {idea.purpose}</div>
-                <button
-                  type="button"
-                  className="mt-3 inline-flex items-center justify-center rounded-lg border border-gray-300 px-3 py-1 text-[12px] font-medium text-gray-700 transition hover:border-black hover:text-black"
-                >
-                  Move to Pipeline
-                </button>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {activeTab === "Scheduled" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="text-sm font-semibold text-black mb-4">Scheduled Distribution</div>
-          <p className="text-[13px] text-gray-600 mb-4">Content ready to ship: LinkedIn posts, webinars, workshops, and more</p>
-          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-            {scheduledContent.map((release) => (
-              <div key={release.id} className="rounded-lg border border-gray-200 p-3">
-                <div className="text-[11px] uppercase tracking-wide text-gray-500">{release.channel || release.format}</div>
-                <div className="mt-1 text-lg font-semibold text-black">{release.title}</div>
-                <div className="text-[12px] text-gray-600 mt-1">
-                  Launch: {release.scheduledDate ? new Date(release.scheduledDate).toLocaleDateString() : 'TBD'}
-                </div>
-                <div className="text-[12px] text-gray-600">Owner: {release.assignedTo || release.createdBy}</div>
-                <div className="mt-2">
-                  <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
-                    {release.purpose}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {activeTab === "Performance" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="text-sm font-semibold text-black mb-4">Performance Signals</div>
-          <p className="text-[13px] text-gray-600 mb-4">Track engagement, reach, and conversions for published content</p>
-          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-            {publishedContent.map((content) => (
-              <Link key={content.id} href={`/content/${content.id}`} className="rounded-lg border border-gray-200 p-3 block hover:border-gray-400 transition">
-                <div className="text-sm font-medium text-black hover:text-gray-600">{content.title}</div>
-                <div className="mt-1 text-[11px] text-gray-500">{content.format} • {content.channel}</div>
-                {content.performanceMetrics && (
-                  <div className="mt-2 space-y-1">
-                    <div className="text-[12px] text-gray-600">Views: {content.performanceMetrics.views?.toLocaleString() || 0}</div>
-                    <div className="text-[12px] text-gray-600">Engagement: {content.performanceMetrics.engagement?.toLocaleString() || 0}</div>
-                    <div className="text-[12px] text-gray-600">Clicks: {content.performanceMetrics.clicks || 0}</div>
-                    {content.performanceMetrics.shares && (
-                      <div className="text-[12px] text-gray-600">Shares: {content.performanceMetrics.shares}</div>
-                    )}
-                  </div>
-                )}
-                <div className="mt-3">
-                  <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
-                    Published
-                  </span>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {activeTab === "Create" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="text-sm font-semibold text-black mb-4">Content Creation Studio</div>
-          <p className="text-[13px] text-gray-600 mb-4">Generate and edit content for clients, prospects, partners, and marketing</p>
-
           <div className="space-y-4">
-            <div className="rounded-lg border border-gray-200 p-4">
-              <div className="text-sm font-medium text-black mb-2">Quick Create</div>
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-                <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
-                  <div className="text-[11px] uppercase tracking-wide text-gray-500">LinkedIn Post</div>
-                  <div className="mt-1 text-sm text-gray-700">Client Success</div>
-                </button>
-                <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
-                  <div className="text-[11px] uppercase tracking-wide text-gray-500">One-Pager</div>
-                  <div className="mt-1 text-sm text-gray-700">Prospect Pitch</div>
-                </button>
-                <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
-                  <div className="text-[11px] uppercase tracking-wide text-gray-500">Email</div>
-                  <div className="mt-1 text-sm text-gray-700">Partner Outreach</div>
-                </button>
-                <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
-                  <div className="text-[11px] uppercase tracking-wide text-gray-500">White Paper</div>
-                  <div className="mt-1 text-sm text-gray-700">Thought Leadership</div>
-                </button>
+            <Card className={cn(TRS_CARD, "p-4")}>
+              <div className="text-sm font-semibold text-black mb-4">
+                Content Pipeline Overview
               </div>
-            </div>
-
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <div className="text-sm font-medium text-black mb-2">AI Content Generator</div>
-              <div className="space-y-3">
-                <textarea
-                  className="w-full rounded-lg border border-gray-300 p-3 text-sm resize-none"
-                  rows={3}
-                  placeholder="Describe the content you want to create... (e.g., 'Create a LinkedIn post about ACME Corp's 40% revenue growth using our platform')"
-                />
-                <div className="flex gap-2">
-                  <select className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
-                    <option>Client</option>
-                    <option>Prospect</option>
-                    <option>Partner</option>
-                    <option>Marketing</option>
-                  </select>
-                  <select className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
-                    <option>Post</option>
-                    <option>Email</option>
-                    <option>One-Pager</option>
-                    <option>White Paper</option>
-                    <option>Case Study</option>
-                  </select>
-                  <button className="ml-auto rounded-lg bg-black px-4 py-2 text-sm text-white hover:bg-gray-800">
-                    Generate Content
-                  </button>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Total Content</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.total}
+                  </div>
+                  <div className="text-[11px] text-gray-600">All pieces</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Published</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.published}
+                  </div>
+                  <div className="text-[11px] text-gray-600">Live content</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Scheduled</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.scheduled}
+                  </div>
+                  <div className="text-[11px] text-gray-600">Ready to ship</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>In Draft</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.draft}
+                  </div>
+                  <div className="text-[11px] text-gray-600">In progress</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Ideas</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.ideas}
+                  </div>
+                  <div className="text-[11px] text-gray-600">In backlog</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </Card>
-      )}
+            </Card>
 
-      {activeTab === "Advertising" && (
-        <div className="space-y-4">
+            <Card className={cn(TRS_CARD, "p-4")}>
+              <div className="text-sm font-semibold text-black mb-4">
+                Performance Metrics
+              </div>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Total Views</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.views.toLocaleString()}
+                  </div>
+                  <div className="text-[11px] text-gray-600">
+                    Across all content
+                  </div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Engagement</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.engagement.toLocaleString()}
+                  </div>
+                  <div className="text-[11px] text-gray-600">Interactions</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Conversions</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.content.conversions}
+                  </div>
+                  <div className="text-[11px] text-gray-600">
+                    Generated leads
+                  </div>
+                </div>
+              </div>
+            </Card>
+
+            <Card className={cn(TRS_CARD, "p-4")}>
+              <div className="text-sm font-semibold text-black mb-4">
+                Advertising Overview
+              </div>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Active Campaigns</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.advertising.activeCampaigns}
+                  </div>
+                  <div className="text-[11px] text-gray-600">Running now</div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Ad Spend</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    ${(kpis.advertising.totalSpend / 1000).toFixed(1)}k
+                  </div>
+                  <div className="text-[11px] text-gray-600">
+                    of ${(kpis.advertising.totalBudget / 1000).toFixed(1)}k
+                    budget
+                  </div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Avg CTR</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.advertising.avgCTR.toFixed(2)}%
+                  </div>
+                  <div className="text-[11px] text-gray-600">
+                    Click-through rate
+                  </div>
+                </div>
+                <div className={cn(TRS_CARD, "p-3")}>
+                  <div className={TRS_SUBTITLE}>Avg ROAS</div>
+                  <div className="mt-1 text-2xl font-semibold text-black">
+                    {kpis.advertising.avgROAS.toFixed(1)}x
+                  </div>
+                  <div className="text-[11px] text-gray-600">
+                    Return on ad spend
+                  </div>
+                </div>
+              </div>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Pipeline" && (
           <Card className={cn(TRS_CARD, "p-4")}>
             <div className="flex items-center justify-between mb-4">
               <div>
-                <div className="text-sm font-semibold text-black">Ad Campaigns</div>
-                <p className="text-[13px] text-gray-600">Develop advertising strategy and track campaign performance</p>
+                <div className="text-sm font-semibold text-black">
+                  Active Content Flow
+                </div>
+                <p className="text-[13px] text-gray-600">
+                  Content in Draft and Review stages
+                </p>
               </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setShowAgentModal(true)}
-                  className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
-                >
-                  AI Agent
-                </button>
-                <button
-                  onClick={() => setShowCampaignModal(true)}
-                  className="text-xs px-3 py-1.5 rounded-md border border-gray-300 hover:bg-gray-100 bg-white"
-                >
-                  + New Campaign
-                </button>
-              </div>
+              <button className="text-xs px-3 py-1.5 rounded-md border border-gray-300 hover:bg-gray-100 bg-white">
+                + New Content
+              </button>
             </div>
             <div className="mt-3 overflow-hidden rounded-lg border border-gray-200">
               <table className="w-full text-sm">
                 <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
                   <tr>
-                    <th className="px-3 py-2 font-medium">Campaign</th>
-                    <th className="px-3 py-2 font-medium">Platform</th>
+                    <th className="px-3 py-2 font-medium">Title</th>
+                    <th className="px-3 py-2 font-medium">Type</th>
+                    <th className="px-3 py-2 font-medium">Format</th>
                     <th className="px-3 py-2 font-medium">Status</th>
-                    <th className="px-3 py-2 font-medium">Budget</th>
-                    <th className="px-3 py-2 font-medium">Spent</th>
-                    <th className="px-3 py-2 font-medium">CTR</th>
-                    <th className="px-3 py-2 font-medium">ROAS</th>
-                    <th className="px-3 py-2 font-medium">Conversions</th>
+                    <th className="px-3 py-2 font-medium">Owner</th>
+                    <th className="px-3 py-2 font-medium">Due Date</th>
+                    <th className="px-3 py-2 font-medium">Purpose</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 bg-white">
-                  {adCampaigns.map((campaign) => (
-                    <tr key={campaign.id} className="hover:bg-gray-50 cursor-pointer">
-                      <td className="px-3 py-2 font-medium text-black">{campaign.name}</td>
-                      <td className="px-3 py-2 text-gray-700">{campaign.platform}</td>
+                  {pipelineContent.map((item) => (
+                    <tr key={item.id} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 font-medium text-black">
+                        <Link
+                          href={`/content/${item.id}`}
+                          className="hover:text-gray-600 hover:underline"
+                        >
+                          {item.title}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {item.contentType}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">{item.format}</td>
                       <td className="px-3 py-2">
-                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                          campaign.status === 'Active' ? 'border border-gray-300 bg-white text-gray-700' :
-                          campaign.status === 'Paused' ? 'bg-amber-100 text-amber-800' :
-                          'bg-gray-100 text-gray-800'
-                        }`}>
-                          {campaign.status}
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                            item.status === "Review"
+                              ? "bg-amber-100 text-amber-800"
+                              : "bg-gray-100 text-gray-800"
+                          }`}
+                        >
+                          {item.status}
                         </span>
                       </td>
-                      <td className="px-3 py-2 text-gray-700">${(campaign.budget / 1000).toFixed(1)}k</td>
-                      <td className="px-3 py-2 text-gray-700">${(campaign.spent / 1000).toFixed(1)}k</td>
-                      <td className="px-3 py-2 text-gray-700">{campaign.metrics?.ctr?.toFixed(2)}%</td>
-                      <td className="px-3 py-2 text-gray-600 font-medium">{campaign.metrics?.roas?.toFixed(1)}x</td>
-                      <td className="px-3 py-2 text-gray-700">{campaign.metrics?.conversions || 0}</td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {item.createdBy}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {item.dueDate
+                          ? new Date(item.dueDate).toLocaleDateString()
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {item.purpose}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
               </table>
             </div>
           </Card>
+        )}
 
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {activeTab === "Ideas" && (
+          <Card className={cn(TRS_CARD, "p-4")}>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <div className="text-sm font-semibold text-black">
+                  Content Ideas
+                </div>
+                <p className="text-[13px] text-gray-600">
+                  AI-generated ideas based on sales trends and market conditions
+                </p>
+              </div>
+              <button className="text-xs px-3 py-1.5 rounded-md bg-black text-white hover:bg-gray-800">
+                Generate Ideas
+              </button>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+              {ideaContent.map((idea) => (
+                <div
+                  key={idea.id}
+                  className="rounded-lg border border-gray-200 p-3 hover:border-gray-400 transition"
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="text-sm font-medium text-black">
+                      {idea.title}
+                    </div>
+                    {idea.aiGenerated && (
+                      <span className="rounded border border-gray-300 px-1.5 py-0.5 text-[10px] text-gray-600">
+                        AI
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-[12px] text-gray-600">
+                    {idea.format} • {idea.contentType}
+                  </div>
+                  <div className="mt-2 text-[12px] text-gray-500">
+                    {idea.description}
+                  </div>
+                  <div className="mt-2 text-[11px] text-gray-500">
+                    Purpose: {idea.purpose}
+                  </div>
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex items-center justify-center rounded-lg border border-gray-300 px-3 py-1 text-[12px] font-medium text-gray-700 transition hover:border-black hover:text-black"
+                  >
+                    Move to Pipeline
+                  </button>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        {activeTab === "Scheduled" && (
+          <Card className={cn(TRS_CARD, "p-4")}>
+            <div className="text-sm font-semibold text-black mb-4">
+              Scheduled Distribution
+            </div>
+            <p className="text-[13px] text-gray-600 mb-4">
+              Content ready to ship: LinkedIn posts, webinars, workshops, and
+              more
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+              {scheduledContent.map((release) => (
+                <div
+                  key={release.id}
+                  className="rounded-lg border border-gray-200 p-3"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                    {release.channel || release.format}
+                  </div>
+                  <div className="mt-1 text-lg font-semibold text-black">
+                    {release.title}
+                  </div>
+                  <div className="text-[12px] text-gray-600 mt-1">
+                    Launch:{" "}
+                    {release.scheduledDate
+                      ? new Date(release.scheduledDate).toLocaleDateString()
+                      : "TBD"}
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    Owner: {release.assignedTo || release.createdBy}
+                  </div>
+                  <div className="mt-2">
+                    <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
+                      {release.purpose}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        {activeTab === "Performance" && (
+          <Card className={cn(TRS_CARD, "p-4")}>
+            <div className="text-sm font-semibold text-black mb-4">
+              Performance Signals
+            </div>
+            <p className="text-[13px] text-gray-600 mb-4">
+              Track engagement, reach, and conversions for published content
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+              {publishedContent.map((content) => (
+                <Link
+                  key={content.id}
+                  href={`/content/${content.id}`}
+                  className="rounded-lg border border-gray-200 p-3 block hover:border-gray-400 transition"
+                >
+                  <div className="text-sm font-medium text-black hover:text-gray-600">
+                    {content.title}
+                  </div>
+                  <div className="mt-1 text-[11px] text-gray-500">
+                    {content.format} • {content.channel}
+                  </div>
+                  {content.performanceMetrics && (
+                    <div className="mt-2 space-y-1">
+                      <div className="text-[12px] text-gray-600">
+                        Views:{" "}
+                        {content.performanceMetrics.views?.toLocaleString() ||
+                          0}
+                      </div>
+                      <div className="text-[12px] text-gray-600">
+                        Engagement:{" "}
+                        {content.performanceMetrics.engagement?.toLocaleString() ||
+                          0}
+                      </div>
+                      <div className="text-[12px] text-gray-600">
+                        Clicks: {content.performanceMetrics.clicks || 0}
+                      </div>
+                      {content.performanceMetrics.shares && (
+                        <div className="text-[12px] text-gray-600">
+                          Shares: {content.performanceMetrics.shares}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  <div className="mt-3">
+                    <span className="inline-flex items-center rounded-full border border-gray-300 bg-white text-gray-700 px-2 py-0.5 text-[11px] font-medium">
+                      Published
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        {activeTab === "Create" && (
+          <Card className={cn(TRS_CARD, "p-4")}>
+            <div className="text-sm font-semibold text-black mb-4">
+              Content Creation Studio
+            </div>
+            <p className="text-[13px] text-gray-600 mb-4">
+              Generate and edit content for clients, prospects, partners, and
+              marketing
+            </p>
+
+            <div className="space-y-4">
+              <div className="rounded-lg border border-gray-200 p-4">
+                <div className="text-sm font-medium text-black mb-2">
+                  Quick Create
+                </div>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                  <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                      LinkedIn Post
+                    </div>
+                    <div className="mt-1 text-sm text-gray-700">
+                      Client Success
+                    </div>
+                  </button>
+                  <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                      One-Pager
+                    </div>
+                    <div className="mt-1 text-sm text-gray-700">
+                      Prospect Pitch
+                    </div>
+                  </button>
+                  <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                      Email
+                    </div>
+                    <div className="mt-1 text-sm text-gray-700">
+                      Partner Outreach
+                    </div>
+                  </button>
+                  <button className="rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 transition">
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                      White Paper
+                    </div>
+                    <div className="mt-1 text-sm text-gray-700">
+                      Thought Leadership
+                    </div>
+                  </button>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <div className="text-sm font-medium text-black mb-2">
+                  AI Content Generator
+                </div>
+                <div className="space-y-3">
+                  <textarea
+                    className="w-full rounded-lg border border-gray-300 p-3 text-sm resize-none"
+                    rows={3}
+                    placeholder="Describe the content you want to create... (e.g., 'Create a LinkedIn post about ACME Corp's 40% revenue growth using our platform')"
+                  />
+                  <div className="flex gap-2">
+                    <select className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
+                      <option>Client</option>
+                      <option>Prospect</option>
+                      <option>Partner</option>
+                      <option>Marketing</option>
+                    </select>
+                    <select className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
+                      <option>Post</option>
+                      <option>Email</option>
+                      <option>One-Pager</option>
+                      <option>White Paper</option>
+                      <option>Case Study</option>
+                    </select>
+                    <button className="ml-auto rounded-lg bg-black px-4 py-2 text-sm text-white hover:bg-gray-800">
+                      Generate Content
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {activeTab === "Advertising" && (
+          <div className="space-y-4">
             <Card className={cn(TRS_CARD, "p-4")}>
-              <div className="text-sm font-semibold text-black mb-3">Campaign Performance</div>
-              <div className="space-y-3">
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>Total Impressions</div>
-                  <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.impressions.toLocaleString()}</div>
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <div className="text-sm font-semibold text-black">
+                    Ad Campaigns
+                  </div>
+                  <p className="text-[13px] text-gray-600">
+                    Develop advertising strategy and track campaign performance
+                  </p>
                 </div>
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>Total Clicks</div>
-                  <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.clicks.toLocaleString()}</div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setShowAgentModal(true)}
+                    className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
+                  >
+                    AI Agent
+                  </button>
+                  <button
+                    onClick={() => setShowCampaignModal(true)}
+                    className="text-xs px-3 py-1.5 rounded-md border border-gray-300 hover:bg-gray-100 bg-white"
+                  >
+                    + New Campaign
+                  </button>
                 </div>
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>Total Conversions</div>
-                  <div className="mt-1 text-2xl font-semibold text-black">{kpis.advertising.conversions}</div>
-                </div>
+              </div>
+              <div className="mt-3 overflow-hidden rounded-lg border border-gray-200">
+                <table className="w-full text-sm">
+                  <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Campaign</th>
+                      <th className="px-3 py-2 font-medium">Platform</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Budget</th>
+                      <th className="px-3 py-2 font-medium">Spent</th>
+                      <th className="px-3 py-2 font-medium">CTR</th>
+                      <th className="px-3 py-2 font-medium">ROAS</th>
+                      <th className="px-3 py-2 font-medium">Conversions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 bg-white">
+                    {adCampaigns.map((campaign) => (
+                      <tr
+                        key={campaign.id}
+                        className="hover:bg-gray-50 cursor-pointer"
+                      >
+                        <td className="px-3 py-2 font-medium text-black">
+                          {campaign.name}
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {campaign.platform}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                              campaign.status === "Active"
+                                ? "border border-gray-300 bg-white text-gray-700"
+                                : campaign.status === "Paused"
+                                  ? "bg-amber-100 text-amber-800"
+                                  : "bg-gray-100 text-gray-800"
+                            }`}
+                          >
+                            {campaign.status}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          ${(campaign.budget / 1000).toFixed(1)}k
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          ${(campaign.spent / 1000).toFixed(1)}k
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {campaign.metrics?.ctr?.toFixed(2)}%
+                        </td>
+                        <td className="px-3 py-2 text-gray-600 font-medium">
+                          {campaign.metrics?.roas?.toFixed(1)}x
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {campaign.metrics?.conversions || 0}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </Card>
 
-            <Card className={cn(TRS_CARD, "p-4")}>
-              <div className="text-sm font-semibold text-black mb-3">Budget Overview</div>
-              <div className="space-y-4">
-                {adCampaigns.filter(c => c.status === 'Active').map((campaign) => (
-                  <div key={campaign.id}>
-                    <div className="flex items-center justify-between mb-1">
-                      <div className="text-[12px] font-medium text-black">{campaign.name}</div>
-                      <div className="text-[12px] text-gray-600">
-                        ${(campaign.spent / 1000).toFixed(1)}k / ${(campaign.budget / 1000).toFixed(1)}k
-                      </div>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-2">
-                      <div
-                        className="bg-gray-700 h-2 rounded-full"
-                        style={{ width: `${Math.min((campaign.spent / campaign.budget) * 100, 100)}%` }}
-                      />
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <Card className={cn(TRS_CARD, "p-4")}>
+                <div className="text-sm font-semibold text-black mb-3">
+                  Campaign Performance
+                </div>
+                <div className="space-y-3">
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>Total Impressions</div>
+                    <div className="mt-1 text-2xl font-semibold text-black">
+                      {kpis.advertising.impressions.toLocaleString()}
                     </div>
                   </div>
-                ))}
-              </div>
-            </Card>
-          </div>
-        </div>
-      )}
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>Total Clicks</div>
+                    <div className="mt-1 text-2xl font-semibold text-black">
+                      {kpis.advertising.clicks.toLocaleString()}
+                    </div>
+                  </div>
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>Total Conversions</div>
+                    <div className="mt-1 text-2xl font-semibold text-black">
+                      {kpis.advertising.conversions}
+                    </div>
+                  </div>
+                </div>
+              </Card>
 
-      {/* Campaign Creation Modal */}
-      {showCampaignModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-black mb-4">Create New Campaign</h2>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Campaign Name</label>
-                <input
-                  type="text"
-                  value={campaignForm.name}
-                  onChange={(e) => setCampaignForm({...campaignForm, name: e.target.value})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="Q1 Revenue Campaign"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Platform</label>
-                <select
-                  value={campaignForm.platform}
-                  onChange={(e) => setCampaignForm({...campaignForm, platform: e.target.value as any})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  <option value="LinkedIn">LinkedIn</option>
-                  <option value="Google">Google</option>
-                  <option value="Facebook">Facebook</option>
-                  <option value="Twitter">Twitter</option>
-                  <option value="Multi-Channel">Multi-Channel</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Objective</label>
-                <select
-                  value={campaignForm.objective}
-                  onChange={(e) => setCampaignForm({...campaignForm, objective: e.target.value as any})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  <option value="Brand Awareness">Brand Awareness</option>
-                  <option value="Lead Generation">Lead Generation</option>
-                  <option value="Conversion">Conversion</option>
-                  <option value="Engagement">Engagement</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Budget ($)</label>
-                <input
-                  type="number"
-                  value={campaignForm.budget}
-                  onChange={(e) => setCampaignForm({...campaignForm, budget: parseInt(e.target.value) || 0})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="10000"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Target Audience</label>
-                <input
-                  type="text"
-                  value={campaignForm.targetAudience}
-                  onChange={(e) => setCampaignForm({...campaignForm, targetAudience: e.target.value})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="CROs, VP Revenue, Enterprise SaaS"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
-                <input
-                  type="date"
-                  value={campaignForm.startDate}
-                  onChange={(e) => setCampaignForm({...campaignForm, startDate: e.target.value})}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                />
-              </div>
-            </div>
-            <div className="flex gap-2 mt-6">
-              <button
-                onClick={() => setShowCampaignModal(false)}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleCreateCampaign}
-                className="flex-1 px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800"
-              >
-                Create Campaign
-              </button>
+              <Card className={cn(TRS_CARD, "p-4")}>
+                <div className="text-sm font-semibold text-black mb-3">
+                  Budget Overview
+                </div>
+                <div className="space-y-4">
+                  {adCampaigns
+                    .filter((c) => c.status === "Active")
+                    .map((campaign) => (
+                      <div key={campaign.id}>
+                        <div className="flex items-center justify-between mb-1">
+                          <div className="text-[12px] font-medium text-black">
+                            {campaign.name}
+                          </div>
+                          <div className="text-[12px] text-gray-600">
+                            ${(campaign.spent / 1000).toFixed(1)}k / $
+                            {(campaign.budget / 1000).toFixed(1)}k
+                          </div>
+                        </div>
+                        <div className="w-full bg-gray-200 rounded-full h-2">
+                          <div
+                            className="bg-gray-700 h-2 rounded-full"
+                            style={{
+                              width: `${Math.min((campaign.spent / campaign.budget) * 100, 100)}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              </Card>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* AI Agent Modal */}
-      {showAgentModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full">
-            <h2 className="text-xl font-semibold text-black mb-4">Advertising Agent</h2>
-            <p className="text-sm text-gray-600 mb-4">
-              Describe your advertising goals and let AI create a campaign strategy for you.
-            </p>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Campaign Description</label>
-                <textarea
-                  value={agentPrompt}
-                  onChange={(e) => setAgentPrompt(e.target.value)}
-                  rows={4}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="Create a LinkedIn campaign to generate leads from enterprise SaaS companies, focusing on revenue operations and forecasting pain points..."
-                />
+        {/* Campaign Creation Modal */}
+        {showCampaignModal && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
+              <h2 className="text-xl font-semibold text-black mb-4">
+                Create New Campaign
+              </h2>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Campaign Name
+                  </label>
+                  <input
+                    type="text"
+                    value={campaignForm.name}
+                    onChange={(e) =>
+                      setCampaignForm({ ...campaignForm, name: e.target.value })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="Q1 Revenue Campaign"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Platform
+                  </label>
+                  <select
+                    value={campaignForm.platform}
+                    onChange={(e) =>
+                      setCampaignForm({
+                        ...campaignForm,
+                        platform: e.target.value as any,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  >
+                    <option value="LinkedIn">LinkedIn</option>
+                    <option value="Google">Google</option>
+                    <option value="Facebook">Facebook</option>
+                    <option value="Twitter">Twitter</option>
+                    <option value="Multi-Channel">Multi-Channel</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Objective
+                  </label>
+                  <select
+                    value={campaignForm.objective}
+                    onChange={(e) =>
+                      setCampaignForm({
+                        ...campaignForm,
+                        objective: e.target.value as any,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  >
+                    <option value="Brand Awareness">Brand Awareness</option>
+                    <option value="Lead Generation">Lead Generation</option>
+                    <option value="Conversion">Conversion</option>
+                    <option value="Engagement">Engagement</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Budget ($)
+                  </label>
+                  <input
+                    type="number"
+                    value={campaignForm.budget}
+                    onChange={(e) =>
+                      setCampaignForm({
+                        ...campaignForm,
+                        budget: parseInt(e.target.value) || 0,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="10000"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Target Audience
+                  </label>
+                  <input
+                    type="text"
+                    value={campaignForm.targetAudience}
+                    onChange={(e) =>
+                      setCampaignForm({
+                        ...campaignForm,
+                        targetAudience: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="CROs, VP Revenue, Enterprise SaaS"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Start Date
+                  </label>
+                  <input
+                    type="date"
+                    value={campaignForm.startDate}
+                    onChange={(e) =>
+                      setCampaignForm({
+                        ...campaignForm,
+                        startDate: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  />
+                </div>
               </div>
-              <div className="text-xs text-gray-500">
-                Tip: Be specific about your target audience, platform preferences, and campaign objectives
+              <div className="flex gap-2 mt-6">
+                <button
+                  onClick={() => setShowCampaignModal(false)}
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleCreateCampaign}
+                  className="flex-1 px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800"
+                >
+                  Create Campaign
+                </button>
               </div>
-            </div>
-            <div className="mt-6 flex gap-2">
-              <button
-                onClick={() => setShowAgentModal(false)}
-                className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleGenerateWithAgent}
-                className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
-              >
-                Generate with AI
-              </button>
             </div>
           </div>
-        </div>
-      )}
+        )}
+
+        {/* AI Agent Modal */}
+        {showAgentModal && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 max-w-md w-full">
+              <h2 className="text-xl font-semibold text-black mb-4">
+                Advertising Agent
+              </h2>
+              <p className="text-sm text-gray-600 mb-4">
+                Describe your advertising goals and let AI create a campaign
+                strategy for you.
+              </p>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Campaign Description
+                  </label>
+                  <textarea
+                    value={agentPrompt}
+                    onChange={(e) => setAgentPrompt(e.target.value)}
+                    rows={4}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="Create a LinkedIn campaign to generate leads from enterprise SaaS companies, focusing on revenue operations and forecasting pain points..."
+                  />
+                </div>
+                <div className="text-xs text-gray-500">
+                  Tip: Be specific about your target audience, platform
+                  preferences, and campaign objectives
+                </div>
+              </div>
+              <div className="mt-6 flex gap-2">
+                <button
+                  onClick={() => setShowAgentModal(false)}
+                  className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleGenerateWithAgent}
+                  className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Generate with AI
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 import { PageTemplate } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
 import AlertList from "@/components/exec/AlertList";
 import KpiCard from "@/components/exec/KpiCard";
 import ScopeBar from "@/components/exec/ScopeBar";
@@ -21,9 +22,11 @@ type DashboardClientProps = {
   exportAction: () => Promise<{ ok: boolean; url: string }>;
 };
 
-export default function DashboardClient({ data, exportAction }: DashboardClientProps) {
+export default function DashboardClient({
+  data,
+  exportAction,
+}: DashboardClientProps) {
   const pathname = usePathname();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
@@ -31,12 +34,23 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
     return current && tabs.includes(current) ? current : tabs[0];
   }, [searchParams, tabs]);
 
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
   const d = data;
 
   const kpiGrid = (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
       <Card className={cn(TRS_CARD, "p-4")}>
-        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">Health Ribbon</div>
+        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">
+          Health Ribbon
+        </div>
         <div className="grid grid-cols-2 gap-3">
           <KpiCard
             label="North Star Run-rate"
@@ -48,30 +62,60 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
             value={`$${Math.round(d.ribbon.cashOnHand / 1000)}K`}
             hint={`${d.ribbon.runwayDays}d runway`}
           />
-          <KpiCard label="TRS Score" value={`${d.ribbon.trsScore}`} hint="0–100" />
-          <KpiCard label="Risk Index" value={`${d.ribbon.riskIndexPct}%`} hint="Prob. downside" />
+          <KpiCard
+            label="TRS Score"
+            value={`${d.ribbon.trsScore}`}
+            hint="0–100"
+          />
+          <KpiCard
+            label="Risk Index"
+            value={`${d.ribbon.riskIndexPct}%`}
+            hint="Prob. downside"
+          />
         </div>
       </Card>
       <Card className={cn(TRS_CARD, "p-4")}>
-        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">Sales</div>
+        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">
+          Sales
+        </div>
         <div className="grid grid-cols-2 gap-3">
-          <KpiCard label="Coverage (x)" value={d.sales.pipelineCoverageX.toFixed(1)} hint="vs target" />
+          <KpiCard
+            label="Coverage (x)"
+            value={d.sales.pipelineCoverageX.toFixed(1)}
+            hint="vs target"
+          />
           <KpiCard label="Win Rate 7d" value={`${d.sales.winRate7dPct}%`} />
           <KpiCard label="Win Rate 30d" value={`${d.sales.winRate30dPct}%`} />
-          <KpiCard label="Cycle Time" value={`${d.sales.cycleTimeDaysMedian}d`} />
+          <KpiCard
+            label="Cycle Time"
+            value={`${d.sales.cycleTimeDaysMedian}d`}
+          />
         </div>
       </Card>
       <Card className={cn(TRS_CARD, "p-4")}>
-        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">Finance</div>
+        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">
+          Finance
+        </div>
         <div className="grid grid-cols-2 gap-3">
-          <KpiCard label="AR Total" value={`$${Math.round(d.finance.arTotal / 1000)}K`} />
+          <KpiCard
+            label="AR Total"
+            value={`$${Math.round(d.finance.arTotal / 1000)}K`}
+          />
           <KpiCard label="DSO" value={`${d.finance.dsoDays}d`} />
-          <KpiCard label="Collected (7d)" value={`$${Math.round(d.finance.cashCollected7d / 1000)}K`} />
-          <KpiCard label="Price Realization" value={`${d.finance.priceRealizationPct}%`} />
+          <KpiCard
+            label="Collected (7d)"
+            value={`$${Math.round(d.finance.cashCollected7d / 1000)}K`}
+          />
+          <KpiCard
+            label="Price Realization"
+            value={`${d.finance.priceRealizationPct}%`}
+          />
         </div>
       </Card>
       <Card className={cn(TRS_CARD, "p-4")}>
-        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">Total Revenue</div>
+        <div className="mb-3 border-b border-gray-200 pb-2 text-sm font-medium text-black">
+          Total Revenue
+        </div>
         <div className="h-40">
           <SmallSpark />
         </div>
@@ -94,22 +138,7 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
       toolbarClassName="flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
       stats={activeTab === "Overview" ? kpiGrid : null}
     >
-      <div className="flex items-center gap-2 border-b border-gray-200 pb-2">
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => router.push(`${pathname}?tab=${encodeURIComponent(tab)}`)}
-            className={cn(
-              "px-3 py-2 text-sm font-medium transition-colors",
-              activeTab === tab
-                ? "border-b-2 border-black text-black"
-                : "text-gray-600 hover:text-black"
-            )}
-          >
-            {tab}
-          </button>
-        ))}
-      </div>
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
 
       {activeTab === "Overview" && (
         <div className="space-y-4">
@@ -127,7 +156,9 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
               <div className="h-64 p-4">
                 <AreaChart />
               </div>
-              <div className="px-4 pb-4 text-[11px] text-gray-500">p10 / p50 / p90 weekly bookings cone (stubbed)</div>
+              <div className="px-4 pb-4 text-[11px] text-gray-500">
+                p10 / p50 / p90 weekly bookings cone (stubbed)
+              </div>
             </Card>
             <Card className={cn(TRS_CARD)}>
               <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
@@ -152,16 +183,30 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
                 </Link>
               </div>
               <div className="grid grid-cols-2 gap-3 p-4">
-                <KpiCard label="Due Today" value={`$${Math.round(d.cashPanel.dueToday / 1000)}K`} />
-                <KpiCard label="Due This Week" value={`$${Math.round(d.cashPanel.dueThisWeek / 1000)}K`} />
-                <KpiCard label="At Risk" value={`$${Math.round(d.cashPanel.atRisk / 1000)}K`} />
-                <KpiCard label="Scenario DSO" value={`-${d.cashPanel.scenarioDSOdaysSaved}d`} />
+                <KpiCard
+                  label="Due Today"
+                  value={`$${Math.round(d.cashPanel.dueToday / 1000)}K`}
+                />
+                <KpiCard
+                  label="Due This Week"
+                  value={`$${Math.round(d.cashPanel.dueThisWeek / 1000)}K`}
+                />
+                <KpiCard
+                  label="At Risk"
+                  value={`$${Math.round(d.cashPanel.atRisk / 1000)}K`}
+                />
+                <KpiCard
+                  label="Scenario DSO"
+                  value={`-${d.cashPanel.scenarioDSOdaysSaved}d`}
+                />
               </div>
             </Card>
 
             <Card className={cn(TRS_CARD)}>
               <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-                <div className="text-sm font-medium">Pricing Power & Deal Desk</div>
+                <div className="text-sm font-medium">
+                  Pricing Power & Deal Desk
+                </div>
                 <Link
                   href="/pipeline?tab=Reports#deal-desk"
                   className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs hover:bg-gray-100"
@@ -170,15 +215,22 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
                 </Link>
               </div>
               <div className="space-y-3 p-4 text-sm">
-                <div className="mb-2 text-[11px] text-gray-500">Discount vs Win vs Margin (stub chart)</div>
+                <div className="mb-2 text-[11px] text-gray-500">
+                  Discount vs Win vs Margin (stub chart)
+                </div>
                 <div className="flex h-24 items-center justify-center rounded-md border border-gray-200 bg-white text-xs text-gray-600">
                   Curve
                 </div>
                 <div>
-                  <div className="mb-2 text-[12px] font-medium">Guardrail Breaches</div>
+                  <div className="mb-2 text-[12px] font-medium">
+                    Guardrail Breaches
+                  </div>
                   <ul className="space-y-2 text-[12px]">
                     {d.pricing.guardrailBreaches.map((b) => (
-                      <li key={b.id} className="flex items-center justify-between">
+                      <li
+                        key={b.id}
+                        className="flex items-center justify-between"
+                      >
                         <span>
                           {b.account} • {b.discountPct}% • {b.owner}
                         </span>
@@ -207,13 +259,27 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
               </div>
               <div className="space-y-3 p-4">
                 <div className="grid grid-cols-2 gap-3">
-                  <KpiCard label="Influenced $" value={`$${Math.round(d.content.influenced / 1000)}K`} />
-                  <KpiCard label="Closed-Won $" value={`$${Math.round(d.content.closedWon / 1000)}K`} />
-                  <KpiCard label="Usage Rate" value={`${d.content.usageRatePct}%`} />
-                  <KpiCard label="Advanced $" value={`$${Math.round(d.content.advanced / 1000)}K`} />
+                  <KpiCard
+                    label="Influenced $"
+                    value={`$${Math.round(d.content.influenced / 1000)}K`}
+                  />
+                  <KpiCard
+                    label="Closed-Won $"
+                    value={`$${Math.round(d.content.closedWon / 1000)}K`}
+                  />
+                  <KpiCard
+                    label="Usage Rate"
+                    value={`${d.content.usageRatePct}%`}
+                  />
+                  <KpiCard
+                    label="Advanced $"
+                    value={`$${Math.round(d.content.advanced / 1000)}K`}
+                  />
                 </div>
                 <div>
-                  <div className="mb-2 text-[11px] font-medium text-gray-700">Alerts</div>
+                  <div className="mb-2 text-[11px] font-medium text-gray-700">
+                    Alerts
+                  </div>
                   <AlertList items={d.alerts.slice(0, 2)} />
                 </div>
               </div>
@@ -225,9 +291,15 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
       {activeTab === "Analytics" && (
         <Card className={cn(TRS_CARD, "p-6")}>
           <div className="space-y-3 text-center">
-            <h2 className="text-lg font-semibold text-black">Advanced Analytics</h2>
-            <p className="text-sm text-gray-600">Deep-dive metrics, cohort analysis, and predictive modeling</p>
-            <div className="text-[11px] text-gray-500 italic">Feature coming soon</div>
+            <h2 className="text-lg font-semibold text-black">
+              Advanced Analytics
+            </h2>
+            <p className="text-sm text-gray-600">
+              Deep-dive metrics, cohort analysis, and predictive modeling
+            </p>
+            <div className="text-[11px] text-gray-500 italic">
+              Feature coming soon
+            </div>
           </div>
         </Card>
       )}
@@ -235,9 +307,15 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
       {activeTab === "Reports" && (
         <Card className={cn(TRS_CARD, "p-6")}>
           <div className="space-y-4">
-            <h2 className="text-lg font-semibold text-black">Executive Reports</h2>
-            <p className="text-sm text-gray-600">Board decks, investor updates, and quarterly business reviews</p>
-            <div className="text-[11px] text-gray-500 italic">Report builder coming soon</div>
+            <h2 className="text-lg font-semibold text-black">
+              Executive Reports
+            </h2>
+            <p className="text-sm text-gray-600">
+              Board decks, investor updates, and quarterly business reviews
+            </p>
+            <div className="text-[11px] text-gray-500 italic">
+              Report builder coming soon
+            </div>
           </div>
         </Card>
       )}
@@ -245,7 +323,9 @@ export default function DashboardClient({ data, exportAction }: DashboardClientP
       {activeTab === "Notifications" && (
         <Card className={cn(TRS_CARD, "p-6")}>
           <div className="space-y-4">
-            <h2 className="text-lg font-semibold text-black">Notifications & Alerts</h2>
+            <h2 className="text-lg font-semibold text-black">
+              Notifications & Alerts
+            </h2>
             <div className="space-y-3">
               <AlertList items={d.alerts} />
             </div>

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -1,15 +1,29 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
-import { usePathname, useSearchParams } from "next/navigation"
-import { PageTemplate } from "@/components/layout/PageTemplate"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { Badge } from "@/ui/badge"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/ui/table"
-import { Button } from "@/ui/button"
-import { cn } from "@/lib/utils"
-import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style"
-import { resolveTabs } from "@/lib/tabs"
+import { useCallback, useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { PageTemplate } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import { Badge } from "@/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/table";
+import { Button } from "@/ui/button";
+import { cn } from "@/lib/utils";
+import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style";
+import { resolveTabs } from "@/lib/tabs";
 import {
   getEquityHolders,
   getInvoices,
@@ -19,46 +33,62 @@ import {
   getCashFlow,
   getCashFlowForecast,
   getFinancialMetrics,
-} from "@/core/finance/store"
+} from "@/core/finance/store";
 
 export default function FinancePage() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
 
-  const equityHolders = useMemo(() => getEquityHolders(), [])
-  const invoices = useMemo(() => getInvoices(), [])
-  const subscriptions = useMemo(() => getSubscriptions(), [])
-  const expenses = useMemo(() => getExpenses(), [])
-  const profitLoss = useMemo(() => getProfitLoss(), [])
-  const cashFlow = useMemo(() => getCashFlow(), [])
-  const cashFlowForecast = useMemo(() => getCashFlowForecast(), [])
-  const metrics = useMemo(() => getFinancialMetrics(), [])
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
 
-  const formatCurrency = (amount: number) => `$${amount.toLocaleString()}`
-  const formatPercent = (value: number) => `${value.toFixed(1)}%`
+  const equityHolders = useMemo(() => getEquityHolders(), []);
+  const invoices = useMemo(() => getInvoices(), []);
+  const subscriptions = useMemo(() => getSubscriptions(), []);
+  const expenses = useMemo(() => getExpenses(), []);
+  const profitLoss = useMemo(() => getProfitLoss(), []);
+  const cashFlow = useMemo(() => getCashFlow(), []);
+  const cashFlowForecast = useMemo(() => getCashFlowForecast(), []);
+  const metrics = useMemo(() => getFinancialMetrics(), []);
+
+  const formatCurrency = (amount: number) => `$${amount.toLocaleString()}`;
+  const formatPercent = (value: number) => `${value.toFixed(1)}%`;
 
   const headerBadges = useMemo(
     () => [
       { label: `${metrics.runway} month runway`, variant: "success" as const },
-      { label: `Burn $${(metrics.burnRate / 1000).toFixed(0)}K/mo`, variant: "default" as const },
+      {
+        label: `Burn $${(metrics.burnRate / 1000).toFixed(0)}K/mo`,
+        variant: "default" as const,
+      },
       { label: `Gross margin ${metrics.grossMargin.toFixed(1)}%` },
     ],
     [metrics.runway, metrics.burnRate, metrics.grossMargin],
-  )
+  );
 
   const metricsGrid = (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
       <Card className={cn(TRS_CARD)}>
         <CardContent className="p-4 space-y-2">
           <div className={TRS_SUBTITLE}>Cash Balance</div>
-          <div className="text-2xl font-semibold text-black">{formatCurrency(metrics.cash)}</div>
+          <div className="text-2xl font-semibold text-black">
+            {formatCurrency(metrics.cash)}
+          </div>
           <div className="flex items-center gap-2 text-xs text-gray-600">
-            <span className="font-medium text-gray-700">{metrics.runway} months</span>
+            <span className="font-medium text-gray-700">
+              {metrics.runway} months
+            </span>
             <span>runway</span>
           </div>
         </CardContent>
@@ -67,7 +97,9 @@ export default function FinancePage() {
       <Card className={cn(TRS_CARD)}>
         <CardContent className="p-4 space-y-2">
           <div className={TRS_SUBTITLE}>MRR</div>
-          <div className="text-2xl font-semibold text-black">${(metrics.mrr / 1000).toFixed(0)}K</div>
+          <div className="text-2xl font-semibold text-black">
+            ${(metrics.mrr / 1000).toFixed(0)}K
+          </div>
           <div className="flex items-center gap-2 text-xs text-gray-600">
             <span className="font-medium text-gray-700">ARR</span>
             <span>${(metrics.arr / 1000).toFixed(0)}K</span>
@@ -78,7 +110,9 @@ export default function FinancePage() {
       <Card className={cn(TRS_CARD)}>
         <CardContent className="p-4 space-y-2">
           <div className={TRS_SUBTITLE}>Gross Margin</div>
-          <div className="text-2xl font-semibold text-black">{formatPercent(metrics.grossMargin)}</div>
+          <div className="text-2xl font-semibold text-black">
+            {formatPercent(metrics.grossMargin)}
+          </div>
           <div className="flex items-center gap-2 text-xs text-gray-600">
             <span className="font-medium text-gray-700">Net</span>
             <span>{formatPercent(metrics.netMargin)}</span>
@@ -89,7 +123,9 @@ export default function FinancePage() {
       <Card className={cn(TRS_CARD)}>
         <CardContent className="p-4 space-y-2">
           <div className={TRS_SUBTITLE}>LTV / CAC</div>
-          <div className="text-2xl font-semibold text-black">{metrics.ltvCacRatio.toFixed(1)}x</div>
+          <div className="text-2xl font-semibold text-black">
+            {metrics.ltvCacRatio.toFixed(1)}x
+          </div>
           <div className="flex items-center gap-2 text-xs text-gray-600">
             <span className="font-medium text-gray-700">Burn</span>
             <span>${(metrics.burnRate / 1000).toFixed(0)}K/mo</span>
@@ -97,7 +133,7 @@ export default function FinancePage() {
         </CardContent>
       </Card>
     </div>
-  )
+  );
 
   return (
     <PageTemplate
@@ -106,12 +142,16 @@ export default function FinancePage() {
       badges={headerBadges}
       stats={metricsGrid}
     >
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
       {activeTab === "Overview" && (
         <div className="space-y-4">
           <div className={cn(TRS_CARD, "p-4 space-y-3")}>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="space-y-1">
-                <h2 className="text-lg font-semibold text-black">Financial Overview</h2>
+                <h2 className="text-lg font-semibold text-black">
+                  Financial Overview
+                </h2>
                 <p className="text-sm text-gray-500">
                   Comprehensive view of equity, revenue, expenses, and cash flow
                 </p>
@@ -122,8 +162,12 @@ export default function FinancePage() {
           {/* Recent Activity */}
           <Card className={cn(TRS_CARD)}>
             <CardHeader>
-              <CardTitle className="text-sm font-medium">Recent Cash Flow</CardTitle>
-              <CardDescription>Latest transactions impacting cash position</CardDescription>
+              <CardTitle className="text-sm font-medium">
+                Recent Cash Flow
+              </CardTitle>
+              <CardDescription>
+                Latest transactions impacting cash position
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
@@ -143,16 +187,27 @@ export default function FinancePage() {
                         {new Date(entry.date).toLocaleDateString()}
                       </TableCell>
                       <TableCell>
-                        <Badge variant={entry.type === 'Inflow' ? 'success' : 'default'}>
+                        <Badge
+                          variant={
+                            entry.type === "Inflow" ? "success" : "default"
+                          }
+                        >
                           {entry.type}
                         </Badge>
                       </TableCell>
-                      <TableCell className="font-medium">{entry.description}</TableCell>
-                      <TableCell className={cn(
-                        "text-right font-medium",
-                        entry.type === 'Inflow' ? 'text-emerald-600' : 'text-rose-600'
-                      )}>
-                        {entry.type === 'Inflow' ? '+' : '-'}{formatCurrency(entry.amount)}
+                      <TableCell className="font-medium">
+                        {entry.description}
+                      </TableCell>
+                      <TableCell
+                        className={cn(
+                          "text-right font-medium",
+                          entry.type === "Inflow"
+                            ? "text-emerald-600"
+                            : "text-rose-600",
+                        )}
+                      >
+                        {entry.type === "Inflow" ? "+" : "-"}
+                        {formatCurrency(entry.amount)}
                       </TableCell>
                       <TableCell className="text-right font-medium">
                         {formatCurrency(entry.balance)}
@@ -173,9 +228,13 @@ export default function FinancePage() {
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <CardTitle>Cap Table</CardTitle>
-                  <CardDescription>Equity ownership and vesting schedules</CardDescription>
+                  <CardDescription>
+                    Equity ownership and vesting schedules
+                  </CardDescription>
                 </div>
-                <Button variant="primary" size="sm">Add Equity Grant</Button>
+                <Button variant="primary" size="sm">
+                  Add Equity Grant
+                </Button>
               </div>
             </CardHeader>
             <CardContent>
@@ -183,25 +242,42 @@ export default function FinancePage() {
                 <div>
                   <div className="text-xs text-gray-500">Total Shares</div>
                   <div className="text-lg font-semibold text-black">
-                    {equityHolders.reduce((sum, h) => sum + h.shares, 0).toLocaleString()}
+                    {equityHolders
+                      .reduce((sum, h) => sum + h.shares, 0)
+                      .toLocaleString()}
                   </div>
                 </div>
                 <div>
-                  <div className="text-xs text-gray-500">Fully Diluted Value</div>
+                  <div className="text-xs text-gray-500">
+                    Fully Diluted Value
+                  </div>
                   <div className="text-lg font-semibold text-black">
-                    {formatCurrency(equityHolders.reduce((sum, h) => sum + h.valueAtCurrent, 0))}
+                    {formatCurrency(
+                      equityHolders.reduce(
+                        (sum, h) => sum + h.valueAtCurrent,
+                        0,
+                      ),
+                    )}
                   </div>
                 </div>
                 <div>
                   <div className="text-xs text-gray-500">Founders</div>
                   <div className="text-lg font-semibold text-black">
-                    {formatPercent(equityHolders.filter(h => h.holderType === 'Founder').reduce((sum, h) => sum + h.percentage, 0))}
+                    {formatPercent(
+                      equityHolders
+                        .filter((h) => h.holderType === "Founder")
+                        .reduce((sum, h) => sum + h.percentage, 0),
+                    )}
                   </div>
                 </div>
                 <div>
                   <div className="text-xs text-gray-500">Investors</div>
                   <div className="text-lg font-semibold text-black">
-                    {formatPercent(equityHolders.filter(h => h.holderType === 'Investor').reduce((sum, h) => sum + h.percentage, 0))}
+                    {formatPercent(
+                      equityHolders
+                        .filter((h) => h.holderType === "Investor")
+                        .reduce((sum, h) => sum + h.percentage, 0),
+                    )}
                   </div>
                 </div>
               </div>
@@ -221,21 +297,34 @@ export default function FinancePage() {
                 <TableBody>
                   {equityHolders.map((holder) => (
                     <TableRow key={holder.id}>
-                      <TableCell className="font-medium">{holder.name}</TableCell>
+                      <TableCell className="font-medium">
+                        {holder.name}
+                      </TableCell>
                       <TableCell>
                         <Badge variant="outline">{holder.holderType}</Badge>
                       </TableCell>
-                      <TableCell className="text-sm text-gray-600">{holder.equityType}</TableCell>
-                      <TableCell className="text-right">{holder.shares.toLocaleString()}</TableCell>
-                      <TableCell className="text-right font-medium">{formatPercent(holder.percentage)}</TableCell>
-                      <TableCell className="text-right">{formatCurrency(holder.valueAtCurrent)}</TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {holder.equityType}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {holder.shares.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatPercent(holder.percentage)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(holder.valueAtCurrent)}
+                      </TableCell>
                       <TableCell className="text-sm text-gray-600">
                         {holder.vestingSchedule ? (
                           <span>
-                            {holder.vestingSchedule.vestedShares.toLocaleString()} / {holder.vestingSchedule.totalShares.toLocaleString()} vested
+                            {holder.vestingSchedule.vestedShares.toLocaleString()}{" "}
+                            /{" "}
+                            {holder.vestingSchedule.totalShares.toLocaleString()}{" "}
+                            vested
                           </span>
                         ) : (
-                          '—'
+                          "—"
                         )}
                       </TableCell>
                     </TableRow>
@@ -252,11 +341,17 @@ export default function FinancePage() {
           <div className="flex items-center justify-between">
             <div>
               <h2 className={TRS_SECTION_TITLE}>Invoices & Billing</h2>
-              <p className={TRS_SUBTITLE}>Track outstanding invoices and payment collection</p>
+              <p className={TRS_SUBTITLE}>
+                Track outstanding invoices and payment collection
+              </p>
             </div>
             <div className="flex gap-2">
-              <Button variant="outline" size="sm">Export</Button>
-              <Button variant="primary" size="sm">New Invoice</Button>
+              <Button variant="outline" size="sm">
+                Export
+              </Button>
+              <Button variant="primary" size="sm">
+                New Invoice
+              </Button>
             </div>
           </div>
 
@@ -264,50 +359,75 @@ export default function FinancePage() {
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <Card>
               <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Total Outstanding</CardTitle>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Total Outstanding
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold text-black">
-                  {formatCurrency(invoices.filter(i => i.status !== 'Paid').reduce((sum, i) => sum + i.total, 0))}
+                  {formatCurrency(
+                    invoices
+                      .filter((i) => i.status !== "Paid")
+                      .reduce((sum, i) => sum + i.total, 0),
+                  )}
                 </p>
               </CardContent>
             </Card>
 
             <Card>
               <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Overdue</CardTitle>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Overdue
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold text-rose-600">
-                  {formatCurrency(invoices.filter(i => i.status === 'Overdue').reduce((sum, i) => sum + i.total, 0))}
+                  {formatCurrency(
+                    invoices
+                      .filter((i) => i.status === "Overdue")
+                      .reduce((sum, i) => sum + i.total, 0),
+                  )}
                 </p>
                 <p className="text-xs text-gray-600 mt-1">
-                  {invoices.filter(i => i.status === 'Overdue').length} invoices
+                  {invoices.filter((i) => i.status === "Overdue").length}{" "}
+                  invoices
                 </p>
               </CardContent>
             </Card>
 
             <Card>
               <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Paid This Month</CardTitle>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Paid This Month
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold text-emerald-600">
-                  {formatCurrency(invoices.filter(i => i.status === 'Paid').reduce((sum, i) => sum + i.total, 0))}
+                  {formatCurrency(
+                    invoices
+                      .filter((i) => i.status === "Paid")
+                      .reduce((sum, i) => sum + i.total, 0),
+                  )}
                 </p>
               </CardContent>
             </Card>
 
             <Card>
               <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Pending</CardTitle>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Pending
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold text-black">
-                  {formatCurrency(invoices.filter(i => i.status === 'Sent').reduce((sum, i) => sum + i.total, 0))}
+                  {formatCurrency(
+                    invoices
+                      .filter((i) => i.status === "Sent")
+                      .reduce((sum, i) => sum + i.total, 0),
+                  )}
                 </p>
                 <p className="text-xs text-gray-600 mt-1">
-                  {invoices.filter(i => i.status === 'Sent').length} invoices
+                  {invoices.filter((i) => i.status === "Sent").length} invoices
                 </p>
               </CardContent>
             </Card>
@@ -317,7 +437,9 @@ export default function FinancePage() {
           <Card>
             <CardHeader>
               <CardTitle>All Invoices</CardTitle>
-              <CardDescription>Complete invoice history and status</CardDescription>
+              <CardDescription>
+                Complete invoice history and status
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
@@ -335,15 +457,22 @@ export default function FinancePage() {
                 <TableBody>
                   {invoices.map((invoice) => (
                     <TableRow key={invoice.id}>
-                      <TableCell className="font-medium">{invoice.invoiceNumber}</TableCell>
+                      <TableCell className="font-medium">
+                        {invoice.invoiceNumber}
+                      </TableCell>
                       <TableCell>{invoice.clientName}</TableCell>
                       <TableCell>
-                        <Badge variant={
-                          invoice.status === 'Paid' ? 'success' :
-                          invoice.status === 'Overdue' ? 'destructive' :
-                          invoice.status === 'Sent' ? 'default' :
-                          'outline'
-                        }>
+                        <Badge
+                          variant={
+                            invoice.status === "Paid"
+                              ? "success"
+                              : invoice.status === "Overdue"
+                                ? "destructive"
+                                : invoice.status === "Sent"
+                                  ? "default"
+                                  : "outline"
+                          }
+                        >
                           {invoice.status}
                         </Badge>
                       </TableCell>
@@ -353,8 +482,12 @@ export default function FinancePage() {
                       <TableCell className="text-sm text-gray-600">
                         {new Date(invoice.dueDate).toLocaleDateString()}
                       </TableCell>
-                      <TableCell className="text-right">{formatCurrency(invoice.amount)}</TableCell>
-                      <TableCell className="text-right font-medium">{formatCurrency(invoice.total)}</TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(invoice.amount)}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatCurrency(invoice.total)}
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -369,59 +502,84 @@ export default function FinancePage() {
           <div className="flex items-center justify-between">
             <div>
               <h2 className={TRS_SECTION_TITLE}>Recurring Revenue</h2>
-              <p className={TRS_SUBTITLE}>Subscription management and MRR/ARR tracking</p>
+              <p className={TRS_SUBTITLE}>
+                Subscription management and MRR/ARR tracking
+              </p>
             </div>
-            <Button variant="primary" size="sm">New Subscription</Button>
+            <Button variant="primary" size="sm">
+              New Subscription
+            </Button>
           </div>
 
           {/* MRR/ARR Stats */}
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <Card>
               <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Monthly Recurring Revenue</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-semibold text-black">
-                  {formatCurrency(subscriptions.filter(s => s.status === 'Active').reduce((sum, s) => sum + s.mrr, 0))}
-                </p>
-                <p className="text-xs text-emerald-600 mt-1">+12% vs last month</p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Annual Recurring Revenue</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-semibold text-black">
-                  {formatCurrency(subscriptions.filter(s => s.status === 'Active').reduce((sum, s) => sum + s.arr, 0))}
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Active Subscriptions</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-semibold text-black">
-                  {subscriptions.filter(s => s.status === 'Active').length}
-                </p>
-                <p className="text-xs text-gray-600 mt-1">
-                  {subscriptions.filter(s => s.status === 'Trial').length} in trial
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium text-gray-600">Avg Contract Value</CardTitle>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Monthly Recurring Revenue
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold text-black">
                   {formatCurrency(
-                    subscriptions.filter(s => s.status === 'Active').reduce((sum, s) => sum + s.contractValue, 0) /
-                    subscriptions.filter(s => s.status === 'Active').length
+                    subscriptions
+                      .filter((s) => s.status === "Active")
+                      .reduce((sum, s) => sum + s.mrr, 0),
+                  )}
+                </p>
+                <p className="text-xs text-emerald-600 mt-1">
+                  +12% vs last month
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Annual Recurring Revenue
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold text-black">
+                  {formatCurrency(
+                    subscriptions
+                      .filter((s) => s.status === "Active")
+                      .reduce((sum, s) => sum + s.arr, 0),
+                  )}
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Active Subscriptions
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold text-black">
+                  {subscriptions.filter((s) => s.status === "Active").length}
+                </p>
+                <p className="text-xs text-gray-600 mt-1">
+                  {subscriptions.filter((s) => s.status === "Trial").length} in
+                  trial
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm font-medium text-gray-600">
+                  Avg Contract Value
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold text-black">
+                  {formatCurrency(
+                    subscriptions
+                      .filter((s) => s.status === "Active")
+                      .reduce((sum, s) => sum + s.contractValue, 0) /
+                      subscriptions.filter((s) => s.status === "Active").length,
                   )}
                 </p>
               </CardContent>
@@ -432,7 +590,9 @@ export default function FinancePage() {
           <Card>
             <CardHeader>
               <CardTitle>All Subscriptions</CardTitle>
-              <CardDescription>Customer subscriptions and recurring revenue breakdown</CardDescription>
+              <CardDescription>
+                Customer subscriptions and recurring revenue breakdown
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
@@ -451,21 +611,36 @@ export default function FinancePage() {
                 <TableBody>
                   {subscriptions.map((sub) => (
                     <TableRow key={sub.id}>
-                      <TableCell className="font-medium">{sub.clientName}</TableCell>
-                      <TableCell className="text-sm text-gray-600">{sub.productName}</TableCell>
+                      <TableCell className="font-medium">
+                        {sub.clientName}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {sub.productName}
+                      </TableCell>
                       <TableCell>
-                        <Badge variant={
-                          sub.status === 'Active' ? 'success' :
-                          sub.status === 'Trial' ? 'default' :
-                          sub.status === 'Paused' ? 'outline' :
-                          'destructive'
-                        }>
+                        <Badge
+                          variant={
+                            sub.status === "Active"
+                              ? "success"
+                              : sub.status === "Trial"
+                                ? "default"
+                                : sub.status === "Paused"
+                                  ? "outline"
+                                  : "destructive"
+                          }
+                        >
                           {sub.status}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-sm text-gray-600">{sub.billingFrequency}</TableCell>
-                      <TableCell className="text-right font-medium">{formatCurrency(sub.mrr)}</TableCell>
-                      <TableCell className="text-right">{formatCurrency(sub.arr)}</TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {sub.billingFrequency}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatCurrency(sub.mrr)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(sub.arr)}
+                      </TableCell>
                       <TableCell className="text-sm text-gray-600">
                         {new Date(sub.nextBillingDate).toLocaleDateString()}
                       </TableCell>
@@ -486,11 +661,17 @@ export default function FinancePage() {
           <div className="flex items-center justify-between">
             <div>
               <h2 className={TRS_SECTION_TITLE}>Expenses & P&L</h2>
-              <p className={TRS_SUBTITLE}>Track expenses and profit/loss statements</p>
+              <p className={TRS_SUBTITLE}>
+                Track expenses and profit/loss statements
+              </p>
             </div>
             <div className="flex gap-2">
-              <Button variant="outline" size="sm">Export P&L</Button>
-              <Button variant="primary" size="sm">Add Expense</Button>
+              <Button variant="outline" size="sm">
+                Export P&L
+              </Button>
+              <Button variant="primary" size="sm">
+                Add Expense
+              </Button>
             </div>
           </div>
 
@@ -499,76 +680,124 @@ export default function FinancePage() {
             <Card>
               <CardHeader>
                 <CardTitle>Profit & Loss - {profitLoss[0].period}</CardTitle>
-                <CardDescription>Income statement for the current period</CardDescription>
+                <CardDescription>
+                  Income statement for the current period
+                </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
                   <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-2">Revenue</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                      Revenue
+                    </h3>
                     <div className="space-y-1 text-sm">
                       <div className="flex justify-between">
                         <span className="text-gray-600">Subscriptions</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].revenue.subscriptions)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].revenue.subscriptions)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-600">Services</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].revenue.services)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].revenue.services)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-600">Other</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].revenue.other)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].revenue.other)}
+                        </span>
                       </div>
                       <div className="flex justify-between pt-2 border-t">
-                        <span className="font-semibold text-black">Total Revenue</span>
-                        <span className="font-semibold text-black">{formatCurrency(profitLoss[0].revenue.total)}</span>
+                        <span className="font-semibold text-black">
+                          Total Revenue
+                        </span>
+                        <span className="font-semibold text-black">
+                          {formatCurrency(profitLoss[0].revenue.total)}
+                        </span>
                       </div>
                     </div>
                   </div>
 
                   <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-2">Expenses</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                      Expenses
+                    </h3>
                     <div className="space-y-1 text-sm">
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Payroll & Benefits</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.payroll)}</span>
+                        <span className="text-gray-600">
+                          Payroll & Benefits
+                        </span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.payroll)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-600">Marketing</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.marketing)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.marketing)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-600">Software & Tools</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.software)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.software)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Office & Equipment</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.office)}</span>
+                        <span className="text-gray-600">
+                          Office & Equipment
+                        </span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.office)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Professional Services</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.professional)}</span>
+                        <span className="text-gray-600">
+                          Professional Services
+                        </span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.professional)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Hosting & Infrastructure</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.hosting)}</span>
+                        <span className="text-gray-600">
+                          Hosting & Infrastructure
+                        </span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.hosting)}
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-600">Other</span>
-                        <span className="font-medium">{formatCurrency(profitLoss[0].expenses.other)}</span>
+                        <span className="font-medium">
+                          {formatCurrency(profitLoss[0].expenses.other)}
+                        </span>
                       </div>
                       <div className="flex justify-between pt-2 border-t">
-                        <span className="font-semibold text-black">Total Expenses</span>
-                        <span className="font-semibold text-black">{formatCurrency(profitLoss[0].expenses.total)}</span>
+                        <span className="font-semibold text-black">
+                          Total Expenses
+                        </span>
+                        <span className="font-semibold text-black">
+                          {formatCurrency(profitLoss[0].expenses.total)}
+                        </span>
                       </div>
                     </div>
                   </div>
 
                   <div className="pt-3 border-t-2 border-gray-200">
                     <div className="flex justify-between items-center">
-                      <span className="text-lg font-bold text-black">Net Income</span>
+                      <span className="text-lg font-bold text-black">
+                        Net Income
+                      </span>
                       <div className="text-right">
-                        <div className="text-2xl font-bold text-emerald-600">{formatCurrency(profitLoss[0].netIncome)}</div>
-                        <div className="text-sm text-gray-600">{formatPercent(profitLoss[0].profitMargin)} margin</div>
+                        <div className="text-2xl font-bold text-emerald-600">
+                          {formatCurrency(profitLoss[0].netIncome)}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          {formatPercent(profitLoss[0].profitMargin)} margin
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -604,12 +833,20 @@ export default function FinancePage() {
                       <TableCell>
                         <Badge variant="outline">{expense.category}</Badge>
                       </TableCell>
-                      <TableCell className="font-medium">{expense.vendor}</TableCell>
-                      <TableCell className="text-sm text-gray-600">{expense.description}</TableCell>
-                      <TableCell className="text-right font-medium">{formatCurrency(expense.amount)}</TableCell>
+                      <TableCell className="font-medium">
+                        {expense.vendor}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {expense.description}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatCurrency(expense.amount)}
+                      </TableCell>
                       <TableCell>
-                        <Badge variant={expense.approved ? 'success' : 'default'}>
-                          {expense.approved ? 'Approved' : 'Pending'}
+                        <Badge
+                          variant={expense.approved ? "success" : "default"}
+                        >
+                          {expense.approved ? "Approved" : "Pending"}
                         </Badge>
                       </TableCell>
                     </TableRow>
@@ -626,34 +863,52 @@ export default function FinancePage() {
           <div className="flex items-center justify-between">
             <div>
               <h2 className={TRS_SECTION_TITLE}>Cash Flow & Forecasting</h2>
-              <p className={TRS_SUBTITLE}>Monitor cash position and forecast future runway</p>
+              <p className={TRS_SUBTITLE}>
+                Monitor cash position and forecast future runway
+              </p>
             </div>
-            <Button variant="primary" size="sm">Update Forecast</Button>
+            <Button variant="primary" size="sm">
+              Update Forecast
+            </Button>
           </div>
 
           {/* Cash Flow Forecast */}
           <Card>
             <CardHeader>
               <CardTitle>3-Month Cash Flow Forecast</CardTitle>
-              <CardDescription>Projected cash position and runway</CardDescription>
+              <CardDescription>
+                Projected cash position and runway
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
                 <TableHeader>
                   <TableRow>
                     <TableHead>Month</TableHead>
-                    <TableHead className="text-right">Beginning Balance</TableHead>
-                    <TableHead className="text-right">Expected Inflows</TableHead>
-                    <TableHead className="text-right">Expected Outflows</TableHead>
+                    <TableHead className="text-right">
+                      Beginning Balance
+                    </TableHead>
+                    <TableHead className="text-right">
+                      Expected Inflows
+                    </TableHead>
+                    <TableHead className="text-right">
+                      Expected Outflows
+                    </TableHead>
                     <TableHead className="text-right">Ending Balance</TableHead>
-                    <TableHead className="text-right">Runway (months)</TableHead>
+                    <TableHead className="text-right">
+                      Runway (months)
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {cashFlowForecast.map((forecast) => (
                     <TableRow key={forecast.month}>
-                      <TableCell className="font-medium">{forecast.month}</TableCell>
-                      <TableCell className="text-right">{formatCurrency(forecast.beginningBalance)}</TableCell>
+                      <TableCell className="font-medium">
+                        {forecast.month}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(forecast.beginningBalance)}
+                      </TableCell>
                       <TableCell className="text-right text-emerald-600">
                         +{formatCurrency(forecast.expectedInflows)}
                       </TableCell>
@@ -663,7 +918,9 @@ export default function FinancePage() {
                       <TableCell className="text-right font-semibold">
                         {formatCurrency(forecast.endingBalance)}
                       </TableCell>
-                      <TableCell className="text-right font-medium">{forecast.runway}mo</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {forecast.runway}mo
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -675,7 +932,9 @@ export default function FinancePage() {
           <Card>
             <CardHeader>
               <CardTitle>Recent Cash Flow Transactions</CardTitle>
-              <CardDescription>Detailed cash inflows and outflows</CardDescription>
+              <CardDescription>
+                Detailed cash inflows and outflows
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
@@ -696,17 +955,30 @@ export default function FinancePage() {
                         {new Date(entry.date).toLocaleDateString()}
                       </TableCell>
                       <TableCell>
-                        <Badge variant={entry.type === 'Inflow' ? 'success' : 'default'}>
+                        <Badge
+                          variant={
+                            entry.type === "Inflow" ? "success" : "default"
+                          }
+                        >
                           {entry.type}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-sm text-gray-600">{entry.category}</TableCell>
-                      <TableCell className="font-medium">{entry.description}</TableCell>
-                      <TableCell className={cn(
-                        "text-right font-medium",
-                        entry.type === 'Inflow' ? 'text-emerald-600' : 'text-rose-600'
-                      )}>
-                        {entry.type === 'Inflow' ? '+' : '-'}{formatCurrency(entry.amount)}
+                      <TableCell className="text-sm text-gray-600">
+                        {entry.category}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {entry.description}
+                      </TableCell>
+                      <TableCell
+                        className={cn(
+                          "text-right font-medium",
+                          entry.type === "Inflow"
+                            ? "text-emerald-600"
+                            : "text-rose-600",
+                        )}
+                      >
+                        {entry.type === "Inflow" ? "+" : "-"}
+                        {formatCurrency(entry.amount)}
                       </TableCell>
                       <TableCell className="text-right font-semibold">
                         {formatCurrency(entry.balance)}
@@ -720,5 +992,5 @@ export default function FinancePage() {
         </div>
       )}
     </PageTemplate>
-  )
+  );
 }

--- a/app/mail-calendar/page.tsx
+++ b/app/mail-calendar/page.tsx
@@ -1,21 +1,29 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
-import { usePathname, useSearchParams } from "next/navigation"
+import { useCallback, useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
-import { PageTemplate } from "@/components/layout/PageTemplate"
-import { Badge } from "@/ui/badge"
-import { Button } from "@/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { TRS_CARD, TRS_SECTION_TITLE } from "@/lib/style"
-import { resolveTabs } from "@/lib/tabs"
+import { PageTemplate } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import { TRS_CARD, TRS_SECTION_TITLE } from "@/lib/style";
+import { resolveTabs } from "@/lib/tabs";
 
 const inboxThreads = [
   {
     id: "t1",
     sender: "RevenueOps Alerts",
     subject: "Daily pipeline sync & risk summary",
-    preview: "Highlights from RevOps: 3 deals need follow up, 1 flagged for pricing exception.",
+    preview:
+      "Highlights from RevOps: 3 deals need follow up, 1 flagged for pricing exception.",
     receivedAt: "9:24 AM",
     tags: ["Priority", "Automation"],
   },
@@ -23,7 +31,8 @@ const inboxThreads = [
     id: "t2",
     sender: "Gmail – Marketing",
     subject: "Launch checklist for Q4 nurture sequence",
-    preview: "Creative brief approved. Final assets due Friday before we handoff to sequencing.",
+    preview:
+      "Creative brief approved. Final assets due Friday before we handoff to sequencing.",
     receivedAt: "8:10 AM",
     tags: ["Campaign", "Content"],
   },
@@ -31,11 +40,12 @@ const inboxThreads = [
     id: "t3",
     sender: "HostGator Support",
     subject: "DNS verification for calendar routing",
-    preview: "TXT records validated. You can finalize calendar availability sync across providers.",
+    preview:
+      "TXT records validated. You can finalize calendar availability sync across providers.",
     receivedAt: "Yesterday",
     tags: ["Integration"],
   },
-]
+];
 
 const calendarEvents = [
   {
@@ -59,62 +69,99 @@ const calendarEvents = [
     participants: ["Demand Gen", "Sales Leads"],
     type: "Collaboration",
   },
-]
+];
 
 const integrationStatus = [
-  { id: "i1", name: "Gmail API", description: "Primary inbox connection for GTM leadership.", status: "Connected" },
-  { id: "i2", name: "Google Calendar", description: "Two-way sync with focus blocks and QBRs.", status: "Connected" },
-  { id: "i3", name: "HostGator Mailboxes", description: "Routing shared support and partner mailboxes.", status: "Syncing" },
-  { id: "i4", name: "Zoom", description: "Auto-attach meeting recordings to thread history.", status: "Planned" },
-]
+  {
+    id: "i1",
+    name: "Gmail API",
+    description: "Primary inbox connection for GTM leadership.",
+    status: "Connected",
+  },
+  {
+    id: "i2",
+    name: "Google Calendar",
+    description: "Two-way sync with focus blocks and QBRs.",
+    status: "Connected",
+  },
+  {
+    id: "i3",
+    name: "HostGator Mailboxes",
+    description: "Routing shared support and partner mailboxes.",
+    status: "Syncing",
+  },
+  {
+    id: "i4",
+    name: "Zoom",
+    description: "Auto-attach meeting recordings to thread history.",
+    status: "Planned",
+  },
+];
 
 const schedulerInsights = [
   "Auto-send recap docs 15 minutes after meetings with transcripts and highlights.",
   "Detect conflicts between focus blocks and external invites to suggest alternates.",
   "Create shared agendas with AI-suggested objectives for pipeline and renewal calls.",
-]
+];
 
 const roadmapItems = [
   {
     id: "r1",
     title: "Outlook + Microsoft 365",
-    description: "Extend parity for enterprise clients running Microsoft stacks.",
+    description:
+      "Extend parity for enterprise clients running Microsoft stacks.",
     eta: "Q1 FY26",
   },
   {
     id: "r2",
     title: "Supabase pipeline highlights",
-    description: "Push high-signal email summaries into deal rooms and CS channels.",
+    description:
+      "Push high-signal email summaries into deal rooms and CS channels.",
     eta: "In discovery",
   },
   {
     id: "r3",
     title: "Dialer intelligence",
-    description: "Attach call notes and Gong snippets to relevant threads automatically.",
+    description:
+      "Attach call notes and Gong snippets to relevant threads automatically.",
     eta: "Pilot customers",
   },
   {
     id: "r4",
     title: "Calendar analytics pack",
-    description: "Report on context switching, meeting load, and focus-time leakage.",
+    description:
+      "Report on context switching, meeting load, and focus-time leakage.",
     eta: "Design sprint",
   },
-]
+];
 
 const availabilityMetrics = [
   { label: "Focus hours protected", value: "18 hrs", trend: "↑ 3 hrs WoW" },
   { label: "QBR windows available", value: "6 slots", trend: "Next 14 days" },
-  { label: "Travel days detected", value: "2 leaders", trend: "Auto-blocked on calendar" },
-]
+  {
+    label: "Travel days detected",
+    value: "2 leaders",
+    trend: "Auto-blocked on calendar",
+  },
+];
 
 export default function MailCalendarPage() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
+
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
 
   return (
     <PageTemplate
@@ -126,24 +173,36 @@ export default function MailCalendarPage() {
         { label: "HostGator routing supported", variant: "default" as const },
       ]}
     >
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
       {activeTab === "Inbox" && (
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Today’s priorities</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Today’s priorities
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Threads surfaced from automation rules, sentiment analysis, and revenue triggers.
+                Threads surfaced from automation rules, sentiment analysis, and
+                revenue triggers.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {inboxThreads.map((thread) => (
-                <div key={thread.id} className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <div
+                  key={thread.id}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+                >
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
-                      <p className="text-sm font-semibold text-black">{thread.subject}</p>
+                      <p className="text-sm font-semibold text-black">
+                        {thread.subject}
+                      </p>
                       <p className="text-xs text-gray-500">{thread.sender}</p>
                     </div>
-                    <span className="text-xs text-gray-500">{thread.receivedAt}</span>
+                    <span className="text-xs text-gray-500">
+                      {thread.receivedAt}
+                    </span>
                   </div>
                   <p className="mt-2 text-sm text-gray-600">{thread.preview}</p>
                   <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -160,9 +219,12 @@ export default function MailCalendarPage() {
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Automation playbooks</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Automation playbooks
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Suggested automations to keep inbox triage tight across GTM teams.
+                Suggested automations to keep inbox triage tight across GTM
+                teams.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -170,33 +232,44 @@ export default function MailCalendarPage() {
                 {
                   id: "a1",
                   title: "Follow-up nudges",
-                  description: "Auto-remind owners on stalled threads after 24 hours with no reply.",
+                  description:
+                    "Auto-remind owners on stalled threads after 24 hours with no reply.",
                   impact: "Protect SLAs",
                 },
                 {
                   id: "a2",
                   title: "Deal room bundling",
-                  description: "Attach latest forecast, pricing sheet, and mutual action plan to opportunity emails.",
+                  description:
+                    "Attach latest forecast, pricing sheet, and mutual action plan to opportunity emails.",
                   impact: "Faster cycles",
                 },
                 {
                   id: "a3",
                   title: "Calendar insights in inbox",
-                  description: "Embed available focus blocks or QBR windows directly into reply suggestions.",
+                  description:
+                    "Embed available focus blocks or QBR windows directly into reply suggestions.",
                   impact: "Eliminate back-and-forth",
                 },
                 {
                   id: "a4",
                   title: "Sentiment routing",
-                  description: "Escalate negative sentiment threads to leadership with context and suggested replies.",
+                  description:
+                    "Escalate negative sentiment threads to leadership with context and suggested replies.",
                   impact: "Save renewals",
                 },
               ].map((play) => (
-                <div key={play.id} className="flex flex-col rounded-lg border border-gray-200 p-4">
+                <div
+                  key={play.id}
+                  className="flex flex-col rounded-lg border border-gray-200 p-4"
+                >
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <p className="text-sm font-semibold text-black">{play.title}</p>
-                      <p className="mt-1 text-sm text-gray-600">{play.description}</p>
+                      <p className="text-sm font-semibold text-black">
+                        {play.title}
+                      </p>
+                      <p className="mt-1 text-sm text-gray-600">
+                        {play.description}
+                      </p>
                     </div>
                     <Badge variant="success">{play.impact}</Badge>
                   </div>
@@ -214,9 +287,12 @@ export default function MailCalendarPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Upcoming schedule</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Upcoming schedule
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Key meetings synchronized from Google Calendar and focus block priorities.
+                Key meetings synchronized from Google Calendar and focus block
+                priorities.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -226,8 +302,12 @@ export default function MailCalendarPage() {
                   className="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 md:flex-row md:items-center md:justify-between"
                 >
                   <div>
-                    <p className="text-sm font-semibold text-black">{event.title}</p>
-                    <p className="text-xs text-gray-500">{event.participants.join(", ")}</p>
+                    <p className="text-sm font-semibold text-black">
+                      {event.title}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {event.participants.join(", ")}
+                    </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
                     <Badge variant="outline">{event.type}</Badge>
@@ -244,19 +324,27 @@ export default function MailCalendarPage() {
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <Card className={TRS_CARD}>
               <CardHeader>
-                <CardTitle className="text-lg font-semibold text-black">Availability intelligence</CardTitle>
+                <CardTitle className="text-lg font-semibold text-black">
+                  Availability intelligence
+                </CardTitle>
                 <CardDescription className="text-sm text-gray-500">
-                  Surface shared free blocks, travel windows, and focus hours per leader.
+                  Surface shared free blocks, travel windows, and focus hours
+                  per leader.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {availabilityMetrics.map((metric) => (
-                  <div key={metric.label} className="rounded-lg border border-dashed border-gray-200 p-3">
+                  <div
+                    key={metric.label}
+                    className="rounded-lg border border-dashed border-gray-200 p-3"
+                  >
                     <div className="flex items-center justify-between text-sm text-gray-600">
                       <span className={TRS_SECTION_TITLE}>{metric.label}</span>
                       <span>{metric.trend}</span>
                     </div>
-                    <p className="mt-1 text-lg font-semibold text-black">{metric.value}</p>
+                    <p className="mt-1 text-lg font-semibold text-black">
+                      {metric.value}
+                    </p>
                   </div>
                 ))}
               </CardContent>
@@ -264,14 +352,20 @@ export default function MailCalendarPage() {
 
             <Card className={TRS_CARD}>
               <CardHeader>
-                <CardTitle className="text-lg font-semibold text-black">Scheduler automations</CardTitle>
+                <CardTitle className="text-lg font-semibold text-black">
+                  Scheduler automations
+                </CardTitle>
                 <CardDescription className="text-sm text-gray-500">
-                  Recommended workflows to align invites, agenda prep, and follow-ups.
+                  Recommended workflows to align invites, agenda prep, and
+                  follow-ups.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {schedulerInsights.map((insight) => (
-                  <div key={insight} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+                  <div
+                    key={insight}
+                    className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700"
+                  >
                     {insight}
                   </div>
                 ))}
@@ -285,9 +379,12 @@ export default function MailCalendarPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Integration status</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Integration status
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Connection health across email, calendar, conferencing, and workspace tools.
+                Connection health across email, calendar, conferencing, and
+                workspace tools.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
@@ -297,13 +394,21 @@ export default function MailCalendarPage() {
                   className="flex flex-col gap-3 rounded-lg border border-gray-200 p-4 md:flex-row md:items-center md:justify-between"
                 >
                   <div>
-                    <p className="text-sm font-semibold text-black">{integration.name}</p>
-                    <p className="text-xs text-gray-500">{integration.description}</p>
+                    <p className="text-sm font-semibold text-black">
+                      {integration.name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {integration.description}
+                    </p>
                   </div>
                   <div className="flex items-center gap-3">
                     <Badge
                       variant={
-                        integration.status === "Connected" ? "success" : integration.status === "Syncing" ? "warning" : "outline"
+                        integration.status === "Connected"
+                          ? "success"
+                          : integration.status === "Syncing"
+                            ? "warning"
+                            : "outline"
                       }
                     >
                       {integration.status}
@@ -319,19 +424,30 @@ export default function MailCalendarPage() {
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Next up</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Next up
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
                 Planned integrations and roadmap items for unified comms.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {roadmapItems.map((item) => (
-                <div key={item.id} className="flex flex-col justify-between rounded-lg border border-gray-200 p-4">
+                <div
+                  key={item.id}
+                  className="flex flex-col justify-between rounded-lg border border-gray-200 p-4"
+                >
                   <div>
-                    <p className="text-sm font-semibold text-black">{item.title}</p>
-                    <p className="mt-1 text-sm text-gray-600">{item.description}</p>
+                    <p className="text-sm font-semibold text-black">
+                      {item.title}
+                    </p>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {item.description}
+                    </p>
                   </div>
-                  <div className="mt-3 text-xs text-gray-500">ETA: {item.eta}</div>
+                  <div className="mt-3 text-xs text-gray-500">
+                    ETA: {item.eta}
+                  </div>
                 </div>
               ))}
             </CardContent>
@@ -339,5 +455,5 @@ export default function MailCalendarPage() {
         </div>
       )}
     </PageTemplate>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { TRS_CARD } from "@/lib/style";
 import { resolveTabs } from "@/lib/tabs";
+import { PageTabs } from "@/components/layout/PageTabs";
 import CommandCard from "@/components/morning/CommandCard";
 import KpiTile from "@/components/morning/KpiTile";
 import PriorityRow from "@/components/morning/PriorityRow";
@@ -35,6 +42,14 @@ export default function MorningPage() {
     const current = searchParams.get("tab");
     return current && tabs.includes(current) ? current : tabs[0];
   }, [searchParams, tabs]);
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
   const [briefTab, setBriefTab] = useState<BriefTab>("Inbox");
 
   useEffect(() => {
@@ -178,6 +193,8 @@ export default function MorningPage() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
       <section className={cn(TRS_CARD, "p-3")}>
         <div className="flex items-center justify-between">
           <div>
@@ -229,10 +246,21 @@ export default function MorningPage() {
       {activeTab === "Today" && (
         <>
           <section className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
-            <KpiTile label="Pipeline Dollars" value={`${s.kpis.pipelineDollars.toLocaleString()}`} hint="vs yesterday" />
+            <KpiTile
+              label="Pipeline Dollars"
+              value={`${s.kpis.pipelineDollars.toLocaleString()}`}
+              hint="vs yesterday"
+            />
             <KpiTile label="Win Rate" value={`${s.kpis.winRatePct}%`} />
-            <KpiTile label="Price Realization" value={`${s.kpis.priceRealizationPct}%`} />
-            <KpiTile label="Focus Sessions" value={`${s.kpis.focusSessionsToday}`} hint="Completed today" />
+            <KpiTile
+              label="Price Realization"
+              value={`${s.kpis.priceRealizationPct}%`}
+            />
+            <KpiTile
+              label="Focus Sessions"
+              value={`${s.kpis.focusSessionsToday}`}
+              hint="Completed today"
+            />
           </section>
 
           <section className="grid grid-cols-1 gap-3 lg:grid-cols-3">
@@ -270,11 +298,14 @@ export default function MorningPage() {
             </div>
             <div className="lg:col-span-2">
               <div className={cn(TRS_CARD, "p-3")}>
-                <div className="mb-2 text-sm font-semibold text-black">Today&apos;s Priorities</div>
+                <div className="mb-2 text-sm font-semibold text-black">
+                  Today&apos;s Priorities
+                </div>
                 <div className="space-y-2">
                   {s.priorities.length === 0 ? (
                     <div className="text-[13px] text-gray-600">
-                      No priorities yet. Compute your plan to get curated actions.
+                      No priorities yet. Compute your plan to get curated
+                      actions.
                     </div>
                   ) : (
                     s.priorities.map((p) => (
@@ -301,42 +332,77 @@ export default function MorningPage() {
 
           <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
             <div className={cn(TRS_CARD, "flex h-full flex-col p-3")}>
-              <div className="mb-2 text-sm font-semibold text-black">Top 5 Emails</div>
+              <div className="mb-2 text-sm font-semibold text-black">
+                Top 5 Emails
+              </div>
               <div className="space-y-2">
                 {topEmails.map((email) => (
-                  <div key={email.id} className="rounded-lg border border-gray-100 bg-white p-3">
+                  <div
+                    key={email.id}
+                    className="rounded-lg border border-gray-100 bg-white p-3"
+                  >
                     <div className="flex items-center justify-between text-[11px] text-gray-500">
-                      <span className="font-medium text-gray-700">{email.sender}</span>
+                      <span className="font-medium text-gray-700">
+                        {email.sender}
+                      </span>
                       <span>{email.receivedAt}</span>
                     </div>
-                    <div className="mt-1 text-[13px] font-semibold text-black">{email.subject}</div>
-                    <div className="mt-1 text-[12px] text-gray-600">{email.preview}</div>
-                    <div className="mt-2 text-[11px] font-medium text-gray-500">Priority: {email.priority}</div>
+                    <div className="mt-1 text-[13px] font-semibold text-black">
+                      {email.subject}
+                    </div>
+                    <div className="mt-1 text-[12px] text-gray-600">
+                      {email.preview}
+                    </div>
+                    <div className="mt-2 text-[11px] font-medium text-gray-500">
+                      Priority: {email.priority}
+                    </div>
                   </div>
                 ))}
               </div>
             </div>
             <div className={cn(TRS_CARD, "flex h-full flex-col p-3")}>
-              <div className="mb-2 text-sm font-semibold text-black">Today&apos;s Schedule</div>
+              <div className="mb-2 text-sm font-semibold text-black">
+                Today&apos;s Schedule
+              </div>
               <div className="space-y-2">
                 {appointments.map((event) => (
-                  <div key={event.id} className="rounded-lg border border-gray-100 bg-white p-3">
-                    <div className="text-[11px] font-medium text-gray-500">{event.time}</div>
-                    <div className="text-[13px] font-semibold text-black">{event.title}</div>
-                    <div className="text-[12px] text-gray-600">{event.location}</div>
-                    <div className="text-[11px] text-gray-500">Attendees: {event.attendees}</div>
+                  <div
+                    key={event.id}
+                    className="rounded-lg border border-gray-100 bg-white p-3"
+                  >
+                    <div className="text-[11px] font-medium text-gray-500">
+                      {event.time}
+                    </div>
+                    <div className="text-[13px] font-semibold text-black">
+                      {event.title}
+                    </div>
+                    <div className="text-[12px] text-gray-600">
+                      {event.location}
+                    </div>
+                    <div className="text-[11px] text-gray-500">
+                      Attendees: {event.attendees}
+                    </div>
                   </div>
                 ))}
               </div>
             </div>
             <div className={cn(TRS_CARD, "flex h-full flex-col p-3")}>
-              <div className="mb-2 text-sm font-semibold text-black">Today&apos;s Tasks</div>
+              <div className="mb-2 text-sm font-semibold text-black">
+                Today&apos;s Tasks
+              </div>
               <div className="space-y-2">
                 {tasks.map((task) => (
-                  <div key={task.id} className="rounded-lg border border-gray-100 bg-white p-3">
-                    <div className="text-[13px] font-semibold text-black">{task.title}</div>
+                  <div
+                    key={task.id}
+                    className="rounded-lg border border-gray-100 bg-white p-3"
+                  >
+                    <div className="text-[13px] font-semibold text-black">
+                      {task.title}
+                    </div>
                     <div className="text-[12px] text-gray-600">{task.due}</div>
-                    <div className="text-[11px] font-medium text-gray-500">Status: {task.status}</div>
+                    <div className="text-[11px] font-medium text-gray-500">
+                      Status: {task.status}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -362,7 +428,9 @@ export default function MorningPage() {
               }
             />
             <div className={cn(TRS_CARD, "p-3")}>
-              <div className="mb-2 text-sm font-semibold text-black">Revenue Digest</div>
+              <div className="mb-2 text-sm font-semibold text-black">
+                Revenue Digest
+              </div>
               <SummaryFeed
                 items={[
                   "Pipeline confidence improved +4.2% overnight; education vertical slow approvals.",
@@ -379,7 +447,10 @@ export default function MorningPage() {
           </section>
 
           <section className="pb-6 text-right">
-            <a href="/dashboard" className="rounded-md border px-2 py-1 text-xs">
+            <a
+              href="/dashboard"
+              className="rounded-md border px-2 py-1 text-xs"
+            >
               Open Executive Dashboard
             </a>
           </section>
@@ -389,48 +460,84 @@ export default function MorningPage() {
       {activeTab === "This Week" && (
         <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">Weekly Momentum Plan</div>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Weekly Momentum Plan
+            </div>
             <ul className="space-y-3 text-[13px] text-gray-700">
               <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Close $1.8M in expansion</div>
-                <div className="text-[12px] text-gray-600">Target accounts: Northwind, Globex, Wayfinder</div>
-                <div className="mt-2 text-[11px] text-gray-500">Owner: Enterprise pod • Status: Tracking</div>
+                <div className="text-sm font-semibold text-black">
+                  Close $1.8M in expansion
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  Target accounts: Northwind, Globex, Wayfinder
+                </div>
+                <div className="mt-2 text-[11px] text-gray-500">
+                  Owner: Enterprise pod • Status: Tracking
+                </div>
               </li>
               <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Accelerate collections cycle</div>
-                <div className="text-[12px] text-gray-600">Launch outreach to all invoices &gt; 30 days</div>
-                <div className="mt-2 text-[11px] text-gray-500">Owner: Finance • Status: In motion</div>
+                <div className="text-sm font-semibold text-black">
+                  Accelerate collections cycle
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  Launch outreach to all invoices &gt; 30 days
+                </div>
+                <div className="mt-2 text-[11px] text-gray-500">
+                  Owner: Finance • Status: In motion
+                </div>
               </li>
               <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Ship updated pricing guardrails</div>
-                <div className="text-[12px] text-gray-600">Align deal desk + enablement by Thursday</div>
-                <div className="mt-2 text-[11px] text-gray-500">Owner: Pricing committee • Status: On track</div>
+                <div className="text-sm font-semibold text-black">
+                  Ship updated pricing guardrails
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  Align deal desk + enablement by Thursday
+                </div>
+                <div className="mt-2 text-[11px] text-gray-500">
+                  Owner: Pricing committee • Status: On track
+                </div>
               </li>
             </ul>
           </div>
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">Key Metrics Watchlist</div>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Key Metrics Watchlist
+            </div>
             <div className="space-y-3 text-[13px] text-gray-700">
               <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
-                  <div className="font-semibold text-black">Pipeline Coverage</div>
-                  <div className="text-[12px] text-gray-600">Goal: 4.5x • Current: 4.1x</div>
+                  <div className="font-semibold text-black">
+                    Pipeline Coverage
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    Goal: 4.5x • Current: 4.1x
+                  </div>
                 </div>
-                <span className="text-[12px] text-emerald-600">Trending up</span>
+                <span className="text-[12px] text-emerald-600">
+                  Trending up
+                </span>
               </div>
               <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
                   <div className="font-semibold text-black">Bookings Pace</div>
-                  <div className="text-[12px] text-gray-600">Goal: $420K/week • Current: $395K</div>
+                  <div className="text-[12px] text-gray-600">
+                    Goal: $420K/week • Current: $395K
+                  </div>
                 </div>
-                <span className="text-[12px] text-amber-600">Needs attention</span>
+                <span className="text-[12px] text-amber-600">
+                  Needs attention
+                </span>
               </div>
               <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
                   <div className="font-semibold text-black">Focus Sessions</div>
-                  <div className="text-[12px] text-gray-600">Goal: 15 • Completed: {s.kpis.focusSessionsToday}</div>
+                  <div className="text-[12px] text-gray-600">
+                    Goal: 15 • Completed: {s.kpis.focusSessionsToday}
+                  </div>
                 </div>
-                <span className="text-[12px] text-gray-500">Mid-week review tomorrow</span>
+                <span className="text-[12px] text-gray-500">
+                  Mid-week review tomorrow
+                </span>
               </div>
             </div>
           </div>
@@ -439,47 +546,81 @@ export default function MorningPage() {
 
       {activeTab === "Focus Blocks" && (
         <section className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <div className={cn(TRS_CARD, "p-4")}> 
-            <div className="mb-3 text-sm font-semibold text-black">Planned Deep Work</div>
+          <div className={cn(TRS_CARD, "p-4")}>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Planned Deep Work
+            </div>
             <div className="space-y-3 text-[13px] text-gray-700">
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Strategic accounts review</div>
-                <div className="text-[12px] text-gray-600">90m • Owner: You</div>
-                <div className="mt-1 text-[11px] text-gray-500">Outcome: Confirm expansion roadmap</div>
+                <div className="text-sm font-semibold text-black">
+                  Strategic accounts review
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  90m • Owner: You
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Outcome: Confirm expansion roadmap
+                </div>
               </div>
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Pricing guardrails draft</div>
-                <div className="text-[12px] text-gray-600">60m • Owner: Deal desk</div>
-                <div className="mt-1 text-[11px] text-gray-500">Outcome: Package scenarios for review</div>
+                <div className="text-sm font-semibold text-black">
+                  Pricing guardrails draft
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  60m • Owner: Deal desk
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Outcome: Package scenarios for review
+                </div>
               </div>
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Collections acceleration</div>
-                <div className="text-[12px] text-gray-600">45m • Owner: Finance</div>
-                <div className="mt-1 text-[11px] text-gray-500">Outcome: Prioritize $380K backlog</div>
+                <div className="text-sm font-semibold text-black">
+                  Collections acceleration
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  45m • Owner: Finance
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Outcome: Prioritize $380K backlog
+                </div>
               </div>
             </div>
           </div>
-          <div className={cn(TRS_CARD, "p-4")}> 
-            <div className="mb-3 text-sm font-semibold text-black">Recent Sessions</div>
+          <div className={cn(TRS_CARD, "p-4")}>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Recent Sessions
+            </div>
             <ul className="space-y-3 text-[13px] text-gray-700">
               <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
-                  <div className="font-semibold text-black">Partner activation audit</div>
-                  <div className="text-[12px] text-gray-600">Completed yesterday • 75m</div>
+                  <div className="font-semibold text-black">
+                    Partner activation audit
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    Completed yesterday • 75m
+                  </div>
                 </div>
                 <span className="text-[12px] text-emerald-600">Complete</span>
               </li>
               <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
-                  <div className="font-semibold text-black">Forecast calibration</div>
-                  <div className="text-[12px] text-gray-600">Completed Monday • 60m</div>
+                  <div className="font-semibold text-black">
+                    Forecast calibration
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    Completed Monday • 60m
+                  </div>
                 </div>
                 <span className="text-[12px] text-emerald-600">Complete</span>
               </li>
               <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
                 <div>
-                  <div className="font-semibold text-black">Team enablement sync</div>
-                  <div className="text-[12px] text-gray-600">Scheduled Thursday • 45m</div>
+                  <div className="font-semibold text-black">
+                    Team enablement sync
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    Scheduled Thursday • 45m
+                  </div>
                 </div>
                 <span className="text-[12px] text-amber-600">Upcoming</span>
               </li>
@@ -490,28 +631,50 @@ export default function MorningPage() {
 
       {activeTab === "Risks" && (
         <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <div className={cn(TRS_CARD, "p-4")}> 
-            <div className="mb-3 text-sm font-semibold text-black">Top Risks</div>
+          <div className={cn(TRS_CARD, "p-4")}>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Top Risks
+            </div>
             <div className="space-y-3 text-[13px] text-gray-700">
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Collections slip in enterprise</div>
-                <div className="text-[12px] text-gray-600">$540K outstanding &gt; 45 days</div>
-                <div className="mt-1 text-[11px] text-gray-500">Mitigation: Finance sprint + AE escalation</div>
+                <div className="text-sm font-semibold text-black">
+                  Collections slip in enterprise
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  $540K outstanding &gt; 45 days
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Mitigation: Finance sprint + AE escalation
+                </div>
               </div>
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Pricing pressure in EMEA</div>
-                <div className="text-[12px] text-gray-600">Win rate down 6 pts week-over-week</div>
-                <div className="mt-1 text-[11px] text-gray-500">Mitigation: Launch value-based play</div>
+                <div className="text-sm font-semibold text-black">
+                  Pricing pressure in EMEA
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  Win rate down 6 pts week-over-week
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Mitigation: Launch value-based play
+                </div>
               </div>
               <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">Enablement backlog</div>
-                <div className="text-[12px] text-gray-600">New reps lacking updated collateral</div>
-                <div className="mt-1 text-[11px] text-gray-500">Mitigation: Publish draft by Friday</div>
+                <div className="text-sm font-semibold text-black">
+                  Enablement backlog
+                </div>
+                <div className="text-[12px] text-gray-600">
+                  New reps lacking updated collateral
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  Mitigation: Publish draft by Friday
+                </div>
               </div>
             </div>
           </div>
-          <div className={cn(TRS_CARD, "p-4")}> 
-            <div className="mb-3 text-sm font-semibold text-black">Alerts & Signals</div>
+          <div className={cn(TRS_CARD, "p-4")}>
+            <div className="mb-3 text-sm font-semibold text-black">
+              Alerts & Signals
+            </div>
             <SummaryFeed
               items={[
                 "3 high-value renewals without active champions.",
@@ -525,7 +688,7 @@ export default function MorningPage() {
 
       {activeTab === "Morning Brief" && (
         <section className="space-y-3">
-          <div className={cn(TRS_CARD, "overflow-hidden")}> 
+          <div className={cn(TRS_CARD, "overflow-hidden")}>
             <div className="flex border-b border-gray-200 bg-gray-50 text-sm font-medium">
               {briefTabs.map((tab) => (
                 <button
@@ -547,18 +710,34 @@ export default function MorningPage() {
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-sm font-semibold text-black">Today&apos;s Inbox</div>
-                      <div className="text-[12px] text-gray-500">Highest leverage threads curated from overnight activity.</div>
+                      <div className="text-sm font-semibold text-black">
+                        Today&apos;s Inbox
+                      </div>
+                      <div className="text-[12px] text-gray-500">
+                        Highest leverage threads curated from overnight
+                        activity.
+                      </div>
                     </div>
-                    <button className="rounded-md border px-3 py-1 text-[12px]">Compose</button>
+                    <button className="rounded-md border px-3 py-1 text-[12px]">
+                      Compose
+                    </button>
                   </div>
                   {inboxItems.map((email) => (
-                    <div key={email.id} className="rounded-lg border border-gray-100 bg-white p-4">
+                    <div
+                      key={email.id}
+                      className="rounded-lg border border-gray-100 bg-white p-4"
+                    >
                       <div className="flex items-start justify-between gap-3">
                         <div>
-                          <div className="text-[12px] font-semibold text-gray-700">{email.sender}</div>
-                          <div className="text-sm font-semibold text-black">{email.subject}</div>
-                          <div className="mt-1 text-[12px] text-gray-600">{email.preview}</div>
+                          <div className="text-[12px] font-semibold text-gray-700">
+                            {email.sender}
+                          </div>
+                          <div className="text-sm font-semibold text-black">
+                            {email.subject}
+                          </div>
+                          <div className="mt-1 text-[12px] text-gray-600">
+                            {email.preview}
+                          </div>
                         </div>
                         <div className="text-right text-[11px] text-gray-500">
                           <div>{email.receivedAt}</div>
@@ -575,13 +754,22 @@ export default function MorningPage() {
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-sm font-semibold text-black">Today&apos;s Calendar</div>
-                      <div className="text-[12px] text-gray-500">Deep work blocks and customer moments lined up.</div>
+                      <div className="text-sm font-semibold text-black">
+                        Today&apos;s Calendar
+                      </div>
+                      <div className="text-[12px] text-gray-500">
+                        Deep work blocks and customer moments lined up.
+                      </div>
                     </div>
-                    <button className="rounded-md border px-3 py-1 text-[12px]">Add Event</button>
+                    <button className="rounded-md border px-3 py-1 text-[12px]">
+                      Add Event
+                    </button>
                   </div>
                   <div className="relative">
-                    <div className="absolute left-[7px] top-0 h-full w-[2px] bg-gray-200" aria-hidden />
+                    <div
+                      className="absolute left-[7px] top-0 h-full w-[2px] bg-gray-200"
+                      aria-hidden
+                    />
                     <div className="space-y-4">
                       {appointments.map((event, idx) => (
                         <div key={event.id} className="relative flex gap-4">
@@ -590,11 +778,19 @@ export default function MorningPage() {
                               {idx + 1}
                             </div>
                           </div>
-                          <div className={cn(TRS_CARD, "flex-1 p-3")}> 
-                            <div className="text-[11px] font-medium text-gray-500">{event.time}</div>
-                            <div className="text-sm font-semibold text-black">{event.title}</div>
-                            <div className="text-[12px] text-gray-600">{event.location}</div>
-                            <div className="text-[11px] text-gray-500">Attendees: {event.attendees}</div>
+                          <div className={cn(TRS_CARD, "flex-1 p-3")}>
+                            <div className="text-[11px] font-medium text-gray-500">
+                              {event.time}
+                            </div>
+                            <div className="text-sm font-semibold text-black">
+                              {event.title}
+                            </div>
+                            <div className="text-[12px] text-gray-600">
+                              {event.location}
+                            </div>
+                            <div className="text-[11px] text-gray-500">
+                              Attendees: {event.attendees}
+                            </div>
                           </div>
                         </div>
                       ))}

--- a/app/partners/[id]/PartnerDetailView.tsx
+++ b/app/partners/[id]/PartnerDetailView.tsx
@@ -1,30 +1,57 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
-import { usePathname, useSearchParams } from "next/navigation"
+import { useCallback, useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
-import { Badge } from "@/ui/badge"
-import { Button } from "@/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/ui/table"
-import { resolveTabs } from "@/lib/tabs"
-import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style"
-import { cn } from "@/lib/utils"
-import type { Partner } from "@/core/partners/types"
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/table";
+import { PageTabs } from "@/components/layout/PageTabs";
+import { resolveTabs } from "@/lib/tabs";
+import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style";
+import { cn } from "@/lib/utils";
+import type { Partner } from "@/core/partners/types";
 
-const formatCurrency = (value: number) => `$${value.toLocaleString()}`
+const formatCurrency = (value: number) => `$${value.toLocaleString()}`;
 
 export default function PartnerDetailView({ partner }: { partner: Partner }) {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
+
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
 
   const readinessTone =
-    partner.readinessScore >= 80 ? "text-emerald-600" : partner.readinessScore >= 60 ? "text-amber-600" : "text-rose-600"
+    partner.readinessScore >= 80
+      ? "text-emerald-600"
+      : partner.readinessScore >= 60
+        ? "text-amber-600"
+        : "text-rose-600";
 
   return (
     <div className="mx-auto max-w-6xl space-y-5 px-4 py-6">
@@ -35,38 +62,60 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
           <Badge variant="default">{partner.model}</Badge>
         </div>
         <p className="text-sm text-gray-600">
-          {partner.organizationType} • {partner.focus} • {partner.city}, {partner.state}
+          {partner.organizationType} • {partner.focus} • {partner.city},{" "}
+          {partner.state}
         </p>
         <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
           <span>Owner {partner.owner}</span>
-          <span>Last interaction {new Date(partner.lastInteraction).toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>
+          <span>
+            Last interaction{" "}
+            {new Date(partner.lastInteraction).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            })}
+          </span>
           {partner.website && (
-            <a href={partner.website} target="_blank" rel="noreferrer" className="text-gray-700 underline">
+            <a
+              href={partner.website}
+              target="_blank"
+              rel="noreferrer"
+              className="text-gray-700 underline"
+            >
               Visit website
             </a>
           )}
         </div>
       </header>
 
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
       {activeTab === "Overview" && (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <Card className={cn(TRS_CARD, "lg:col-span-2 p-4 space-y-4")}> 
+          <Card className={cn(TRS_CARD, "lg:col-span-2 p-4 space-y-4")}>
             <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
               <div className="space-y-1">
-                <div className="text-lg font-semibold text-black">Relationship Snapshot</div>
+                <div className="text-lg font-semibold text-black">
+                  Relationship Snapshot
+                </div>
                 <p className="text-sm text-gray-600">
-                  Potential shared revenue {formatCurrency(partner.potentialValue)} • Warm introductions {partner.warmIntroductions}
-                  • Mutual clients {partner.mutualClients}
+                  Potential shared revenue{" "}
+                  {formatCurrency(partner.potentialValue)} • Warm introductions{" "}
+                  {partner.warmIntroductions}• Mutual clients{" "}
+                  {partner.mutualClients}
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-3 text-sm text-gray-700">
                 <div>
                   <div className={TRS_SUBTITLE}>Readiness</div>
-                  <div className={cn("mt-1 font-semibold", readinessTone)}>{partner.readinessScore}%</div>
+                  <div className={cn("mt-1 font-semibold", readinessTone)}>
+                    {partner.readinessScore}%
+                  </div>
                 </div>
                 <div>
                   <div className={TRS_SUBTITLE}>Ecosystem fit</div>
-                  <div className="mt-1 font-semibold text-black">{partner.ecosystemFit}</div>
+                  <div className="mt-1 font-semibold text-black">
+                    {partner.ecosystemFit}
+                  </div>
                 </div>
               </div>
             </div>
@@ -100,25 +149,39 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
             </div>
           </Card>
 
-          <Card className={cn(TRS_CARD, "p-4 space-y-3")}> 
+          <Card className={cn(TRS_CARD, "p-4 space-y-3")}>
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-semibold">Key Contacts</CardTitle>
+              <CardTitle className="text-sm font-semibold">
+                Key Contacts
+              </CardTitle>
               <Button size="sm" variant="outline" className="h-7 px-3 text-xs">
                 Add contact
               </Button>
             </div>
             <div className="space-y-3 text-sm text-gray-700">
               {partner.contacts.map((contact) => (
-                <div key={contact.id} className="rounded-lg border border-gray-200 p-3">
+                <div
+                  key={contact.id}
+                  className="rounded-lg border border-gray-200 p-3"
+                >
                   <div className="font-medium text-black">{contact.name}</div>
                   <div className="text-xs text-gray-500">{contact.role}</div>
                   {contact.email && (
-                    <a href={`mailto:${contact.email}`} className="mt-1 block text-xs text-gray-500 underline">
+                    <a
+                      href={`mailto:${contact.email}`}
+                      className="mt-1 block text-xs text-gray-500 underline"
+                    >
                       {contact.email}
                     </a>
                   )}
-                  {contact.phone && <div className="text-xs text-gray-500">{contact.phone}</div>}
-                  {contact.notes && <div className="mt-2 text-xs text-gray-500">{contact.notes}</div>}
+                  {contact.phone && (
+                    <div className="text-xs text-gray-500">{contact.phone}</div>
+                  )}
+                  {contact.notes && (
+                    <div className="mt-2 text-xs text-gray-500">
+                      {contact.notes}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -129,12 +192,18 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
       {activeTab === "Introductions" && (
         <Card className={cn(TRS_CARD)}>
           <CardHeader>
-            <CardTitle className="text-sm font-semibold">Warm introductions</CardTitle>
-            <CardDescription>Mutual opportunities sourced through this relationship.</CardDescription>
+            <CardTitle className="text-sm font-semibold">
+              Warm introductions
+            </CardTitle>
+            <CardDescription>
+              Mutual opportunities sourced through this relationship.
+            </CardDescription>
           </CardHeader>
           <CardContent>
             {partner.opportunities.length === 0 ? (
-              <div className="py-8 text-center text-sm text-gray-600">No introductions logged yet.</div>
+              <div className="py-8 text-center text-sm text-gray-600">
+                No introductions logged yet.
+              </div>
             ) : (
               <Table>
                 <TableHeader>
@@ -150,7 +219,9 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
                 <TableBody>
                   {partner.opportunities.map((opportunity) => (
                     <TableRow key={opportunity.id}>
-                      <TableCell className="font-medium text-black">{opportunity.name}</TableCell>
+                      <TableCell className="font-medium text-black">
+                        {opportunity.name}
+                      </TableCell>
                       <TableCell>{opportunity.type}</TableCell>
                       <TableCell>
                         <Badge
@@ -158,22 +229,27 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
                             opportunity.status === "In Motion"
                               ? "success"
                               : opportunity.status === "Introduced"
-                              ? "default"
-                              : "outline"
+                                ? "default"
+                                : "outline"
                           }
                         >
                           {opportunity.status}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-sm text-gray-600">{opportunity.targetClient}</TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {opportunity.targetClient}
+                      </TableCell>
                       <TableCell className="text-right font-medium text-black">
                         {formatCurrency(opportunity.value)}
                       </TableCell>
                       <TableCell className="text-sm text-gray-600">
-                        {new Date(opportunity.expectedClose).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        })}
+                        {new Date(opportunity.expectedClose).toLocaleDateString(
+                          "en-US",
+                          {
+                            month: "short",
+                            day: "numeric",
+                          },
+                        )}
                       </TableCell>
                     </TableRow>
                   ))}
@@ -187,23 +263,42 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
       {activeTab === "Initiatives" && (
         <Card className={cn(TRS_CARD)}>
           <CardHeader>
-            <CardTitle className="text-sm font-semibold">Joint initiatives</CardTitle>
-            <CardDescription>Co-marketing, events, and shared plays in motion.</CardDescription>
+            <CardTitle className="text-sm font-semibold">
+              Joint initiatives
+            </CardTitle>
+            <CardDescription>
+              Co-marketing, events, and shared plays in motion.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             {partner.initiatives.map((initiative) => (
-              <div key={initiative.id} className="rounded-lg border border-gray-200 p-3">
+              <div
+                key={initiative.id}
+                className="rounded-lg border border-gray-200 p-3"
+              >
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div>
-                    <div className="text-sm font-semibold text-black">{initiative.title}</div>
-                    <div className="text-xs text-gray-500">Owner {initiative.owner}</div>
+                    <div className="text-sm font-semibold text-black">
+                      {initiative.title}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      Owner {initiative.owner}
+                    </div>
                   </div>
                   <div className="text-xs text-gray-500">
-                    Due {new Date(initiative.dueDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                    Due{" "}
+                    {new Date(initiative.dueDate).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
                   </div>
                 </div>
-                <div className="mt-2 text-xs uppercase tracking-wide text-gray-400">{initiative.status}</div>
-                <p className="mt-2 text-sm text-gray-600">{initiative.description}</p>
+                <div className="mt-2 text-xs uppercase tracking-wide text-gray-400">
+                  {initiative.status}
+                </div>
+                <p className="mt-2 text-sm text-gray-600">
+                  {initiative.description}
+                </p>
               </div>
             ))}
           </CardContent>
@@ -213,20 +308,36 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
       {activeTab === "Notes" && (
         <Card className={cn(TRS_CARD)}>
           <CardHeader>
-            <CardTitle className="text-sm font-semibold">Touchpoint timeline</CardTitle>
-            <CardDescription>Every conversation, intro, and next step.</CardDescription>
+            <CardTitle className="text-sm font-semibold">
+              Touchpoint timeline
+            </CardTitle>
+            <CardDescription>
+              Every conversation, intro, and next step.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             {partner.interactions.map((interaction) => (
-              <div key={interaction.id} className="rounded-lg border border-gray-200 p-3">
+              <div
+                key={interaction.id}
+                className="rounded-lg border border-gray-200 p-3"
+              >
                 <div className="flex items-center justify-between text-sm">
-                  <div className="font-medium text-black">{interaction.type}</div>
+                  <div className="font-medium text-black">
+                    {interaction.type}
+                  </div>
                   <span className="text-xs text-gray-500">
-                    {new Date(interaction.date).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                    {new Date(interaction.date).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
                   </span>
                 </div>
-                <div className="mt-1 text-xs uppercase tracking-wide text-gray-400">Sentiment: {interaction.sentiment}</div>
-                <p className="mt-2 text-sm text-gray-600">{interaction.summary}</p>
+                <div className="mt-1 text-xs uppercase tracking-wide text-gray-400">
+                  Sentiment: {interaction.sentiment}
+                </div>
+                <p className="mt-2 text-sm text-gray-600">
+                  {interaction.summary}
+                </p>
                 {interaction.nextStep && (
                   <div className="mt-2 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-600">
                     Next step: {interaction.nextStep}
@@ -241,16 +352,27 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
       {activeTab === "Resources" && (
         <Card className={cn(TRS_CARD)}>
           <CardHeader>
-            <CardTitle className="text-sm font-semibold">Shared resources</CardTitle>
-            <CardDescription>Assets curated for this partnership.</CardDescription>
+            <CardTitle className="text-sm font-semibold">
+              Shared resources
+            </CardTitle>
+            <CardDescription>
+              Assets curated for this partnership.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-gray-700">
             {partner.resources.map((resource) => (
-              <div key={resource.id} className="flex items-center justify-between rounded-lg border border-gray-200 p-3">
+              <div
+                key={resource.id}
+                className="flex items-center justify-between rounded-lg border border-gray-200 p-3"
+              >
                 <div>
                   <div className="font-medium text-black">{resource.title}</div>
                   <div className="text-xs text-gray-500">{resource.type}</div>
-                  {resource.notes && <div className="mt-1 text-xs text-gray-500">{resource.notes}</div>}
+                  {resource.notes && (
+                    <div className="mt-1 text-xs text-gray-500">
+                      {resource.notes}
+                    </div>
+                  )}
                 </div>
                 <a
                   href={resource.url}
@@ -266,5 +388,5 @@ export default function PartnerDetailView({ partner }: { partner: Partner }) {
         </Card>
       )}
     </div>
-  )
+  );
 }

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -1,19 +1,33 @@
-"use client"
+"use client";
 
-import { useMemo, useState } from "react"
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { Badge } from "@/ui/badge"
-import { Button } from "@/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { Input } from "@/ui/input"
-import { PageDescription, PageTitle } from "@/ui/page-header"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/ui/table"
-import { cn } from "@/lib/utils"
-import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style"
-import { resolveTabs } from "@/lib/tabs"
-import { getPartners } from "@/core/partners/store"
-import type { Partner } from "@/core/partners/types"
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import { Input } from "@/ui/input";
+import { PageDescription, PageTitle } from "@/ui/page-header";
+import { PageTabs } from "@/components/layout/PageTabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/table";
+import { cn } from "@/lib/utils";
+import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style";
+import { resolveTabs } from "@/lib/tabs";
+import { getPartners } from "@/core/partners/store";
+import type { Partner } from "@/core/partners/types";
 
 const relationshipStages: Partner["stage"][] = [
   "Initial Outreach",
@@ -22,42 +36,67 @@ const relationshipStages: Partner["stage"][] = [
   "Contracting",
   "Launch",
   "Dormant",
-]
+];
 
-const partnerModels: Partner["model"][] = ["Referral Exchange", "Co-Marketing", "Co-Sell", "Community"]
+const partnerModels: Partner["model"][] = [
+  "Referral Exchange",
+  "Co-Marketing",
+  "Co-Sell",
+  "Community",
+];
 
-const formatCurrency = (value: number) => `$${(value / 1000).toFixed(0)}K`
+const formatCurrency = (value: number) => `$${(value / 1000).toFixed(0)}K`;
 
 export default function PartnersPage() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
 
-  const router = useRouter()
-  const partnerDataset = useMemo(() => getPartners(), [])
-  const [relationships, setRelationships] = useState<Partner[]>(partnerDataset)
-  const [search, setSearch] = useState("")
-  const [stageFilter, setStageFilter] = useState<string>("all")
-  const [modelFilter, setModelFilter] = useState<string>("all")
-  const [sortBy, setSortBy] = useState<string>("readiness-desc")
-  const [showLogModal, setShowLogModal] = useState(false)
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
+  const router = useRouter();
+  const partnerDataset = useMemo(() => getPartners(), []);
+  const [relationships, setRelationships] = useState<Partner[]>(partnerDataset);
+  const [search, setSearch] = useState("");
+  const [stageFilter, setStageFilter] = useState<string>("all");
+  const [modelFilter, setModelFilter] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<string>("readiness-desc");
+  const [showLogModal, setShowLogModal] = useState(false);
   const [newRelationship, setNewRelationship] = useState({
     name: "",
     organizationType: "",
     city: "",
     stage: "Discovery" as Partner["stage"],
     owner: "",
-  })
+  });
 
-  const totalPotentialValue = relationships.reduce((sum, partner) => sum + partner.potentialValue, 0)
-  const warmIntros = relationships.reduce((sum, partner) => sum + partner.warmIntroductions, 0)
+  const totalPotentialValue = relationships.reduce(
+    (sum, partner) => sum + partner.potentialValue,
+    0,
+  );
+  const warmIntros = relationships.reduce(
+    (sum, partner) => sum + partner.warmIntroductions,
+    0,
+  );
   const avgReadiness = relationships.length
-    ? Math.round(relationships.reduce((sum, partner) => sum + partner.readinessScore, 0) / relationships.length)
-    : 0
+    ? Math.round(
+        relationships.reduce(
+          (sum, partner) => sum + partner.readinessScore,
+          0,
+        ) / relationships.length,
+      )
+    : 0;
   const activePipeline = relationships.reduce(
     (sum, partner) =>
       sum +
@@ -65,51 +104,54 @@ export default function PartnersPage() {
         .filter((opportunity) => opportunity.status !== "Won")
         .reduce((value, opportunity) => value + opportunity.value, 0),
     0,
-  )
+  );
 
-  const communityGoal = 450000
-  const coverage = Math.min(100, Math.round((activePipeline / communityGoal) * 100))
+  const communityGoal = 450000;
+  const coverage = Math.min(
+    100,
+    Math.round((activePipeline / communityGoal) * 100),
+  );
 
   const filteredPartners = useMemo(() => {
-    let list = relationships
+    let list = relationships;
 
     if (search.trim()) {
-      const term = search.trim().toLowerCase()
+      const term = search.trim().toLowerCase();
       list = list.filter(
         (partner) =>
           partner.name.toLowerCase().includes(term) ||
           partner.focus.toLowerCase().includes(term) ||
           partner.city.toLowerCase().includes(term),
-      )
+      );
     }
 
     if (stageFilter !== "all") {
-      list = list.filter((partner) => partner.stage === stageFilter)
+      list = list.filter((partner) => partner.stage === stageFilter);
     }
 
     if (modelFilter !== "all") {
-      list = list.filter((partner) => partner.model === modelFilter)
+      list = list.filter((partner) => partner.model === modelFilter);
     }
 
     return [...list].sort((a, b) => {
       switch (sortBy) {
         case "potential-desc":
-          return b.potentialValue - a.potentialValue
+          return b.potentialValue - a.potentialValue;
         case "potential-asc":
-          return a.potentialValue - b.potentialValue
+          return a.potentialValue - b.potentialValue;
         case "readiness-asc":
-          return a.readinessScore - b.readinessScore
+          return a.readinessScore - b.readinessScore;
         case "name-asc":
-          return a.name.localeCompare(b.name)
+          return a.name.localeCompare(b.name);
         case "name-desc":
-          return b.name.localeCompare(a.name)
+          return b.name.localeCompare(a.name);
         case "warm-desc":
-          return b.warmIntroductions - a.warmIntroductions
+          return b.warmIntroductions - a.warmIntroductions;
         default:
-          return b.readinessScore - a.readinessScore
+          return b.readinessScore - a.readinessScore;
       }
-    })
-  }, [relationships, search, stageFilter, modelFilter, sortBy])
+    });
+  }, [relationships, search, stageFilter, modelFilter, sortBy]);
 
   const upcomingInteractions = useMemo(
     () =>
@@ -125,7 +167,7 @@ export default function PartnersPage() {
         .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
         .slice(0, 5),
     [relationships],
-  )
+  );
 
   const activeOpportunities = useMemo(
     () =>
@@ -142,28 +184,28 @@ export default function PartnersPage() {
         )
         .sort((a, b) => b.value - a.value),
     [relationships],
-  )
+  );
 
   const readinessByBand = useMemo(() => {
-    const buckets = { ready: 0, ramping: 0, emerging: 0 }
+    const buckets = { ready: 0, ramping: 0, emerging: 0 };
 
     relationships.forEach((partner) => {
       if (partner.readinessScore >= 80) {
-        buckets.ready += 1
+        buckets.ready += 1;
       } else if (partner.readinessScore >= 60) {
-        buckets.ramping += 1
+        buckets.ramping += 1;
       } else {
-        buckets.emerging += 1
+        buckets.emerging += 1;
       }
-    })
+    });
 
-    return buckets
-  }, [relationships])
+    return buckets;
+  }, [relationships]);
 
   const handleCreateRelationship = () => {
     if (!newRelationship.name || !newRelationship.organizationType) {
-      alert("Name and organization type are required")
-      return
+      alert("Name and organization type are required");
+      return;
     }
 
     const potential: Partner = {
@@ -190,35 +232,51 @@ export default function PartnersPage() {
       initiatives: [],
       interactions: [],
       resources: [],
-    }
+    };
 
-    setRelationships([potential, ...relationships])
-    setNewRelationship({ name: "", organizationType: "", city: "", stage: "Discovery", owner: "" })
-    setShowLogModal(false)
-  }
+    setRelationships([potential, ...relationships]);
+    setNewRelationship({
+      name: "",
+      organizationType: "",
+      city: "",
+      stage: "Discovery",
+      owner: "",
+    });
+    setShowLogModal(false);
+  };
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
       <div className="flex flex-col gap-2">
-        <PageTitle className="text-xl font-semibold text-black">Potential Partner Network</PageTitle>
+        <PageTitle className="text-xl font-semibold text-black">
+          Potential Partner Network
+        </PageTitle>
         <PageDescription className="text-sm text-gray-500">
-          Curate warm local relationships, track reciprocal referrals, and spotlight the businesses that trust TRS
-          RevenueOS.
+          Curate warm local relationships, track reciprocal referrals, and
+          spotlight the businesses that trust TRS RevenueOS.
         </PageDescription>
       </div>
+
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
 
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
         <Card className={cn(TRS_CARD)}>
           <CardContent className="p-4 space-y-2">
             <div className={TRS_SUBTITLE}>Warm Intro Pipeline</div>
-            <div className="text-2xl font-semibold text-black">{warmIntros}</div>
-            <div className="text-xs text-gray-600">Across all active community partners</div>
+            <div className="text-2xl font-semibold text-black">
+              {warmIntros}
+            </div>
+            <div className="text-xs text-gray-600">
+              Across all active community partners
+            </div>
           </CardContent>
         </Card>
         <Card className={cn(TRS_CARD)}>
           <CardContent className="p-4 space-y-2">
             <div className={TRS_SUBTITLE}>Potential Shared Revenue</div>
-            <div className="text-2xl font-semibold text-black">{formatCurrency(totalPotentialValue)}</div>
+            <div className="text-2xl font-semibold text-black">
+              {formatCurrency(totalPotentialValue)}
+            </div>
             <div className="flex items-center gap-2 text-xs text-gray-600">
               <span className="font-medium text-gray-700">↑ 14%</span>
               <span>vs last quarter</span>
@@ -229,33 +287,52 @@ export default function PartnersPage() {
           <CardContent className="p-4 space-y-2">
             <div className={TRS_SUBTITLE}>Community Coverage</div>
             <div className="text-2xl font-semibold text-black">{coverage}%</div>
-            <div className="text-xs text-gray-600">of ${Math.round(communityGoal / 1000)}K warm intro goal</div>
+            <div className="text-xs text-gray-600">
+              of ${Math.round(communityGoal / 1000)}K warm intro goal
+            </div>
           </CardContent>
         </Card>
         <Card className={cn(TRS_CARD)}>
           <CardContent className="p-4 space-y-2">
             <div className={TRS_SUBTITLE}>Avg Partner Readiness</div>
-            <div className="text-2xl font-semibold text-black">{avgReadiness}%</div>
-            <div className="text-xs text-gray-600">Enablement score across portfolio</div>
+            <div className="text-2xl font-semibold text-black">
+              {avgReadiness}%
+            </div>
+            <div className="text-xs text-gray-600">
+              Enablement score across portfolio
+            </div>
           </CardContent>
         </Card>
       </div>
 
       {activeTab === "Overview" && (
         <div className="space-y-4">
-          <Card className={cn(TRS_CARD, "p-4 space-y-4")}> 
+          <Card className={cn(TRS_CARD, "p-4 space-y-4")}>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="space-y-1">
-                <PageTitle className="text-lg font-semibold text-black">Local Relationship Intelligence</PageTitle>
+                <PageTitle className="text-lg font-semibold text-black">
+                  Local Relationship Intelligence
+                </PageTitle>
                 <PageDescription className="text-sm text-gray-500">
-                  Snapshot of warm introductions, co-marketing momentum, and where to invest the next coffee chat.
+                  Snapshot of warm introductions, co-marketing momentum, and
+                  where to invest the next coffee chat.
                 </PageDescription>
               </div>
               <div className="flex flex-wrap items-center gap-2">
-                <Button variant="primary" size="sm" onClick={() => setShowLogModal(true)}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => setShowLogModal(true)}
+                >
                   + Log Relationship
                 </Button>
-                <Button variant="outline" size="sm" onClick={() => router.push("/pipeline")}>View Sales Pipeline</Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => router.push("/pipeline")}
+                >
+                  View Sales Pipeline
+                </Button>
               </div>
             </div>
 
@@ -264,10 +341,17 @@ export default function PartnersPage() {
                 <div className={TRS_SECTION_TITLE}>Relationship Momentum</div>
                 <ul className="mt-3 space-y-2 text-sm text-gray-700">
                   {relationships.slice(0, 3).map((partner) => (
-                    <li key={partner.id} className="flex items-center justify-between">
+                    <li
+                      key={partner.id}
+                      className="flex items-center justify-between"
+                    >
                       <div>
-                        <div className="font-medium text-black">{partner.name}</div>
-                        <div className="text-xs text-gray-500">{partner.stage} • {partner.city}, {partner.state}</div>
+                        <div className="font-medium text-black">
+                          {partner.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {partner.stage} • {partner.city}, {partner.state}
+                        </div>
                       </div>
                       <Badge variant="outline">{partner.model}</Badge>
                     </li>
@@ -278,12 +362,21 @@ export default function PartnersPage() {
                 <div className={TRS_SECTION_TITLE}>Next Warm Introductions</div>
                 <ul className="mt-3 space-y-2 text-sm text-gray-700">
                   {activeOpportunities.slice(0, 4).map((opportunity) => (
-                    <li key={opportunity.id} className="flex items-center justify-between">
+                    <li
+                      key={opportunity.id}
+                      className="flex items-center justify-between"
+                    >
                       <div>
-                        <div className="font-medium text-black">{opportunity.name}</div>
-                        <div className="text-xs text-gray-500">{opportunity.partnerName} • {opportunity.type}</div>
+                        <div className="font-medium text-black">
+                          {opportunity.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {opportunity.partnerName} • {opportunity.type}
+                        </div>
                       </div>
-                      <span className="text-xs text-gray-600">{formatCurrency(opportunity.value)}</span>
+                      <span className="text-xs text-gray-600">
+                        {formatCurrency(opportunity.value)}
+                      </span>
                     </li>
                   ))}
                 </ul>
@@ -311,22 +404,36 @@ export default function PartnersPage() {
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
             <Card className={cn(TRS_CARD)}>
               <CardHeader>
-                <CardTitle className="text-sm font-medium">Recent Touchpoints</CardTitle>
-                <CardDescription>Recap of the last five relationship moves.</CardDescription>
+                <CardTitle className="text-sm font-medium">
+                  Recent Touchpoints
+                </CardTitle>
+                <CardDescription>
+                  Recap of the last five relationship moves.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {upcomingInteractions.map((interaction) => (
-                  <div key={interaction.id} className="rounded-lg border border-gray-200 p-3">
+                  <div
+                    key={interaction.id}
+                    className="rounded-lg border border-gray-200 p-3"
+                  >
                     <div className="flex items-center justify-between text-sm">
-                      <span className="font-semibold text-black">{interaction.partnerName}</span>
+                      <span className="font-semibold text-black">
+                        {interaction.partnerName}
+                      </span>
                       <span className="text-xs text-gray-500">
-                        {new Date(interaction.date).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                        {new Date(interaction.date).toLocaleDateString(
+                          "en-US",
+                          { month: "short", day: "numeric" },
+                        )}
                       </span>
                     </div>
                     <div className="mt-1 text-xs uppercase tracking-wide text-gray-400">
                       {interaction.type} • {interaction.stage}
                     </div>
-                    <p className="mt-2 text-sm text-gray-600">{interaction.summary}</p>
+                    <p className="mt-2 text-sm text-gray-600">
+                      {interaction.summary}
+                    </p>
                     {interaction.nextStep && (
                       <div className="mt-2 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-600">
                         Next step: {interaction.nextStep}
@@ -339,24 +446,41 @@ export default function PartnersPage() {
 
             <Card className={cn(TRS_CARD)}>
               <CardHeader>
-                <CardTitle className="text-sm font-medium">Partner Coverage Map</CardTitle>
-                <CardDescription>Visualize strategic anchors across the metro ecosystem.</CardDescription>
+                <CardTitle className="text-sm font-medium">
+                  Partner Coverage Map
+                </CardTitle>
+                <CardDescription>
+                  Visualize strategic anchors across the metro ecosystem.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3 text-sm text-gray-600">
                 <div className="flex items-center justify-between rounded-lg border border-dashed border-gray-300 p-4">
                   <div>
-                    <div className="text-sm font-semibold text-black">Central Texas Growth Loop</div>
-                    <div className="text-xs text-gray-500">Austin • Dallas • San Antonio • Houston</div>
+                    <div className="text-sm font-semibold text-black">
+                      Central Texas Growth Loop
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      Austin • Dallas • San Antonio • Houston
+                    </div>
                   </div>
                   <div className="text-right text-xs text-gray-500">
-                    {relationships.length} partners<br />
+                    {relationships.length} partners
+                    <br />
                     {warmIntros} warm intros in play
                   </div>
                 </div>
                 <p>
-                  Anchor partners like <span className="font-medium text-black">Stride Business Coalition</span> and
-                  <span className="font-medium text-black"> Artisan Retail Alliance</span> are fueling reciprocal deals and
-                  storytelling. Double down on enablement to convert emerging partners into active champions.
+                  Anchor partners like{" "}
+                  <span className="font-medium text-black">
+                    Stride Business Coalition
+                  </span>{" "}
+                  and
+                  <span className="font-medium text-black">
+                    {" "}
+                    Artisan Retail Alliance
+                  </span>{" "}
+                  are fueling reciprocal deals and storytelling. Double down on
+                  enablement to convert emerging partners into active champions.
                 </p>
               </CardContent>
             </Card>
@@ -370,7 +494,9 @@ export default function PartnersPage() {
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div>
                 <CardTitle>Partner Directory</CardTitle>
-                <CardDescription>Every local organization cultivating a mutual growth lane.</CardDescription>
+                <CardDescription>
+                  Every local organization cultivating a mutual growth lane.
+                </CardDescription>
               </div>
               <div className="flex flex-col gap-2 md:flex-row md:items-center">
                 <Input
@@ -409,11 +535,19 @@ export default function PartnersPage() {
                     onChange={(event) => setSortBy(event.target.value)}
                     className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
                   >
-                    <option value="readiness-desc">Readiness (High to Low)</option>
-                    <option value="potential-desc">Potential Value (High to Low)</option>
-                    <option value="potential-asc">Potential Value (Low to High)</option>
+                    <option value="readiness-desc">
+                      Readiness (High to Low)
+                    </option>
+                    <option value="potential-desc">
+                      Potential Value (High to Low)
+                    </option>
+                    <option value="potential-asc">
+                      Potential Value (Low to High)
+                    </option>
                     <option value="warm-desc">Warm Intros (High to Low)</option>
-                    <option value="readiness-asc">Readiness (Low to High)</option>
+                    <option value="readiness-asc">
+                      Readiness (Low to High)
+                    </option>
                     <option value="name-asc">Name (A-Z)</option>
                     <option value="name-desc">Name (Z-A)</option>
                   </select>
@@ -442,8 +576,12 @@ export default function PartnersPage() {
                     onClick={() => router.push(`/partners/${partner.id}`)}
                   >
                     <TableCell>
-                      <div className="font-medium text-black">{partner.name}</div>
-                      <div className="text-xs text-gray-500">{partner.focus}</div>
+                      <div className="font-medium text-black">
+                        {partner.name}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {partner.focus}
+                      </div>
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline">{partner.stage}</Badge>
@@ -454,14 +592,23 @@ export default function PartnersPage() {
                     <TableCell className="text-sm text-gray-600">
                       {partner.city}, {partner.state}
                     </TableCell>
-                    <TableCell className="text-right font-medium text-black">{formatCurrency(partner.potentialValue)}</TableCell>
-                    <TableCell className="text-right text-sm text-gray-700">{partner.warmIntroductions}</TableCell>
+                    <TableCell className="text-right font-medium text-black">
+                      {formatCurrency(partner.potentialValue)}
+                    </TableCell>
+                    <TableCell className="text-right text-sm text-gray-700">
+                      {partner.warmIntroductions}
+                    </TableCell>
                     <TableCell className="text-right">
                       <div className="flex items-center justify-end gap-2 text-xs text-gray-600">
                         <div className="h-2 w-16 overflow-hidden rounded-full bg-gray-100">
-                          <div className="h-full bg-gray-900" style={{ width: `${partner.readinessScore}%` }} />
+                          <div
+                            className="h-full bg-gray-900"
+                            style={{ width: `${partner.readinessScore}%` }}
+                          />
                         </div>
-                        <span className="font-medium text-black">{partner.readinessScore}%</span>
+                        <span className="font-medium text-black">
+                          {partner.readinessScore}%
+                        </span>
                       </div>
                     </TableCell>
                   </TableRow>
@@ -475,31 +622,53 @@ export default function PartnersPage() {
       {activeTab === "Introductions" && (
         <Card className={cn(TRS_CARD)}>
           <CardHeader>
-            <CardTitle className="text-sm font-medium">Warm Introductions & Co-Sell Plays</CardTitle>
-            <CardDescription>Track every mutual opportunity in motion.</CardDescription>
+            <CardTitle className="text-sm font-medium">
+              Warm Introductions & Co-Sell Plays
+            </CardTitle>
+            <CardDescription>
+              Track every mutual opportunity in motion.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             {activeOpportunities.map((opportunity) => (
-              <div key={opportunity.id} className="rounded-lg border border-gray-200 p-3">
+              <div
+                key={opportunity.id}
+                className="rounded-lg border border-gray-200 p-3"
+              >
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div>
-                    <div className="text-sm font-semibold text-black">{opportunity.name}</div>
+                    <div className="text-sm font-semibold text-black">
+                      {opportunity.name}
+                    </div>
                     <div className="text-xs text-gray-500">
-                      {opportunity.partnerName} • {opportunity.type} • {opportunity.status}
+                      {opportunity.partnerName} • {opportunity.type} •{" "}
+                      {opportunity.status}
                     </div>
                   </div>
                   <div className="text-right text-sm font-medium text-black">
                     {formatCurrency(opportunity.value)}
-                    <div className="text-xs font-normal text-gray-500">Target: {opportunity.targetClient}</div>
+                    <div className="text-xs font-normal text-gray-500">
+                      Target: {opportunity.targetClient}
+                    </div>
                   </div>
                 </div>
                 <div className="mt-2 flex flex-wrap items-center justify-between text-xs text-gray-500">
-                  <span>Expected wrap: {new Date(opportunity.expectedClose).toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>
+                  <span>
+                    Expected wrap:{" "}
+                    {new Date(opportunity.expectedClose).toLocaleDateString(
+                      "en-US",
+                      { month: "short", day: "numeric" },
+                    )}
+                  </span>
                   <Button
                     size="sm"
                     variant="outline"
                     className="h-7 px-3 text-xs"
-                    onClick={() => router.push(`/partners/${opportunity.partnerId}?tab=Introductions`)}
+                    onClick={() =>
+                      router.push(
+                        `/partners/${opportunity.partnerId}?tab=Introductions`,
+                      )
+                    }
                   >
                     View partner record
                   </Button>
@@ -514,23 +683,56 @@ export default function PartnersPage() {
         <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <Card className={cn(TRS_CARD)}>
             <CardHeader>
-              <CardTitle className="text-sm font-medium">Partner Enablement Roadmap</CardTitle>
-              <CardDescription>Prioritize the assets that accelerate reciprocity.</CardDescription>
+              <CardTitle className="text-sm font-medium">
+                Partner Enablement Roadmap
+              </CardTitle>
+              <CardDescription>
+                Prioritize the assets that accelerate reciprocity.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {["Referral toolkit", "Co-branded event kit", "Revenue readiness dashboard"].map((item, index) => (
-                <div key={item} className="rounded-lg border border-gray-200 p-3">
+              {[
+                "Referral toolkit",
+                "Co-branded event kit",
+                "Revenue readiness dashboard",
+              ].map((item, index) => (
+                <div
+                  key={item}
+                  className="rounded-lg border border-gray-200 p-3"
+                >
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-sm font-semibold text-black">{item}</div>
-                      <div className="text-xs text-gray-500">Owner: {index === 0 ? "Jordan Blake" : index === 1 ? "Morgan Lee" : "Enablement"}</div>
+                      <div className="text-sm font-semibold text-black">
+                        {item}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        Owner:{" "}
+                        {index === 0
+                          ? "Jordan Blake"
+                          : index === 1
+                            ? "Morgan Lee"
+                            : "Enablement"}
+                      </div>
                     </div>
-                    <Badge variant={index === 0 ? "success" : index === 1 ? "default" : "outline"}>
-                      {index === 0 ? "Ready" : index === 1 ? "In Flight" : "Planned"}
+                    <Badge
+                      variant={
+                        index === 0
+                          ? "success"
+                          : index === 1
+                            ? "default"
+                            : "outline"
+                      }
+                    >
+                      {index === 0
+                        ? "Ready"
+                        : index === 1
+                          ? "In Flight"
+                          : "Planned"}
                     </Badge>
                   </div>
                   <div className="mt-2 text-xs text-gray-500">
-                    Align deliverables with partner strengths to keep intros flowing.
+                    Align deliverables with partner strengths to keep intros
+                    flowing.
                   </div>
                 </div>
               ))}
@@ -539,14 +741,20 @@ export default function PartnersPage() {
 
           <Card className={cn(TRS_CARD)}>
             <CardHeader>
-              <CardTitle className="text-sm font-medium">Readiness Breakdown</CardTitle>
-              <CardDescription>Where to invest coaching and storytelling next.</CardDescription>
+              <CardTitle className="text-sm font-medium">
+                Readiness Breakdown
+              </CardTitle>
+              <CardDescription>
+                Where to invest coaching and storytelling next.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4 text-sm text-gray-600">
               <div className="space-y-2">
                 {["ready", "ramping", "emerging"].map((band) => (
                   <div key={band} className="flex items-center gap-3">
-                    <div className="w-20 text-xs font-semibold uppercase text-gray-400">{band}</div>
+                    <div className="w-20 text-xs font-semibold uppercase text-gray-400">
+                      {band}
+                    </div>
                     <div className="flex-1">
                       <div className="h-2 rounded-full bg-gray-100">
                         <div
@@ -554,7 +762,11 @@ export default function PartnersPage() {
                           style={{
                             width: `${
                               relationships.length
-                                ? (readinessByBand[band as keyof typeof readinessByBand] / relationships.length) * 100
+                                ? (readinessByBand[
+                                    band as keyof typeof readinessByBand
+                                  ] /
+                                    relationships.length) *
+                                  100
                                 : 0
                             }%`,
                           }}
@@ -562,14 +774,16 @@ export default function PartnersPage() {
                       </div>
                     </div>
                     <div className="w-12 text-right text-xs text-gray-500">
-                      {readinessByBand[band as keyof typeof readinessByBand]} partners
+                      {readinessByBand[band as keyof typeof readinessByBand]}{" "}
+                      partners
                     </div>
                   </div>
                 ))}
               </div>
               <p>
-                Share success stories and enablement kits with <span className="font-medium text-black">ramping</span> allies to
-                graduate them into ready advocates this quarter.
+                Share success stories and enablement kits with{" "}
+                <span className="font-medium text-black">ramping</span> allies
+                to graduate them into ready advocates this quarter.
               </p>
             </CardContent>
           </Card>
@@ -577,17 +791,27 @@ export default function PartnersPage() {
       )}
 
       {showLogModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowLogModal(false)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setShowLogModal(false)}
+        >
           <div
             className="w-full max-w-xl rounded-lg border border-gray-200 bg-white p-6 shadow-xl"
             onClick={(event) => event.stopPropagation()}
           >
             <div className="mb-4 flex items-start justify-between">
               <div>
-                <h2 className="text-lg font-semibold text-black">Log new relationship</h2>
-                <p className="text-sm text-gray-500">Capture the essentials so you can nurture the next warm intro.</p>
+                <h2 className="text-lg font-semibold text-black">
+                  Log new relationship
+                </h2>
+                <p className="text-sm text-gray-500">
+                  Capture the essentials so you can nurture the next warm intro.
+                </p>
               </div>
-              <button onClick={() => setShowLogModal(false)} className="text-gray-400 hover:text-gray-600">
+              <button
+                onClick={() => setShowLogModal(false)}
+                className="text-gray-400 hover:text-gray-600"
+              >
                 ✕
               </button>
             </div>
@@ -595,20 +819,32 @@ export default function PartnersPage() {
             <div className="space-y-4">
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
-                  <label className="text-sm font-medium text-black">Organization name *</label>
+                  <label className="text-sm font-medium text-black">
+                    Organization name *
+                  </label>
                   <Input
                     value={newRelationship.name}
-                    onChange={(event) => setNewRelationship({ ...newRelationship, name: event.target.value })}
+                    onChange={(event) =>
+                      setNewRelationship({
+                        ...newRelationship,
+                        name: event.target.value,
+                      })
+                    }
                     placeholder="e.g. Eastside Founders Guild"
                     className="mt-1"
                   />
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-black">Organization type *</label>
+                  <label className="text-sm font-medium text-black">
+                    Organization type *
+                  </label>
                   <Input
                     value={newRelationship.organizationType}
                     onChange={(event) =>
-                      setNewRelationship({ ...newRelationship, organizationType: event.target.value })
+                      setNewRelationship({
+                        ...newRelationship,
+                        organizationType: event.target.value,
+                      })
                     }
                     placeholder="Chamber, co-op, accelerator..."
                     className="mt-1"
@@ -621,17 +857,27 @@ export default function PartnersPage() {
                   <label className="text-sm font-medium text-black">City</label>
                   <Input
                     value={newRelationship.city}
-                    onChange={(event) => setNewRelationship({ ...newRelationship, city: event.target.value })}
+                    onChange={(event) =>
+                      setNewRelationship({
+                        ...newRelationship,
+                        city: event.target.value,
+                      })
+                    }
                     placeholder="Austin"
                     className="mt-1"
                   />
                 </div>
                 <div>
-                  <label className="text-sm font-medium text-black">Stage</label>
+                  <label className="text-sm font-medium text-black">
+                    Stage
+                  </label>
                   <select
                     value={newRelationship.stage}
                     onChange={(event) =>
-                      setNewRelationship({ ...newRelationship, stage: event.target.value as Partner["stage"] })
+                      setNewRelationship({
+                        ...newRelationship,
+                        stage: event.target.value as Partner["stage"],
+                      })
                     }
                     className="mt-1 h-10 w-full rounded-md border border-gray-200 bg-white px-3 text-sm"
                   >
@@ -648,17 +894,30 @@ export default function PartnersPage() {
                 <label className="text-sm font-medium text-black">Owner</label>
                 <Input
                   value={newRelationship.owner}
-                  onChange={(event) => setNewRelationship({ ...newRelationship, owner: event.target.value })}
+                  onChange={(event) =>
+                    setNewRelationship({
+                      ...newRelationship,
+                      owner: event.target.value,
+                    })
+                  }
                   placeholder="Who is nurturing this?"
                   className="mt-1"
                 />
               </div>
 
               <div className="flex justify-end gap-2 border-t border-gray-200 pt-4">
-                <Button variant="outline" size="sm" onClick={() => setShowLogModal(false)}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowLogModal(false)}
+                >
                   Cancel
                 </Button>
-                <Button variant="primary" size="sm" onClick={handleCreateRelationship}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleCreateRelationship}
+                >
                   Save relationship
                 </Button>
               </div>
@@ -667,5 +926,5 @@ export default function PartnersPage() {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/app/pipeline/PipelineClient.tsx
+++ b/app/pipeline/PipelineClient.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 
 import { PageTemplate } from "@/components/layout/PageTemplate";
 import type { PageTemplateBadge } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
 import { AddProspectModal } from "@/components/pipeline/AddProspectModal";
 import { PipelineFilters } from "@/components/pipeline/PipelineFilters";
 import { PipelineKanban } from "@/components/pipeline/PipelineKanban";
@@ -27,7 +28,11 @@ type Props = {
   userId: string;
 };
 
-export default function PipelineClient({ opportunities, metrics, userId }: Props) {
+export default function PipelineClient({
+  opportunities,
+  metrics,
+  userId,
+}: Props) {
   const [activeTab, setActiveTab] = useState("Overview");
   const [showAddProspect, setShowAddProspect] = useState(false);
   const [filteredOpportunities, setFilteredOpportunities] =
@@ -42,11 +47,20 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
   }, [opportunities]);
 
   const opportunitiesByStage = useMemo(() => {
-    const stages = ["Prospect", "Qualify", "Proposal", "Negotiation", "ClosedWon", "ClosedLost"];
+    const stages = [
+      "Prospect",
+      "Qualify",
+      "Proposal",
+      "Negotiation",
+      "ClosedWon",
+      "ClosedLost",
+    ];
     const grouped: { [stage: string]: OpportunityWithNotes[] } = {};
 
     stages.forEach((stage) => {
-      grouped[stage] = filteredOpportunities.filter((opp) => opp.stage === stage);
+      grouped[stage] = filteredOpportunities.filter(
+        (opp) => opp.stage === stage,
+      );
     });
 
     return grouped;
@@ -113,15 +127,18 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
       <Card className={cn(TRS_CARD)}>
         <CardContent className="p-4 space-y-2">
           <div className={TRS_SUBTITLE}>Win Rate</div>
-          <div className="text-2xl font-semibold text-black">{metrics.winRate.toFixed(0)}%</div>
+          <div className="text-2xl font-semibold text-black">
+            {metrics.winRate.toFixed(0)}%
+          </div>
           <div className="flex items-center gap-2 text-xs text-gray-600">
             <span className="font-medium text-gray-700">
-              {(opportunitiesByStage.ClosedWon?.length || 0)} won
+              {opportunitiesByStage.ClosedWon?.length || 0} won
             </span>
             <span>/</span>
             <span>
               {(opportunitiesByStage.ClosedWon?.length || 0) +
-                (opportunitiesByStage.ClosedLost?.length || 0)} closed
+                (opportunitiesByStage.ClosedLost?.length || 0)}{" "}
+              closed
             </span>
           </div>
         </CardContent>
@@ -167,28 +184,19 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
       badges={headerBadges}
       stats={kpiCards}
     >
-      <div className="flex items-center gap-2 border-b border-gray-200 pb-2">
-        {["Overview", "Pipeline", "Forecast"].map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={cn(
-              "px-3 py-2 text-sm font-medium transition-colors",
-              activeTab === tab
-                ? "border-b-2 border-black text-black"
-                : "text-gray-600 hover:text-black"
-            )}
-          >
-            {tab}
-          </button>
-        ))}
-      </div>
+      <PageTabs
+        tabs={["Overview", "Pipeline", "Forecast"]}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
 
       {activeTab === "Overview" && (
         <div className="space-y-4">
           <div className={cn(TRS_CARD, "p-4")}>
             <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-black">Sales Pipeline Overview</h2>
+              <h2 className="text-lg font-semibold text-black">
+                Sales Pipeline Overview
+              </h2>
               <p className="text-sm text-gray-500">
                 Track prospects through your sales funnel
               </p>
@@ -196,10 +204,19 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
           </div>
 
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
-            {["Prospect", "Qualify", "Proposal", "Negotiation", "ClosedWon"].map((stage) => {
+            {[
+              "Prospect",
+              "Qualify",
+              "Proposal",
+              "Negotiation",
+              "ClosedWon",
+            ].map((stage) => {
               const count = opportunitiesByStage[stage]?.length || 0;
               const value =
-                opportunitiesByStage[stage]?.reduce((sum, opp) => sum + opp.amount, 0) || 0;
+                opportunitiesByStage[stage]?.reduce(
+                  (sum, opp) => sum + opp.amount,
+                  0,
+                ) || 0;
 
               return (
                 <Card key={stage} className={cn(TRS_CARD)}>
@@ -207,8 +224,12 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
                     <div className="mb-2 text-xs font-medium uppercase text-gray-500">
                       {stage === "ClosedWon" ? "Closed Won" : stage}
                     </div>
-                    <div className="mb-1 text-2xl font-semibold text-black">{count}</div>
-                    <div className="text-sm text-gray-600">{(value / 1000).toFixed(0)}K</div>
+                    <div className="mb-1 text-2xl font-semibold text-black">
+                      {count}
+                    </div>
+                    <div className="text-sm text-gray-600">
+                      {(value / 1000).toFixed(0)}K
+                    </div>
                   </CardContent>
                 </Card>
               );
@@ -230,7 +251,9 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
                       >
                         <div>
                           <div className="font-medium">{deal.name}</div>
-                          <div className="text-xs text-gray-500">{deal.client?.name}</div>
+                          <div className="text-xs text-gray-500">
+                            {deal.client?.name}
+                          </div>
                         </div>
                         <Badge variant="outline">{deal.stage}</Badge>
                       </div>
@@ -250,7 +273,8 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
                     atRiskDeals.slice(0, 5).map((deal) => {
                       const updated = new Date(deal.updated_at);
                       const daysStale = Math.floor(
-                        (Date.now() - updated.getTime()) / (1000 * 60 * 60 * 24)
+                        (Date.now() - updated.getTime()) /
+                          (1000 * 60 * 60 * 24),
                       );
 
                       return (
@@ -260,7 +284,9 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
                         >
                           <div>
                             <div className="font-medium">{deal.name}</div>
-                            <div className="text-xs text-gray-500">{deal.client?.name}</div>
+                            <div className="text-xs text-gray-500">
+                              {deal.client?.name}
+                            </div>
                           </div>
                           <Badge variant="warning">{daysStale}d</Badge>
                         </div>
@@ -279,7 +305,9 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
           <div className={cn(TRS_CARD, "p-4")}>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="space-y-1">
-                <h2 className="text-lg font-semibold text-black">Pipeline Kanban Board</h2>
+                <h2 className="text-lg font-semibold text-black">
+                  Pipeline Kanban Board
+                </h2>
                 <p className="text-sm text-gray-500">
                   Drag and drop deals to move them through stages
                 </p>
@@ -295,7 +323,10 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
             onFilterChange={setFilteredOpportunities}
           />
 
-          <PipelineKanban opportunitiesByStage={opportunitiesByStage} userId={userId} />
+          <PipelineKanban
+            opportunitiesByStage={opportunitiesByStage}
+            userId={userId}
+          />
         </div>
       )}
 
@@ -309,7 +340,10 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
       )}
 
       {showAddProspect && (
-        <AddProspectModal onClose={() => setShowAddProspect(false)} userId={userId} />
+        <AddProspectModal
+          onClose={() => setShowAddProspect(false)}
+          userId={userId}
+        />
       )}
     </PageTemplate>
   );

--- a/app/projects/ProjectsPageClient.tsx
+++ b/app/projects/ProjectsPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
+import { PageTabs } from "@/components/layout/PageTabs";
 import { Card } from "@/components/kit/Card";
 import { resolveTabs } from "@/lib/tabs";
 import { cn } from "@/lib/utils";
@@ -76,7 +77,12 @@ export default function ProjectsPageClient({
   stats,
 }: {
   projects: Project[];
-  stats: { active: number; onTrack: number; atRisk: number; avgProgress: number };
+  stats: {
+    active: number;
+    onTrack: number;
+    atRisk: number;
+    avgProgress: number;
+  };
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -86,171 +92,242 @@ export default function ProjectsPageClient({
     return current && tabs.includes(current) ? current : tabs[0];
   }, [searchParams, tabs]);
 
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
+
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
       <section className="space-y-4">
         <header className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold text-black">Projects Control Center</h1>
-        <p className="text-sm text-gray-600">
-          Coordinate delivery motions, surface risk, and keep stakeholders aligned across TRS programs.
-        </p>
+          <h1 className="text-2xl font-semibold text-black">
+            Projects Control Center
+          </h1>
+          <p className="text-sm text-gray-600">
+            Coordinate delivery motions, surface risk, and keep stakeholders
+            aligned across TRS programs.
+          </p>
         </header>
 
-        {activeTab === "Overview" && (
-        <div className="space-y-4">
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              <div>
-                <div className="text-sm font-semibold text-black">Live Programs</div>
-                <p className="text-xs text-gray-600">Snapshot of core initiatives and momentum.</p>
-              </div>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>Active Projects</div>
-                  <div className="mt-1 text-xl font-semibold text-black">{stats.active}</div>
-                  <div className="text-[11px] text-gray-600">Live delivery</div>
-                </div>
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>On Track</div>
-                  <div className="mt-1 text-xl font-semibold text-black">{stats.onTrack}</div>
-                  <div className="text-[11px] text-gray-600">Healthy projects</div>
-                </div>
-                <div className={cn(TRS_CARD, "p-3")}>
-                  <div className={TRS_SUBTITLE}>At Risk</div>
-                  <div className="mt-1 text-xl font-semibold text-black">{stats.atRisk}</div>
-                  <div className="text-[11px] text-gray-600">Requires action</div>
-                </div>
-              </div>
-            </div>
-            <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
-              <table className="w-full text-sm">
-                <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
-                  <tr>
-                    <th className="px-3 py-2 font-medium">Project</th>
-                    <th className="px-3 py-2 font-medium">Client</th>
-                    <th className="px-3 py-2 font-medium">Phase</th>
-                    <th className="px-3 py-2 font-medium">Owner</th>
-                    <th className="px-3 py-2 font-medium">Health</th>
-                    <th className="px-3 py-2 font-medium">Progress</th>
-                    <th className="px-3 py-2 font-medium">Due</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
-                  {projects.map((project) => (
-                    <tr key={project.id} className="hover:bg-gray-50">
-                      <td className="px-3 py-2 font-medium text-black">{project.name}</td>
-                      <td className="px-3 py-2">
-                        <Link
-                          href={`/clients/${project.clientId}?tab=Projects`}
-                          className="text-gray-700 hover:text-black hover:underline"
-                        >
-                          {project.clientName}
-                        </Link>
-                      </td>
-                      <td className="px-3 py-2 text-gray-700">{project.phase}</td>
-                      <td className="px-3 py-2 text-gray-700">{project.owner}</td>
-                      <td
-                        className={`px-3 py-2 text-sm ${
-                          project.health === "green"
-                            ? "text-gray-600"
-                            : project.health === "yellow"
-                            ? "text-gray-600"
-                            : "text-gray-600"
-                        }`}
-                      >
-                        {project.health === "green" ? "On Track" : project.health === "yellow" ? "At Risk" : "Critical"}
-                      </td>
-                      <td className="px-3 py-2 text-gray-700">{project.progress}%</td>
-                      <td className="px-3 py-2 text-gray-700">{project.dueDate || "—"}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </Card>
-        </div>
-      )}
+        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
 
-      {activeTab === "Active" && (
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          {activeStreams.map((stream) => (
-            <Card key={stream.title} className={cn(TRS_CARD, "p-4")}>
-              <div className="text-sm font-semibold text-black">{stream.title}</div>
-              <div className="mt-3 space-y-3">
-                {stream.items.map((item) => (
-                  <div key={`${stream.title}-${item.task}`} className="rounded-lg border border-gray-200 p-3">
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <div className="text-sm font-medium text-black">{item.task}</div>
-                        <div className="text-[12px] text-gray-600">
-                          Owner: {item.owner} • Due {item.due}
+        {activeTab === "Overview" && (
+          <div className="space-y-4">
+            <Card className={cn(TRS_CARD, "p-4")}>
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <div className="text-sm font-semibold text-black">
+                    Live Programs
+                  </div>
+                  <p className="text-xs text-gray-600">
+                    Snapshot of core initiatives and momentum.
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>Active Projects</div>
+                    <div className="mt-1 text-xl font-semibold text-black">
+                      {stats.active}
+                    </div>
+                    <div className="text-[11px] text-gray-600">
+                      Live delivery
+                    </div>
+                  </div>
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>On Track</div>
+                    <div className="mt-1 text-xl font-semibold text-black">
+                      {stats.onTrack}
+                    </div>
+                    <div className="text-[11px] text-gray-600">
+                      Healthy projects
+                    </div>
+                  </div>
+                  <div className={cn(TRS_CARD, "p-3")}>
+                    <div className={TRS_SUBTITLE}>At Risk</div>
+                    <div className="mt-1 text-xl font-semibold text-black">
+                      {stats.atRisk}
+                    </div>
+                    <div className="text-[11px] text-gray-600">
+                      Requires action
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
+                <table className="w-full text-sm">
+                  <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Project</th>
+                      <th className="px-3 py-2 font-medium">Client</th>
+                      <th className="px-3 py-2 font-medium">Phase</th>
+                      <th className="px-3 py-2 font-medium">Owner</th>
+                      <th className="px-3 py-2 font-medium">Health</th>
+                      <th className="px-3 py-2 font-medium">Progress</th>
+                      <th className="px-3 py-2 font-medium">Due</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 bg-white">
+                    {projects.map((project) => (
+                      <tr key={project.id} className="hover:bg-gray-50">
+                        <td className="px-3 py-2 font-medium text-black">
+                          {project.name}
+                        </td>
+                        <td className="px-3 py-2">
+                          <Link
+                            href={`/clients/${project.clientId}?tab=Projects`}
+                            className="text-gray-700 hover:text-black hover:underline"
+                          >
+                            {project.clientName}
+                          </Link>
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {project.phase}
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {project.owner}
+                        </td>
+                        <td
+                          className={`px-3 py-2 text-sm ${
+                            project.health === "green"
+                              ? "text-gray-600"
+                              : project.health === "yellow"
+                                ? "text-gray-600"
+                                : "text-gray-600"
+                          }`}
+                        >
+                          {project.health === "green"
+                            ? "On Track"
+                            : project.health === "yellow"
+                              ? "At Risk"
+                              : "Critical"}
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {project.progress}%
+                        </td>
+                        <td className="px-3 py-2 text-gray-700">
+                          {project.dueDate || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </div>
+        )}
+
+        {activeTab === "Active" && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {activeStreams.map((stream) => (
+              <Card key={stream.title} className={cn(TRS_CARD, "p-4")}>
+                <div className="text-sm font-semibold text-black">
+                  {stream.title}
+                </div>
+                <div className="mt-3 space-y-3">
+                  {stream.items.map((item) => (
+                    <div
+                      key={`${stream.title}-${item.task}`}
+                      className="rounded-lg border border-gray-200 p-3"
+                    >
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <div className="text-sm font-medium text-black">
+                            {item.task}
+                          </div>
+                          <div className="text-[12px] text-gray-600">
+                            Owner: {item.owner} • Due {item.due}
+                          </div>
                         </div>
+                        <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+                          {item.status}
+                        </span>
                       </div>
-                      <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-                        {item.status}
-                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {activeTab === "Forecast" && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              {forecastMetrics.map((metric) => (
+                <Card key={metric.label} className={cn(TRS_CARD, "p-4")}>
+                  <div className={TRS_SUBTITLE}>{metric.label}</div>
+                  <div className="mt-2 text-2xl font-semibold text-black">
+                    {metric.value}
+                  </div>
+                  <div className="text-[12px] text-gray-600">
+                    {metric.context}
+                  </div>
+                </Card>
+              ))}
+            </div>
+            <Card className={cn(TRS_CARD, "p-4")}>
+              <div className="text-sm font-semibold text-black">
+                Quarterly outlook
+              </div>
+              <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+                {forecastTimeline.map((point) => (
+                  <div
+                    key={point.month}
+                    className="rounded-lg border border-gray-200 p-3"
+                  >
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                      {point.month}
+                    </div>
+                    <div className="mt-1 text-lg font-semibold text-black">
+                      {point.arr}
+                    </div>
+                    <div className="text-[12px] text-gray-600">
+                      {point.milestone}
                     </div>
                   </div>
                 ))}
               </div>
             </Card>
-          ))}
-        </div>
-      )}
-
-      {activeTab === "Forecast" && (
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-            {forecastMetrics.map((metric) => (
-              <Card key={metric.label} className={cn(TRS_CARD, "p-4")}>
-                <div className={TRS_SUBTITLE}>{metric.label}</div>
-                <div className="mt-2 text-2xl font-semibold text-black">{metric.value}</div>
-                <div className="text-[12px] text-gray-600">{metric.context}</div>
-              </Card>
-            ))}
           </div>
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="text-sm font-semibold text-black">Quarterly outlook</div>
-            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-              {forecastTimeline.map((point) => (
-                <div key={point.month} className="rounded-lg border border-gray-200 p-3">
-                  <div className="text-[11px] uppercase tracking-wide text-gray-500">{point.month}</div>
-                  <div className="mt-1 text-lg font-semibold text-black">{point.arr}</div>
-                  <div className="text-[12px] text-gray-600">{point.milestone}</div>
-                </div>
-              ))}
-            </div>
-          </Card>
-        </div>
-      )}
+        )}
 
-      {activeTab === "Agent" && (
-        <Card className={cn(TRS_CARD, "p-4")}>
-          <div className="text-sm font-semibold text-black">Project Intelligence Agent</div>
-          <p className="mt-2 text-sm text-gray-600">
-            Ask the agent to analyze timelines, forecast budget impact, or surface risk across delivery tracks.
-          </p>
-          <div className="mt-4 space-y-3">
-            <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
-              Prompt workspace placeholder
+        {activeTab === "Agent" && (
+          <Card className={cn(TRS_CARD, "p-4")}>
+            <div className="text-sm font-semibold text-black">
+              Project Intelligence Agent
             </div>
-            <div>
-              <div className="text-[12px] uppercase tracking-wide text-gray-500">Quick prompts</div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {agentPrompts.map((prompt) => (
-                  <button
-                    key={prompt}
-                    className="rounded-full border border-gray-300 px-3 py-1 text-[12px] text-gray-700 transition hover:border-black hover:text-black"
-                    type="button"
-                  >
-                    {prompt}
-                  </button>
-                ))}
+            <p className="mt-2 text-sm text-gray-600">
+              Ask the agent to analyze timelines, forecast budget impact, or
+              surface risk across delivery tracks.
+            </p>
+            <div className="mt-4 space-y-3">
+              <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+                Prompt workspace placeholder
+              </div>
+              <div>
+                <div className="text-[12px] uppercase tracking-wide text-gray-500">
+                  Quick prompts
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {agentPrompts.map((prompt) => (
+                    <button
+                      key={prompt}
+                      className="rounded-full border border-gray-300 px-3 py-1 text-[12px] text-gray-700 transition hover:border-black hover:text-black"
+                      type="button"
+                    >
+                      {prompt}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
-        </Card>
-      )}
+          </Card>
+        )}
       </section>
     </div>
   );

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,69 +1,143 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
-import { usePathname, useSearchParams } from "next/navigation"
+import { useCallback, useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
-import { PageTemplate } from "@/components/layout/PageTemplate"
-import { Badge } from "@/ui/badge"
-import { Button } from "@/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card"
-import { TRS_CARD } from "@/lib/style"
-import { resolveTabs } from "@/lib/tabs"
+import { PageTemplate } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/card";
+import { TRS_CARD } from "@/lib/style";
+import { resolveTabs } from "@/lib/tabs";
 
 const pricingScenarios = [
-  { tier: "Starter", list: 8500, floor: 7200, discountGuard: "15% max", packaging: "Seats + usage" },
-  { tier: "Growth", list: 18500, floor: 16000, discountGuard: "12% max", packaging: "Seats + workflow pack" },
-  { tier: "Enterprise", list: 42000, floor: 38000, discountGuard: "10% max", packaging: "Seats + governance + support" },
-]
+  {
+    tier: "Starter",
+    list: 8500,
+    floor: 7200,
+    discountGuard: "15% max",
+    packaging: "Seats + usage",
+  },
+  {
+    tier: "Growth",
+    list: 18500,
+    floor: 16000,
+    discountGuard: "12% max",
+    packaging: "Seats + workflow pack",
+  },
+  {
+    tier: "Enterprise",
+    list: 42000,
+    floor: 38000,
+    discountGuard: "10% max",
+    packaging: "Seats + governance + support",
+  },
+];
 
 const revenueDrivers = [
   { id: "rd1", name: "Net new ARR", amount: 185000, change: "+12% MoM" },
   { id: "rd2", name: "Expansion ARR", amount: 95000, change: "+6% MoM" },
   { id: "rd3", name: "Contraction ARR", amount: -45000, change: "-2% MoM" },
   { id: "rd4", name: "Churn ARR", amount: -115000, change: "+1% MoM" },
-]
+];
 
 const profitMetrics = [
-  { id: "pm1", name: "Gross margin", value: "78%", benchmark: "Top quartile SaaS" },
-  { id: "pm2", name: "Magic number", value: "1.3x", benchmark: "Efficient growth" },
-  { id: "pm3", name: "CAC payback", value: "13.5 months", benchmark: "Target < 15 months" },
+  {
+    id: "pm1",
+    name: "Gross margin",
+    value: "78%",
+    benchmark: "Top quartile SaaS",
+  },
+  {
+    id: "pm2",
+    name: "Magic number",
+    value: "1.3x",
+    benchmark: "Efficient growth",
+  },
+  {
+    id: "pm3",
+    name: "CAC payback",
+    value: "13.5 months",
+    benchmark: "Target < 15 months",
+  },
   { id: "pm4", name: "Rule of 40", value: "62", benchmark: "Above target" },
-]
+];
 
 const coverageMetrics = [
-  { label: "Total quota capacity", value: "$9.2M", detail: "12 AEs · 2.3x pipeline coverage" },
-  { label: "In-quarter commit", value: "$3.4M", detail: "65% probability weighted" },
-  { label: "Stretch scenario", value: "$4.1M", detail: "Requires 3 net-new logo wins" },
-]
+  {
+    label: "Total quota capacity",
+    value: "$9.2M",
+    detail: "12 AEs · 2.3x pipeline coverage",
+  },
+  {
+    label: "In-quarter commit",
+    value: "$3.4M",
+    detail: "65% probability weighted",
+  },
+  {
+    label: "Stretch scenario",
+    value: "$4.1M",
+    detail: "Requires 3 net-new logo wins",
+  },
+];
 
 const cashFlowItems = [
   "Headcount pacing vs plan",
   "Vendor consolidation savings",
   "Capital efficiency by cohort",
-]
+];
 
 const marginIdeas = [
   "Shift implementation to partners for enterprise tier",
   "Launch usage alerts to prevent overage credits",
   "Automate onboarding to reduce services cost",
-]
+];
 
 const scenarioPacks = [
-  { title: "Base", summary: "Plan of record, current hiring, pipeline confidence." },
-  { title: "Upside", summary: "Requires 2 strategic wins + PLG conversion lift." },
-  { title: "Downside", summary: "Models churn risk, slip deals, and cost controls." },
-]
+  {
+    title: "Base",
+    summary: "Plan of record, current hiring, pipeline confidence.",
+  },
+  {
+    title: "Upside",
+    summary: "Requires 2 strategic wins + PLG conversion lift.",
+  },
+  {
+    title: "Downside",
+    summary: "Models churn risk, slip deals, and cost controls.",
+  },
+];
 
-const whatIfLevers = ["AE ramp time", "Enterprise discount rate", "Partner-sourced pipeline"]
+const whatIfLevers = [
+  "AE ramp time",
+  "Enterprise discount rate",
+  "Partner-sourced pipeline",
+];
 
 export default function ResourcesPage() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname])
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
   const activeTab = useMemo(() => {
-    const current = searchParams.get("tab")
-    return current && tabs.includes(current) ? current : tabs[0]
-  }, [searchParams, tabs])
+    const current = searchParams.get("tab");
+    return current && tabs.includes(current) ? current : tabs[0];
+  }, [searchParams, tabs]);
+
+  const buildTabHref = useCallback(
+    (tab: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      return `${pathname}?${params.toString()}`;
+    },
+    [pathname, searchParams],
+  );
 
   return (
     <PageTemplate
@@ -75,25 +149,35 @@ export default function ResourcesPage() {
         { label: "Downloadable templates", variant: "default" as const },
       ]}
     >
+      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
+
       {activeTab === "Pricing" && (
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Guardrail calculator</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Guardrail calculator
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Set floor prices, packaging guardrails, and instant impact to ARR and margin.
+                Set floor prices, packaging guardrails, and instant impact to
+                ARR and margin.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
-                Adjust list price and discount allowances to visualize net ARR impact. Export recommendations for sales playbooks
-                in one click.
+                Adjust list price and discount allowances to visualize net ARR
+                impact. Export recommendations for sales playbooks in one click.
               </div>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 {pricingScenarios.map((scenario) => (
-                  <div key={scenario.tier} className="flex flex-col rounded-lg border border-gray-200 p-4">
+                  <div
+                    key={scenario.tier}
+                    className="flex flex-col rounded-lg border border-gray-200 p-4"
+                  >
                     <div className="flex items-center justify-between">
-                      <p className="text-sm font-semibold text-black">{scenario.tier}</p>
+                      <p className="text-sm font-semibold text-black">
+                        {scenario.tier}
+                      </p>
                       <Badge variant="outline">{scenario.packaging}</Badge>
                     </div>
                     <dl className="mt-3 space-y-2 text-sm text-gray-700">
@@ -110,7 +194,10 @@ export default function ResourcesPage() {
                         <dd>{scenario.discountGuard}</dd>
                       </div>
                     </dl>
-                    <Button variant="outline" className="mt-4 self-start text-sm">
+                    <Button
+                      variant="outline"
+                      className="mt-4 self-start text-sm"
+                    >
                       Export playbook
                     </Button>
                   </div>
@@ -121,23 +208,28 @@ export default function ResourcesPage() {
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Packaging experiments</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Packaging experiments
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Compare usage-based vs seat-based packaging to find the optimal blend.
+                Compare usage-based vs seat-based packaging to find the optimal
+                blend.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-3 rounded-lg border border-gray-200 p-4">
                 <p className="text-sm font-medium text-black">Usage-first</p>
                 <p className="text-sm text-gray-600">
-                  Meter core AI generation and automations. Seat add-ons unlock analytics and governance modules.
+                  Meter core AI generation and automations. Seat add-ons unlock
+                  analytics and governance modules.
                 </p>
                 <Badge variant="success">Recommended</Badge>
               </div>
               <div className="space-y-3 rounded-lg border border-gray-200 p-4">
                 <p className="text-sm font-medium text-black">Seat-first</p>
                 <p className="text-sm text-gray-600">
-                  Predictable ARR but lower margin. Layer usage overages when activation crosses 120% of plan.
+                  Predictable ARR but lower margin. Layer usage overages when
+                  activation crosses 120% of plan.
                 </p>
                 <Badge variant="outline">In testing</Badge>
               </div>
@@ -150,17 +242,27 @@ export default function ResourcesPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Revenue bridge</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Revenue bridge
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Understand what is driving ARR movement across segments and motions.
+                Understand what is driving ARR movement across segments and
+                motions.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 {revenueDrivers.map((driver) => (
-                  <div key={driver.id} className="rounded-lg border border-gray-200 p-4">
-                    <p className="text-sm font-medium text-black">{driver.name}</p>
-                    <p className={`mt-2 text-2xl font-semibold ${driver.amount >= 0 ? "text-emerald-600" : "text-rose-600"}`}>
+                  <div
+                    key={driver.id}
+                    className="rounded-lg border border-gray-200 p-4"
+                  >
+                    <p className="text-sm font-medium text-black">
+                      {driver.name}
+                    </p>
+                    <p
+                      className={`mt-2 text-2xl font-semibold ${driver.amount >= 0 ? "text-emerald-600" : "text-rose-600"}`}
+                    >
                       ${Math.abs(driver.amount / 1000).toFixed(0)}K
                     </p>
                     <p className="text-xs text-gray-500">{driver.change}</p>
@@ -168,24 +270,35 @@ export default function ResourcesPage() {
                 ))}
               </div>
               <div className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-700">
-                Model net new pipeline coverage, expansion playbooks, and churn saves with scenario toggles. Export to RevOps
-                dashboards instantly.
+                Model net new pipeline coverage, expansion playbooks, and churn
+                saves with scenario toggles. Export to RevOps dashboards
+                instantly.
               </div>
             </CardContent>
           </Card>
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Coverage calculator</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Coverage calculator
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Blend quota capacity, attainment, and forecast confidence to project outcomes.
+                Blend quota capacity, attainment, and forecast confidence to
+                project outcomes.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
               {coverageMetrics.map((metric) => (
-                <div key={metric.label} className="rounded-lg border border-gray-200 p-4">
-                  <p className="text-xs font-medium uppercase tracking-wide text-gray-500">{metric.label}</p>
-                  <p className="mt-2 text-2xl font-semibold text-black">{metric.value}</p>
+                <div
+                  key={metric.label}
+                  className="rounded-lg border border-gray-200 p-4"
+                >
+                  <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                    {metric.label}
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-black">
+                    {metric.value}
+                  </p>
                   <p className="mt-1 text-xs text-gray-500">{metric.detail}</p>
                 </div>
               ))}
@@ -198,35 +311,51 @@ export default function ResourcesPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Financial runway</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Financial runway
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Plan burn, runway, and investment pacing with CFO-grade controls.
+                Plan burn, runway, and investment pacing with CFO-grade
+                controls.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-3 rounded-lg border border-gray-200 p-4">
                 <p className="text-sm font-medium text-black">Base plan</p>
                 <p className="text-3xl font-semibold text-black">18.5 months</p>
-                <p className="text-xs text-gray-500">Runway based on current burn rate of $185K/mo</p>
+                <p className="text-xs text-gray-500">
+                  Runway based on current burn rate of $185K/mo
+                </p>
               </div>
               <div className="space-y-3 rounded-lg border border-gray-200 p-4">
-                <p className="text-sm font-medium text-black">Efficiency scenario</p>
-                <p className="text-3xl font-semibold text-emerald-600">21.3 months</p>
-                <p className="text-xs text-gray-500">Assumes 8% opex reduction + 6% ARR uplift</p>
+                <p className="text-sm font-medium text-black">
+                  Efficiency scenario
+                </p>
+                <p className="text-3xl font-semibold text-emerald-600">
+                  21.3 months
+                </p>
+                <p className="text-xs text-gray-500">
+                  Assumes 8% opex reduction + 6% ARR uplift
+                </p>
               </div>
             </CardContent>
           </Card>
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Cash flow planner</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Cash flow planner
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
                 Align hiring plans, vendor spend, and capital strategy.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               {cashFlowItems.map((item) => (
-                <div key={item} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+                <div
+                  key={item}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700"
+                >
                   {item}
                 </div>
               ))}
@@ -242,16 +371,25 @@ export default function ResourcesPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Profitability snapshot</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Profitability snapshot
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
                 Track margin, CAC payback, and capital efficiency benchmarks.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {profitMetrics.map((metric) => (
-                <div key={metric.id} className="rounded-lg border border-gray-200 p-4">
-                  <p className="text-sm font-medium text-black">{metric.name}</p>
-                  <p className="mt-2 text-2xl font-semibold text-black">{metric.value}</p>
+                <div
+                  key={metric.id}
+                  className="rounded-lg border border-gray-200 p-4"
+                >
+                  <p className="text-sm font-medium text-black">
+                    {metric.name}
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-black">
+                    {metric.value}
+                  </p>
                   <p className="text-xs text-gray-500">{metric.benchmark}</p>
                 </div>
               ))}
@@ -260,14 +398,19 @@ export default function ResourcesPage() {
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Margin improvement ideas</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Margin improvement ideas
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
                 Quick wins sourced from GTM, product, and finance collaboration.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               {marginIdeas.map((idea) => (
-                <div key={idea} className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+                <div
+                  key={idea}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700"
+                >
                   {idea}
                 </div>
               ))}
@@ -280,16 +423,24 @@ export default function ResourcesPage() {
         <div className="space-y-4">
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">Board-ready packs</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                Board-ready packs
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Assemble scenario outputs with commentary, risks, and actions in seconds.
+                Assemble scenario outputs with commentary, risks, and actions in
+                seconds.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
               {scenarioPacks.map((pack) => (
-                <div key={pack.title} className="flex flex-col justify-between rounded-lg border border-gray-200 p-4">
+                <div
+                  key={pack.title}
+                  className="flex flex-col justify-between rounded-lg border border-gray-200 p-4"
+                >
                   <div>
-                    <p className="text-sm font-semibold text-black">{pack.title}</p>
+                    <p className="text-sm font-semibold text-black">
+                      {pack.title}
+                    </p>
                     <p className="mt-1 text-sm text-gray-600">{pack.summary}</p>
                   </div>
                   <Button variant="outline" className="mt-4 self-start text-sm">
@@ -302,14 +453,20 @@ export default function ResourcesPage() {
 
           <Card className={TRS_CARD}>
             <CardHeader>
-              <CardTitle className="text-lg font-semibold text-black">What-if levers</CardTitle>
+              <CardTitle className="text-lg font-semibold text-black">
+                What-if levers
+              </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Toggle hiring, win rates, and pricing to see multi-quarter impact.
+                Toggle hiring, win rates, and pricing to see multi-quarter
+                impact.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               {whatIfLevers.map((lever) => (
-                <div key={lever} className="flex items-center justify-between rounded-lg border border-gray-200 p-3 text-sm text-gray-700">
+                <div
+                  key={lever}
+                  className="flex items-center justify-between rounded-lg border border-gray-200 p-3 text-sm text-gray-700"
+                >
                   <span>{lever}</span>
                   <Badge variant="outline">Interactive</Badge>
                 </div>
@@ -319,5 +476,5 @@ export default function ResourcesPage() {
         </div>
       )}
     </PageTemplate>
-  )
+  );
 }

--- a/components/kit/TopTabs.tsx
+++ b/components/kit/TopTabs.tsx
@@ -1,30 +1,27 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
+
+import { PageTabs } from "@/components/layout/PageTabs";
 import { resolveTabs } from "@/lib/tabs";
 
-export function TopTabs({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+export function TopTabs({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
   const pathname = usePathname();
   const tabs = resolveTabs(pathname);
   const active = tabs.includes(value) ? value : tabs[0];
 
   return (
-    <div className="flex h-[44px] items-center gap-2">
-      {tabs.map((t) => (
-        <button
-          key={t}
-          onClick={() => onChange(t)}
-          className={cn(
-            "h-8 rounded-md border px-3 text-sm transition-colors",
-            active === t
-              ? "border-gray-900 bg-white font-semibold text-black"
-              : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-black",
-          )}
-        >
-          {t}
-        </button>
-      ))}
-    </div>
+    <PageTabs
+      tabs={tabs}
+      activeTab={active}
+      onTabChange={onChange}
+      className="h-[44px] items-end gap-3 border-b-0 pb-0"
+    />
   );
 }

--- a/components/layout/PageTabs.tsx
+++ b/components/layout/PageTabs.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+export type PageTabsProps = {
+  tabs: string[];
+  activeTab: string;
+  onTabChange?: (tab: string) => void;
+  hrefForTab?: (tab: string) => string;
+  className?: string;
+};
+
+export function PageTabs({
+  tabs,
+  activeTab,
+  onTabChange,
+  hrefForTab,
+  className,
+}: PageTabsProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-gray-200 pb-2",
+        className,
+      )}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab === activeTab;
+        const tabClasses = cn(
+          "border-b-2 border-transparent px-3 py-2 text-sm font-medium transition-colors",
+          isActive
+            ? "border-black text-black"
+            : "text-gray-600 hover:text-black",
+        );
+
+        if (hrefForTab) {
+          const href = hrefForTab(tab);
+          return (
+            <Link
+              key={tab}
+              href={href}
+              className={tabClasses}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {tab}
+            </Link>
+          );
+        }
+
+        return (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => onTabChange?.(tab)}
+            className={tabClasses}
+          >
+            {tab}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/settings/SettingsPageClient.tsx
+++ b/components/settings/SettingsPageClient.tsx
@@ -1,25 +1,28 @@
-"use client"
+"use client";
 
-import { useMemo, useState } from "react"
-import { PageTemplate } from "@/components/layout/PageTemplate"
-import type { PageTemplateBadge } from "@/components/layout/PageTemplate"
-import { AgentManager } from "@/components/settings/AgentManager"
-import { FeatureFlags } from "@/components/settings/FeatureFlags"
-import { IntegrationsForm } from "@/components/settings/IntegrationsForm"
-import { ThemeCard } from "@/components/settings/ThemeCard"
-import { ToneManager } from "@/components/settings/ToneManager"
-import { cn } from "@/lib/utils"
-import type { AgentBehaviorMap, AgentDefinition } from "@/lib/agents/types"
-import type { FeatureFlagRecord, IntegrationSettings } from "@/lib/settings/types"
+import { useMemo, useState } from "react";
+import { PageTemplate } from "@/components/layout/PageTemplate";
+import type { PageTemplateBadge } from "@/components/layout/PageTemplate";
+import { PageTabs } from "@/components/layout/PageTabs";
+import { AgentManager } from "@/components/settings/AgentManager";
+import { FeatureFlags } from "@/components/settings/FeatureFlags";
+import { IntegrationsForm } from "@/components/settings/IntegrationsForm";
+import { ThemeCard } from "@/components/settings/ThemeCard";
+import { ToneManager } from "@/components/settings/ToneManager";
+import type { AgentBehaviorMap, AgentDefinition } from "@/lib/agents/types";
+import type {
+  FeatureFlagRecord,
+  IntegrationSettings,
+} from "@/lib/settings/types";
 
 type SettingsPageClientProps = {
-  agents: AgentDefinition[]
-  behavior: AgentBehaviorMap
-  integrations: IntegrationSettings
-  featureFlags: FeatureFlagRecord[]
-  featureFlagServiceAvailable: boolean
-  featureFlagError?: string | null
-}
+  agents: AgentDefinition[];
+  behavior: AgentBehaviorMap;
+  integrations: IntegrationSettings;
+  featureFlags: FeatureFlagRecord[];
+  featureFlagServiceAvailable: boolean;
+  featureFlagError?: string | null;
+};
 
 export function SettingsPageClient({
   agents,
@@ -29,24 +32,38 @@ export function SettingsPageClient({
   featureFlagServiceAvailable,
   featureFlagError,
 }: SettingsPageClientProps) {
-  const [activeTab, setActiveTab] = useState("Agents")
+  const [activeTab, setActiveTab] = useState("Agents");
 
-  const tabs = ["Agents", "Appearance", "Integrations", "Feature Flags", "Behavior"]
+  const tabs = [
+    "Agents",
+    "Appearance",
+    "Integrations",
+    "Feature Flags",
+    "Behavior",
+  ];
 
   const headerBadges = useMemo<PageTemplateBadge[]>(
     () => [
       { label: `${agents.length} agents configured`, variant: "default" },
       {
-        label: featureFlagServiceAvailable ? "Feature flags connected" : "Feature flags offline",
+        label: featureFlagServiceAvailable
+          ? "Feature flags connected"
+          : "Feature flags offline",
         variant: featureFlagServiceAvailable ? "success" : "outline",
       },
       {
-        label: integrations.calendarSyncEnabled ? "Calendar sync enabled" : "Calendar sync disabled",
+        label: integrations.calendarSyncEnabled
+          ? "Calendar sync enabled"
+          : "Calendar sync disabled",
         variant: integrations.calendarSyncEnabled ? "success" : "outline",
       },
     ],
-    [agents.length, featureFlagServiceAvailable, integrations.calendarSyncEnabled],
-  )
+    [
+      agents.length,
+      featureFlagServiceAvailable,
+      integrations.calendarSyncEnabled,
+    ],
+  );
 
   return (
     <PageTemplate
@@ -54,23 +71,7 @@ export function SettingsPageClient({
       description="Configure agents, integrations, and governance controls for RevenueOS."
       badges={headerBadges}
     >
-      {/* Tab Navigation */}
-      <div className="flex items-center gap-2 border-b border-gray-200 pb-2">
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={cn(
-              "px-3 py-2 text-sm font-medium transition-colors",
-              activeTab === tab
-                ? "border-b-2 border-black text-black"
-                : "text-gray-600 hover:text-black"
-            )}
-          >
-            {tab}
-          </button>
-        ))}
-      </div>
+      <PageTabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
 
       {/* Tab Content */}
       {activeTab === "Agents" && (
@@ -110,5 +111,5 @@ export function SettingsPageClient({
         </div>
       )}
     </PageTemplate>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add a reusable PageTabs component to handle tab rendering with shared styling and optional routing
- update settings, the app shell, and revenue-facing pages to adopt the shared tabs so navigation appears consistently

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9ca4a317c8324a5879426851d9470