### PR TITLE
fix: route login to morning brief

### DIFF
--- a/components/ui/login-1.tsx
+++ b/components/ui/login-1.tsx
@@ -46,7 +46,7 @@ export default function LoginScreen() {
         }
 
         setAuthMessage("Signed in successfully.")
-        router.replace("/dashboard")
+        router.replace("/")
       } else {
         const { error } = await supabase.auth.signUp({
           email: formData.email,
@@ -79,7 +79,7 @@ export default function LoginScreen() {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/auth/callback?next=/dashboard`,
+          redirectTo: `${window.location.origin}/auth/callback?next=/`,
         },
       })
 


### PR DESCRIPTION
## Summary
- redirect password sign-ins to the morning brief home page
- update Google OAuth callback to send users back to the morning brief

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9f423b94083248de938e37e16ebef