### PR TITLE
Update morning brief header to match marketing layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,9 @@ import SummaryFeed from "@/components/morning/SummaryFeed";
 import CoPilotDrawer from "@/components/morning/CoPilotDrawer";
 import NewsTicker from "@/components/morning/NewsTicker";
 import NewsFeed from "@/components/morning/NewsFeed";
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import { PageHeader, PageTitle, PageDescription } from "@/ui/page-header";
 import {
   computePlan,
   lockPlan,
@@ -192,55 +195,69 @@ export default function MorningPage() {
   const briefTabs: BriefTab[] = ["Inbox", "Calendar"];
 
   return (
-    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
-      <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
-
-      <section className={cn(TRS_CARD, "p-3")}>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="text-lg font-semibold text-black">Good morning</div>
-            <div className="text-[12px] text-gray-500">
-              {greeting} • Momentum: {s.momentum} • {s.note}
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-6">
+      <section className="space-y-4">
+        <PageHeader className="gap-4 rounded-xl border border-[color:var(--color-outline)]">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <PageTitle>Morning Brief</PageTitle>
+              <PageDescription>
+                Good morning — {greeting}. Daily revenue operating briefing curated by the
+                Morning Agent. {s.note}.
+              </PageDescription>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={pending}
+                onClick={() =>
+                  start(async () => {
+                    await computePlan();
+                    await refresh();
+                  })
+                }
+              >
+                Compute Plan
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={pending || s.planLocked}
+                onClick={() =>
+                  start(async () => {
+                    await lockPlan();
+                    await refresh();
+                  })
+                }
+              >
+                {s.planLocked ? "Locked" : "Lock Plan"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={pending}
+                onClick={() =>
+                  start(async () => {
+                    await downloadIcal();
+                  })
+                }
+              >
+                Download iCal
+              </Button>
+              <CoPilotDrawer />
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() =>
-                start(async () => {
-                  await computePlan();
-                  await refresh();
-                })
-              }
-              disabled={pending}
-              className="rounded-md border px-2 py-1 text-xs"
-            >
-              Compute Plan
-            </button>
-            <button
-              onClick={() =>
-                start(async () => {
-                  await lockPlan();
-                  await refresh();
-                })
-              }
-              disabled={pending}
-              className="rounded-md border px-2 py-1 text-xs"
-            >
-              {s.planLocked ? "Locked" : "Lock Plan"}
-            </button>
-            <button
-              onClick={() =>
-                start(async () => {
-                  await downloadIcal();
-                })
-              }
-              className="rounded-md border px-2 py-1 text-xs"
-            >
-              Download iCal
-            </button>
-            <CoPilotDrawer />
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <Badge variant="success">Momentum: {s.momentum}</Badge>
+            <Badge variant={s.planLocked ? "success" : "warning"}>
+              {s.planLocked ? "Plan locked" : "Plan draft"}
+            </Badge>
+            <Badge variant="outline">Focus sessions today: {s.kpis.focusSessionsToday}</Badge>
           </div>
-        </div>
+        </PageHeader>
+
+        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
       </section>
 
       {activeTab === "Today" && (

--- a/components/morning/CoPilotDrawer.tsx
+++ b/components/morning/CoPilotDrawer.tsx
@@ -2,24 +2,51 @@
 
 import { useState } from "react";
 
-export default function CoPilotDrawer(){
+import { Button } from "@/ui/button";
+
+export default function CoPilotDrawer() {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <button onClick={()=>setOpen(true)} className="text-xs px-2 py-1 rounded-md border">Ask Morning Agent</button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="font-medium"
+      >
+        Ask Morning Agent
+      </Button>
       {open && (
-        <div className="fixed inset-0 z-50 bg-black/30" onClick={()=>setOpen(false)}>
-          <div className="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-xl p-4" onClick={e=>e.stopPropagation()}>
+        <div
+          className="fixed inset-0 z-50 bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="absolute right-0 top-0 h-full w-full max-w-md bg-white p-4 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between">
               <div className="text-sm font-semibold">Morning Agent</div>
-              <button className="text-xs" onClick={()=>setOpen(false)}>Close</button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </Button>
             </div>
             <div className="mt-3 text-sm text-gray-600">
-              Ask things like: &ldquo;What moved ARR yesterday?&rdquo;, &ldquo;What&apos;s the fastest way to lift win rate 10% this week?&rdquo;
+              Ask things like: &ldquo;What moved ARR yesterday?&rdquo;, &ldquo;What&apos;s the fastest
+              way to lift win rate 10% this week?&rdquo;
             </div>
-            <textarea className="mt-3 w-full h-24 border rounded-md p-2 text-sm" placeholder="Type your question…" />
-            <div className="mt-2">
-              <button className="text-xs px-2 py-1 rounded-md border">Send</button>
+            <textarea
+              className="mt-3 h-24 w-full rounded-md border p-2 text-sm"
+              placeholder="Type your question…"
+            />
+            <div className="mt-3 flex justify-end">
+              <Button size="sm">
+                Send
+              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the Morning Brief landing view to use the shared PageHeader pattern and status badges like our marketing surfaces
- swap the action row to shared button components and surface plan, momentum, and focus badges for visual consistency
- refresh the Morning Agent drawer trigger to use the shared button styles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9f2b5b0b083249da0e57bf5de8587