### PR TITLE
feat: wire projects page to supabase data

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,21 +1,100 @@
-import { listProjects, getProjectStats } from "@/core/projects/store";
+import {
+  actionGetProjectStats,
+  actionListProjectMilestones,
+  actionListProjectUpdates,
+  actionListProjects,
+} from "@/core/projects/actions";
 import ProjectsPageClient from "./ProjectsPageClient";
-import type { RevOSPhase } from "@/core/clients/types";
+import type { ProjectMilestone, ProjectStats } from "@/core/projects/types";
 
-export type ProjectRowData = {
-  name: string;
-  clientId: string;
-  clientName: string;
-  owner: string;
-  status: RevOSPhase;
-  progress: number;
-  dueDate: string;
-  health: "green" | "yellow" | "red";
-};
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
 
-export default function ProjectsPage() {
-  const projects = listProjects();
-  const stats = getProjectStats();
+const percentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 0,
+});
 
-  return <ProjectsPageClient projects={projects} stats={stats} />;
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+});
+
+type ForecastMetric = { label: string; value: string; context?: string };
+type ForecastTimelinePoint = { period: string; count: number; highlight: string };
+type ForecastData = { metrics: ForecastMetric[]; timeline: ForecastTimelinePoint[] };
+
+function buildForecastMetrics(stats: ProjectStats): ForecastMetric[] {
+  const portfolioBudget = stats.totalBudget > 0 ? currencyFormatter.format(stats.totalBudget) : "—";
+  const totalSpend = stats.totalSpent > 0 ? currencyFormatter.format(stats.totalSpent) : "—";
+  const utilization = stats.totalBudget > 0 ? `${stats.budgetUtilization}% utilized` : "No budget captured";
+
+  return [
+    { label: "Portfolio Budget", value: portfolioBudget, context: utilization },
+    {
+      label: "Total Spend",
+      value: totalSpend,
+      context: stats.totalBudget > 0 ? `${percentFormatter.format(stats.totalSpent / stats.totalBudget)} of budget` : "—",
+    },
+    {
+      label: "Average Progress",
+      value: `${stats.avgProgress}%`,
+      context: `${stats.active} active projects`,
+    },
+  ];
+}
+
+function buildForecastTimeline(milestones: ProjectMilestone[]): ForecastTimelinePoint[] {
+  const buckets = new Map<string, { count: number; highlight: string }>();
+
+  milestones
+    .filter((milestone) => milestone.dueDate)
+    .forEach((milestone) => {
+      const due = new Date(milestone.dueDate!);
+      const key = `${due.getUTCFullYear()}-${due.getUTCMonth()}`;
+      const bucket = buckets.get(key) ?? { count: 0, highlight: milestone.title };
+      const highlight = bucket.highlight || milestone.title;
+      buckets.set(key, {
+        count: bucket.count + 1,
+        highlight,
+      });
+    });
+
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .slice(0, 4)
+    .map(([key, value]) => {
+      const [year, month] = key.split("-").map((part) => Number(part));
+      const periodDate = new Date(Date.UTC(year, month, 1));
+      return {
+        period: `${monthFormatter.format(periodDate)} ${year}`,
+        count: value.count,
+        highlight: value.highlight,
+      };
+    });
+}
+
+export default async function ProjectsPage() {
+  const [projects, stats, updates, milestones] = await Promise.all([
+    actionListProjects(),
+    actionGetProjectStats(),
+    actionListProjectUpdates(),
+    actionListProjectMilestones(),
+  ]);
+
+  const forecast: ForecastData = {
+    metrics: buildForecastMetrics(stats),
+    timeline: buildForecastTimeline(milestones),
+  };
+
+  return (
+    <ProjectsPageClient
+      projects={projects}
+      stats={stats}
+      activity={{ updates, milestones }}
+      forecast={forecast}
+    />
+  );
 }

--- a/core/projects/actions.ts
+++ b/core/projects/actions.ts
@@ -1,50 +1,527 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
 import {
-  listProjects,
-  getProject,
-  getProjectsByClient,
-  createProject,
-  updateProject,
-  deleteProject,
-  getProjectStats,
+  listProjects as listProjectsFallback,
+  getProject as getProjectFallback,
+  getProjectsByClient as getProjectsByClientFallback,
+  createProject as createProjectFallback,
+  updateProject as updateProjectFallback,
+  deleteProject as deleteProjectFallback,
+  getProjectStats as getProjectStatsFallback,
+  listProjectUpdates as listProjectUpdatesFallback,
+  listProjectMilestones as listProjectMilestonesFallback,
 } from "./store";
-import type { CreateProjectInput, Project } from "./types";
+import type {
+  CreateProjectInput,
+  Project,
+  ProjectMilestone,
+  ProjectStats,
+  ProjectUpdate,
+  ProjectStatus,
+  ProjectHealth,
+} from "./types";
+import type { RevOSPhase } from "@/core/clients/types";
+
+const hasSupabaseCredentials = () =>
+  Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+
+type ProjectRecord = {
+  id: string;
+  name: string;
+  client_id: string;
+  description: string | null;
+  owner_id: string | null;
+  status: ProjectStatus | null;
+  phase: RevOSPhase | null;
+  health: ProjectHealth | null;
+  progress: number | null;
+  start_date: string | null;
+  due_date: string | null;
+  completed_date: string | null;
+  budget: number | null;
+  spent: number | null;
+  deliverables: string[] | null;
+  notes: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  client: { id: string; name: string | null; phase: RevOSPhase | null } | null;
+  owner: { id: string; name: string | null } | null;
+};
+
+const normalizeProject = (record: ProjectRecord): Project => {
+  const defaultPhase: RevOSPhase = "Discovery";
+  const fallbackDate = new Date().toISOString();
+
+  return {
+    id: record.id,
+    name: record.name,
+    clientId: record.client_id,
+    clientName: record.client?.name ?? "Unknown Client",
+    description: record.description ?? undefined,
+    owner: record.owner?.name ?? "Unassigned",
+    ownerId: record.owner?.id ?? undefined,
+    status: (record.status ?? "Active") as ProjectStatus,
+    phase: (record.phase ?? record.client?.phase ?? defaultPhase) as RevOSPhase,
+    health: (record.health ?? "yellow") as ProjectHealth,
+    progress: record.progress ?? 0,
+    startDate: record.start_date ?? fallbackDate.split("T")[0],
+    dueDate: record.due_date ?? undefined,
+    completedDate: record.completed_date ?? undefined,
+    budget: record.budget !== null ? Number(record.budget) : undefined,
+    spent: record.spent !== null ? Number(record.spent) : undefined,
+    deliverables: record.deliverables ?? undefined,
+    notes: record.notes ?? undefined,
+    createdAt: record.created_at ?? fallbackDate,
+    updatedAt: record.updated_at ?? fallbackDate,
+  };
+};
 
 export async function actionListProjects(): Promise<Project[]> {
-  return listProjects();
+  if (!hasSupabaseCredentials()) {
+    return listProjectsFallback();
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      `
+        id,
+        name,
+        client_id,
+        description,
+        owner_id,
+        status,
+        phase,
+        health,
+        progress,
+        start_date,
+        due_date,
+        completed_date,
+        budget,
+        spent,
+        deliverables,
+        notes,
+        created_at,
+        updated_at,
+        client:clients!projects_client_id_fkey(id, name, phase),
+        owner:users!projects_owner_id_fkey(id, name)
+      `,
+    )
+    .order("updated_at", { ascending: false });
+
+  if (error || !data) {
+    console.error("Error fetching projects from Supabase", error);
+    return listProjectsFallback();
+  }
+
+  return data.map((record) => normalizeProject(record as ProjectRecord));
 }
 
 export async function actionGetProject(id: string): Promise<Project | null> {
-  return getProject(id);
+  if (!hasSupabaseCredentials()) {
+    return getProjectFallback(id);
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      `
+        id,
+        name,
+        client_id,
+        description,
+        owner_id,
+        status,
+        phase,
+        health,
+        progress,
+        start_date,
+        due_date,
+        completed_date,
+        budget,
+        spent,
+        deliverables,
+        notes,
+        created_at,
+        updated_at,
+        client:clients!projects_client_id_fkey(id, name, phase),
+        owner:users!projects_owner_id_fkey(id, name)
+      `,
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !data) {
+    console.error("Error fetching project", error);
+    return getProjectFallback(id);
+  }
+
+  return normalizeProject(data as ProjectRecord);
 }
 
 export async function actionGetProjectsByClient(clientId: string): Promise<Project[]> {
-  return getProjectsByClient(clientId);
+  if (!hasSupabaseCredentials()) {
+    return getProjectsByClientFallback(clientId);
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      `
+        id,
+        name,
+        client_id,
+        description,
+        owner_id,
+        status,
+        phase,
+        health,
+        progress,
+        start_date,
+        due_date,
+        completed_date,
+        budget,
+        spent,
+        deliverables,
+        notes,
+        created_at,
+        updated_at,
+        client:clients!projects_client_id_fkey(id, name, phase),
+        owner:users!projects_owner_id_fkey(id, name)
+      `,
+    )
+    .eq("client_id", clientId)
+    .order("created_at", { ascending: false });
+
+  if (error || !data) {
+    console.error("Error fetching projects by client", error);
+    return getProjectsByClientFallback(clientId);
+  }
+
+  return data.map((record) => normalizeProject(record as ProjectRecord));
 }
 
-export async function actionCreateProject(input: CreateProjectInput): Promise<{ ok: boolean; project?: Project; error?: string }> {
-  try {
-    const project = createProject(input);
-    return { ok: true, project };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : "Failed to create project" };
+export async function actionCreateProject(
+  input: CreateProjectInput,
+): Promise<{ ok: boolean; project?: Project; error?: string }> {
+  if (!hasSupabaseCredentials()) {
+    try {
+      const project = createProjectFallback(input);
+      return { ok: true, project };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to create project" };
+    }
   }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .insert({
+      name: input.name,
+      client_id: input.clientId,
+      description: input.description,
+      owner_id: null,
+      status: "Active",
+      phase: input.phase,
+      health: "green",
+      progress: 0,
+      due_date: input.dueDate,
+      budget: input.budget,
+      deliverables: input.deliverables,
+    })
+    .select(
+      `
+        id,
+        name,
+        client_id,
+        description,
+        owner_id,
+        status,
+        phase,
+        health,
+        progress,
+        start_date,
+        due_date,
+        completed_date,
+        budget,
+        spent,
+        deliverables,
+        notes,
+        created_at,
+        updated_at,
+        client:clients!projects_client_id_fkey(id, name, phase),
+        owner:users!projects_owner_id_fkey(id, name)
+      `,
+    )
+    .single();
+
+  if (error || !data) {
+    console.error("Error creating project", error);
+    return { ok: false, error: error?.message ?? "Failed to create project" };
+  }
+
+  revalidatePath("/projects");
+  revalidatePath(`/clients/${input.clientId}?tab=Projects`);
+
+  return { ok: true, project: normalizeProject(data as ProjectRecord) };
 }
 
 export async function actionUpdateProject(
   id: string,
-  updates: Partial<Omit<Project, "id" | "clientId" | "clientName" | "createdAt">>
-): Promise<{ ok: boolean; project?: Project | null }> {
-  const project = updateProject(id, updates);
-  return { ok: true, project };
+  updates: Partial<Omit<Project, "id" | "clientId" | "clientName" | "createdAt" | "owner">>,
+): Promise<{ ok: boolean; project?: Project | null; error?: string }> {
+  if (!hasSupabaseCredentials()) {
+    const project = updateProjectFallback(id, updates as any);
+    return { ok: true, project };
+  }
+
+  const supabase = await createClient();
+  const mappedUpdates: Record<string, unknown> = {
+    status: updates.status,
+    phase: updates.phase,
+    health: updates.health,
+    progress: updates.progress,
+    due_date: updates.dueDate,
+    completed_date: updates.completedDate,
+    budget: updates.budget,
+    spent: updates.spent,
+    deliverables: updates.deliverables,
+    notes: updates.notes,
+  };
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update({
+      ...mappedUpdates,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .select(
+      `
+        id,
+        name,
+        client_id,
+        description,
+        owner_id,
+        status,
+        phase,
+        health,
+        progress,
+        start_date,
+        due_date,
+        completed_date,
+        budget,
+        spent,
+        deliverables,
+        notes,
+        created_at,
+        updated_at,
+        client:clients!projects_client_id_fkey(id, name, phase),
+        owner:users!projects_owner_id_fkey(id, name)
+      `,
+    )
+    .maybeSingle();
+
+  if (error) {
+    console.error("Error updating project", error);
+    return { ok: false, error: error.message };
+  }
+
+  revalidatePath("/projects");
+  if (data?.client_id) {
+    revalidatePath(`/clients/${data.client_id}?tab=Projects`);
+  }
+
+  return { ok: true, project: data ? normalizeProject(data as ProjectRecord) : null };
 }
 
 export async function actionDeleteProject(id: string): Promise<{ ok: boolean }> {
-  const deleted = deleteProject(id);
-  return { ok: deleted };
+  if (!hasSupabaseCredentials()) {
+    const deleted = deleteProjectFallback(id);
+    return { ok: deleted };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("projects").delete().eq("id", id);
+
+  if (error) {
+    console.error("Error deleting project", error);
+    return { ok: false };
+  }
+
+  revalidatePath("/projects");
+  return { ok: true };
 }
 
-export async function actionGetProjectStats() {
-  return getProjectStats();
+export async function actionGetProjectStats(): Promise<ProjectStats> {
+  if (!hasSupabaseCredentials()) {
+    return getProjectStatsFallback();
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .select("status, health, progress, budget, spent");
+
+  if (error || !data) {
+    console.error("Error fetching project stats", error);
+    return getProjectStatsFallback();
+  }
+
+  const active = data.filter((project) => project.status === "Active").length;
+  const onTrack = data.filter((project) => project.health === "green").length;
+  const atRisk = data.filter((project) => project.health === "red").length;
+  const avgProgress =
+    data.length > 0
+      ? Math.round(data.reduce((sum, project) => sum + (project.progress ?? 0), 0) / data.length)
+      : 0;
+  const totalBudget = data.reduce((sum, project) => sum + Number(project.budget ?? 0), 0);
+  const totalSpent = data.reduce((sum, project) => sum + Number(project.spent ?? 0), 0);
+  const budgetUtilization = totalBudget > 0 ? Math.round((totalSpent / totalBudget) * 100) : 0;
+
+  const milestones = await actionListProjectMilestones();
+  const now = new Date();
+  const futureMilestones = milestones.filter((milestone) => {
+    if (!milestone.dueDate) return false;
+    const due = new Date(milestone.dueDate);
+    return due >= now;
+  }).length;
+
+  return {
+    active,
+    onTrack,
+    atRisk,
+    avgProgress,
+    totalBudget,
+    totalSpent,
+    budgetUtilization,
+    upcomingMilestones: futureMilestones,
+  };
+}
+
+export async function actionListProjectUpdates(): Promise<ProjectUpdate[]> {
+  if (!hasSupabaseCredentials()) {
+    return listProjectUpdatesFallback();
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("project_updates")
+    .select(
+      `
+        id,
+        project_id,
+        status,
+        summary,
+        risk_level,
+        created_at,
+        project:projects!project_updates_project_id_fkey(id, name),
+        author:users!project_updates_author_id_fkey(id, name)
+      `,
+    )
+    .order("created_at", { ascending: false })
+    .limit(25);
+
+  if (error || !data) {
+    console.error("Error fetching project updates", error);
+    return listProjectUpdatesFallback();
+  }
+
+  return data.map((update) => ({
+    id: update.id,
+    projectId: update.project_id,
+    projectName: update.project?.name ?? "Unknown Project",
+    authorId: update.author?.id ?? "",
+    authorName: update.author?.name ?? "Unknown",
+    status: update.status,
+    summary: update.summary,
+    riskLevel: update.risk_level,
+    createdAt: update.created_at,
+  }));
+}
+
+export async function actionListProjectMilestones(): Promise<ProjectMilestone[]> {
+  if (!hasSupabaseCredentials()) {
+    return listProjectMilestonesFallback();
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("project_milestones")
+    .select(
+      `
+        id,
+        project_id,
+        owner_id,
+        title,
+        status,
+        confidence,
+        due_date,
+        description,
+        created_at,
+        updated_at,
+        project:projects!project_milestones_project_id_fkey(id, name),
+        owner:users!project_milestones_owner_id_fkey(id, name)
+      `,
+    )
+    .order("due_date", { ascending: true, nullsLast: true })
+    .limit(25);
+
+  if (error || !data) {
+    console.error("Error fetching project milestones", error);
+    return listProjectMilestonesFallback();
+  }
+
+  return data.map((milestone) => ({
+    id: milestone.id,
+    projectId: milestone.project_id,
+    projectName: milestone.project?.name ?? "Unknown Project",
+    ownerId: milestone.owner?.id,
+    ownerName: milestone.owner?.name ?? undefined,
+    title: milestone.title,
+    status: milestone.status as ProjectMilestone["status"],
+    confidence: milestone.confidence,
+    dueDate: milestone.due_date,
+    description: milestone.description,
+    createdAt: milestone.created_at,
+    updatedAt: milestone.updated_at,
+  }));
+}
+
+export async function actionSubmitProjectAgentPrompt({
+  prompt,
+  projectId,
+  userId,
+}: {
+  prompt: string;
+  projectId?: string;
+  userId?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  if (!hasSupabaseCredentials()) {
+    return { ok: true };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("analytics_events").insert({
+    event_type: "project_agent_prompt",
+    entity_type: projectId ? "project" : null,
+    entity_id: projectId ?? null,
+    metadata: {
+      prompt,
+    },
+    user_id: userId ?? null,
+  });
+
+  if (error) {
+    console.error("Error logging project agent prompt", error);
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true };
 }

--- a/core/projects/types.ts
+++ b/core/projects/types.ts
@@ -11,6 +11,7 @@ export type Project = {
   clientName: string;
   description?: string;
   owner: string;
+  ownerId?: string;
   status: ProjectStatus;
   phase: RevOSPhase;
   health: ProjectHealth;
@@ -35,4 +36,42 @@ export type CreateProjectInput = {
   dueDate?: string;
   budget?: number;
   deliverables?: string[];
+};
+
+export type ProjectUpdate = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  authorId: string;
+  authorName: string;
+  status?: string | null;
+  summary?: string | null;
+  riskLevel?: string | null;
+  createdAt: string;
+};
+
+export type ProjectMilestone = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  ownerId?: string | null;
+  ownerName?: string | null;
+  title: string;
+  status: "Planned" | "In Progress" | "Complete" | "Blocked";
+  confidence?: number | null;
+  dueDate?: string | null;
+  description?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ProjectStats = {
+  active: number;
+  onTrack: number;
+  atRisk: number;
+  avgProgress: number;
+  totalBudget: number;
+  totalSpent: number;
+  budgetUtilization: number;
+  upcomingMilestones: number;
 };

--- a/docs/projects/projects-page-plan.md
+++ b/docs/projects/projects-page-plan.md
@@ -1,0 +1,27 @@
+# Projects Page Functionalization Plan
+
+## Objectives
+- Replace placeholder data on the Projects control center with live Supabase-backed content.
+- Surface actionable delivery insights across Overview, Active, Forecast, and Agent tabs.
+- Maintain a graceful fallback for local environments without Supabase credentials.
+
+## Workstreams
+1. **Data plumbing**
+   - [x] Introduce a `project_milestones` table with RLS aligned to `project_updates`.
+   - [x] Expand server-side project actions to pull from Supabase (projects, updates, milestones) with in-memory fallback.
+   - [x] Shape aggregate helpers for stats, activity, and forecast insights to keep UI components lean.
+
+2. **Projects page integration**
+   - [x] Update the `/projects` route to fetch real data via the new actions.
+   - [x] Render a live overview table with client navigation, health, and progress sourced from Supabase.
+   - [x] Replace placeholder Active and Forecast tab content with updates, milestones, and derived budget/progress metrics.
+   - [x] Introduce a functional agent request form wired to analytics logging for future automation.
+
+3. **Quality and resilience**
+   - [ ] Seed example projects, updates, and milestones for local/dev use.
+   - [ ] Add unit coverage around the projection helpers.
+   - [ ] Document Supabase dependencies and fallback behavior.
+
+## Delivery Notes
+- The initial milestone will focus on workstreams 1 & 2 bullet points up to a usable agent submission stub. Quality workstream items will be scheduled in a follow-up once live data proves stable.
+- Supabase joins will return owner and client metadata to satisfy existing `Project` typings without forcing a breaking UI refactor.

--- a/supabase/migrations/20251012000100_create_project_milestones.sql
+++ b/supabase/migrations/20251012000100_create_project_milestones.sql
@@ -1,0 +1,52 @@
+-- Migration: create project_milestones table and policies
+
+CREATE TABLE IF NOT EXISTS public.project_milestones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  owner_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('Planned', 'In Progress', 'Complete', 'Blocked')),
+  confidence INTEGER CHECK (confidence >= 0 AND confidence <= 100),
+  due_date DATE,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_milestones_project_id
+  ON public.project_milestones(project_id, due_date);
+
+ALTER TABLE public.project_milestones ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  CREATE POLICY "project_milestones_select"
+  ON public.project_milestones
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects
+    )
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE POLICY "project_milestones_mutate"
+  ON public.project_milestones
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -547,6 +547,48 @@ CREATE POLICY IF NOT EXISTS "project_updates_mutate"
     )
   );
 
+-- project_milestones
+CREATE TABLE IF NOT EXISTS public.project_milestones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  owner_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('Planned', 'In Progress', 'Complete', 'Blocked')),
+  confidence INTEGER CHECK (confidence >= 0 AND confidence <= 100),
+  due_date DATE,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_milestones_project_id
+  ON public.project_milestones(project_id, due_date);
+
+ALTER TABLE public.project_milestones ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "project_milestones_select"
+  ON public.project_milestones
+  FOR SELECT
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "project_milestones_mutate"
+  ON public.project_milestones
+  FOR ALL
+  USING (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  )
+  WITH CHECK (
+    project_id IN (
+      SELECT id FROM public.projects WHERE owner_id = auth.uid() OR public.is_admin()
+    )
+  );
+
 -- ================================================================
 -- content_metrics
 -- ================================================================


### PR DESCRIPTION
## Summary
- add a tracked Projects page plan and capture the initial milestone scope
- create the project_milestones table plus RLS policies and expose Supabase-backed project actions with in-memory fallbacks
- rework the projects route UI to render live stats, activity, forecasts, and an agent submission form using the new data helpers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9d73404408324a576df73dd51344b