### PR TITLE
Fix prospect creation to match Supabase schema

### DIFF
--- a/app/pipeline/PipelineClient.tsx
+++ b/app/pipeline/PipelineClient.tsx
@@ -8,6 +8,11 @@ import { AddProspectModal } from "@/components/pipeline/AddProspectModal";
 import { PipelineFilters } from "@/components/pipeline/PipelineFilters";
 import { PipelineKanban } from "@/components/pipeline/PipelineKanban";
 import type { OpportunityWithNotes } from "@/core/pipeline/actions";
+import {
+  PIPELINE_STAGE_LABELS,
+  PIPELINE_STAGE_ORDER,
+  type PipelineStage,
+} from "@/core/pipeline/constants";
 import { Badge } from "@/ui/badge";
 import { Button } from "@/ui/button";
 import { Card, CardContent } from "@/ui/card";
@@ -42,14 +47,12 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
   }, [opportunities]);
 
   const opportunitiesByStage = useMemo(() => {
-    const stages = ["Prospect", "Qualify", "Proposal", "Negotiation", "ClosedWon", "ClosedLost"];
-    const grouped: { [stage: string]: OpportunityWithNotes[] } = {};
-
-    stages.forEach((stage) => {
-      grouped[stage] = filteredOpportunities.filter((opp) => opp.stage === stage);
-    });
-
-    return grouped;
+    return PIPELINE_STAGE_ORDER.reduce<
+      Partial<Record<PipelineStage, OpportunityWithNotes[]>>
+    >((acc, stage) => {
+      acc[stage] = filteredOpportunities.filter((opp) => opp.stage === stage);
+      return acc;
+    }, {});
   }, [filteredOpportunities]);
 
   const quarterlyTarget = 1_200_000;
@@ -196,7 +199,7 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
           </div>
 
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
-            {["Prospect", "Qualify", "Proposal", "Negotiation", "ClosedWon"].map((stage) => {
+            {PIPELINE_STAGE_ORDER.filter((stage) => stage !== "ClosedLost").map((stage) => {
               const count = opportunitiesByStage[stage]?.length || 0;
               const value =
                 opportunitiesByStage[stage]?.reduce((sum, opp) => sum + opp.amount, 0) || 0;
@@ -205,7 +208,7 @@ export default function PipelineClient({ opportunities, metrics, userId }: Props
                 <Card key={stage} className={cn(TRS_CARD)}>
                   <CardContent className="p-4">
                     <div className="mb-2 text-xs font-medium uppercase text-gray-500">
-                      {stage === "ClosedWon" ? "Closed Won" : stage}
+                      {PIPELINE_STAGE_LABELS[stage]}
                     </div>
                     <div className="mb-1 text-2xl font-semibold text-black">{count}</div>
                     <div className="text-sm text-gray-600">{(value / 1000).toFixed(0)}K</div>

--- a/components/pipeline/DealDetailModal.tsx
+++ b/components/pipeline/DealDetailModal.tsx
@@ -11,6 +11,12 @@ import {
   addOpportunityNote,
   type OpportunityWithNotes
 } from "@/core/pipeline/actions";
+import {
+  PIPELINE_STAGE_LABELS,
+  PIPELINE_STAGE_ORDER,
+  PIPELINE_STAGE_PROBABILITIES,
+  type PipelineStage,
+} from "@/core/pipeline/constants";
 import { cn } from "@/lib/utils";
 import { ActivitySection } from "./ActivitySection";
 
@@ -20,14 +26,11 @@ type DealDetailModalProps = {
   userId: string;
 };
 
-const STAGES = [
-  { key: "Prospect", label: "Prospect", probability: 10 },
-  { key: "Qualify", label: "Qualify", probability: 25 },
-  { key: "Proposal", label: "Proposal", probability: 50 },
-  { key: "Negotiation", label: "Negotiation", probability: 75 },
-  { key: "ClosedWon", label: "Closed Won", probability: 100 },
-  { key: "ClosedLost", label: "Closed Lost", probability: 0 },
-];
+const STAGES = PIPELINE_STAGE_ORDER.map((stage) => ({
+  key: stage,
+  label: PIPELINE_STAGE_LABELS[stage],
+  probability: PIPELINE_STAGE_PROBABILITIES[stage],
+}));
 
 export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -38,7 +41,7 @@ export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps)
   const [formData, setFormData] = useState({
     name: deal.name,
     amount: deal.amount.toString(),
-    stage: deal.stage,
+    stage: deal.stage as PipelineStage,
     probability: deal.probability.toString(),
     close_date: deal.close_date || "",
     next_step: deal.next_step || "",
@@ -182,11 +185,15 @@ export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps)
                   <select
                     value={formData.stage}
                     onChange={(e) => {
-                      const stage = STAGES.find(s => s.key === e.target.value);
+                      const stageKey = e.target.value as PipelineStage;
+                      const probability =
+                        PIPELINE_STAGE_PROBABILITIES[stageKey] ??
+                        Number(formData.probability);
+
                       setFormData({
                         ...formData,
-                        stage: e.target.value,
-                        probability: stage?.probability.toString() || formData.probability
+                        stage: stageKey,
+                        probability: probability.toString(),
                       });
                     }}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md"
@@ -198,11 +205,11 @@ export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps)
                       </option>
                     ))}
                   </select>
-                ) : (
-                  <Badge variant="outline" className="text-sm">
-                    {deal.stage === "ClosedWon" ? "Closed Won" : deal.stage}
-                  </Badge>
-                )}
+                  ) : (
+                    <Badge variant="outline" className="text-sm">
+                      {PIPELINE_STAGE_LABELS[deal.stage]}
+                    </Badge>
+                  )}
               </div>
 
               <div>

--- a/components/pipeline/PipelineFilters.tsx
+++ b/components/pipeline/PipelineFilters.tsx
@@ -5,6 +5,11 @@ import { Input } from "@/ui/input";
 import { Button } from "@/ui/button";
 import { cn } from "@/lib/utils";
 import type { OpportunityWithNotes } from "@/core/pipeline/actions";
+import {
+  PIPELINE_STAGE_LABELS,
+  PIPELINE_STAGE_ORDER,
+  type PipelineStage,
+} from "@/core/pipeline/constants";
 
 type PipelineFiltersProps = {
   opportunities: OpportunityWithNotes[];
@@ -16,7 +21,7 @@ type Filters = {
   owner: string;
   minAmount: string;
   maxAmount: string;
-  stage: string;
+  stage: "" | PipelineStage;
   minProbability: string;
 };
 
@@ -212,16 +217,20 @@ export function PipelineFilters({ opportunities, onFilterChange }: PipelineFilte
             </label>
             <select
               value={filters.stage}
-              onChange={(e) => applyFilters({ ...filters, stage: e.target.value })}
+              onChange={(e) =>
+                applyFilters({
+                  ...filters,
+                  stage: e.target.value as Filters["stage"],
+                })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
             >
               <option value="">All Stages</option>
-              <option value="Prospect">Prospect</option>
-              <option value="Qualify">Qualify</option>
-              <option value="Proposal">Proposal</option>
-              <option value="Negotiation">Negotiation</option>
-              <option value="ClosedWon">Closed Won</option>
-              <option value="ClosedLost">Closed Lost</option>
+              {PIPELINE_STAGE_ORDER.map((stage) => (
+                <option key={stage} value={stage}>
+                  {PIPELINE_STAGE_LABELS[stage]}
+                </option>
+              ))}
             </select>
           </div>
 

--- a/core/pipeline/constants.ts
+++ b/core/pipeline/constants.ts
@@ -1,0 +1,36 @@
+export const PIPELINE_STAGE_ORDER = [
+  "New",
+  "Qualify",
+  "Proposal",
+  "Negotiation",
+  "ClosedWon",
+  "ClosedLost",
+] as const;
+
+export type PipelineStage = (typeof PIPELINE_STAGE_ORDER)[number];
+
+export const PIPELINE_STAGE_LABELS: Record<PipelineStage, string> = {
+  New: "Prospect",
+  Qualify: "Qualify",
+  Proposal: "Proposal",
+  Negotiation: "Negotiation",
+  ClosedWon: "Closed Won",
+  ClosedLost: "Closed Lost",
+};
+
+export const PIPELINE_STAGE_PROBABILITIES: Record<PipelineStage, number> = {
+  New: 10,
+  Qualify: 25,
+  Proposal: 50,
+  Negotiation: 75,
+  ClosedWon: 100,
+  ClosedLost: 0,
+};
+
+export const PIPELINE_STAGE_COLORS: Partial<Record<PipelineStage, string>> = {
+  New: "bg-gray-100",
+  Qualify: "bg-blue-100",
+  Proposal: "bg-purple-100",
+  Negotiation: "bg-yellow-100",
+  ClosedWon: "bg-green-100",
+};


### PR DESCRIPTION
## Summary
- add shared pipeline stage constants and switch UI to reference schema-compliant stage keys
- update prospect creation to insert valid client records and use the "New" opportunity stage
- adjust pipeline conversion flow to keep client phases within allowed values

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9cb78e6c0832493ff4d0d6a8d7054