### PR TITLE
Fix mobile navigation drawer and global search overlay

### DIFF
--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import * as Icons from 'lucide-react'
 import Header from '@/components/nav/Header'
 import HamburgerDrawer from '@/components/nav/HamburgerDrawer'
 import MobileBottomNav from '@/components/nav/MobileBottomNav'
+import SearchOverlay from '@/components/nav/SearchOverlay'
 import { MAIN_NAV, type NavItem } from '@/lib/navigation'
 import { cn, isActivePath } from '@/lib/utils'
 
@@ -27,11 +28,20 @@ type AppShellProps = {
 export default function AppShell({ children }: AppShellProps) {
   const pathname = usePathname()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   useEffect(() => {
     // Close the drawer after a successful navigation to keep UX tight on mobile.
     setDrawerOpen(false)
+    setSearchOpen(false)
   }, [pathname])
+
+  useEffect(() => {
+    if (!searchOpen) {
+      setSearchQuery('')
+    }
+  }, [searchOpen])
 
   const shouldBypassShell = useMemo(() => {
     if (!pathname) return false
@@ -47,8 +57,22 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="flex min-h-screen flex-col bg-white text-black">
-      <Header onMenuToggle={() => setDrawerOpen(true)} />
+      <Header
+        onMenuToggle={() => setDrawerOpen(true)}
+        onSearch={(term) => {
+          setSearchOpen(true)
+          setSearchQuery(term)
+        }}
+        onSearchOpen={() => setSearchOpen(true)}
+        searchValue={searchQuery}
+      />
       <HamburgerDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <SearchOverlay
+        open={searchOpen}
+        query={searchQuery}
+        onQueryChange={setSearchQuery}
+        onClose={() => setSearchOpen(false)}
+      />
       <div className="flex flex-1">
         <aside className="sticky top-0 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 border-r border-gray-200 bg-white lg:block">
           <nav className="flex h-full flex-col gap-4 overflow-y-auto px-5 py-6 text-sm">

--- a/components/nav/HamburgerDrawer.tsx
+++ b/components/nav/HamburgerDrawer.tsx
@@ -28,6 +28,17 @@ export default function HamburgerDrawer({ open, onClose }: HamburgerDrawerProps)
     }
   }, [open])
 
+  useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
   if (!open) {
     return null
   }
@@ -54,7 +65,12 @@ export default function HamburgerDrawer({ open, onClose }: HamburgerDrawerProps)
         <nav className="flex-1 overflow-y-auto px-4 py-6">
           <DrawerSection title="Main">
             {MAIN_NAV.map((item) => (
-              <DrawerLink key={item.href} item={item} currentPath={pathname ?? ''} />
+              <DrawerLink
+                key={item.href}
+                item={item}
+                currentPath={pathname ?? ''}
+                onNavigate={onClose}
+              />
             ))}
           </DrawerSection>
         </nav>
@@ -80,9 +96,10 @@ function DrawerSection({ title, children }: DrawerSectionProps) {
 type DrawerLinkProps = {
   item: NavItem
   currentPath: string
+  onNavigate: () => void
 }
 
-function DrawerLink({ item, currentPath }: DrawerLinkProps) {
+function DrawerLink({ item, currentPath, onNavigate }: DrawerLinkProps) {
   const active = isActivePath(currentPath, item.href)
   const Icon = (Icons[item.icon as keyof typeof Icons] ?? Icons.Circle) as Icons.LucideIcon
 
@@ -94,6 +111,12 @@ function DrawerLink({ item, currentPath }: DrawerLinkProps) {
           'flex items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-sm font-medium transition-colors',
           active ? 'border-gray-900 bg-gray-900 text-white' : 'text-gray-700 hover:border-gray-300 hover:bg-gray-50'
         )}
+        onClick={(event) => {
+          if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return
+          }
+          onNavigate()
+        }}
       >
         <Icon className="h-4 w-4" aria-hidden="true" />
         <span>{item.label}</span>

--- a/components/nav/Header.tsx
+++ b/components/nav/Header.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils'
 export type HeaderProps = {
   onMenuToggle?: () => void
   onSearch?: (term: string) => void
+  onSearchOpen?: () => void
+  searchValue?: string
 }
 
 /**
@@ -16,7 +18,7 @@ export type HeaderProps = {
  * On small screens the hamburger button is shown so users can reveal the drawer.
  * Search collapses to an icon on narrow widths and expands to a full input on `sm`.
  */
-export default function Header({ onMenuToggle, onSearch }: HeaderProps) {
+export default function Header({ onMenuToggle, onSearch, onSearchOpen, searchValue }: HeaderProps) {
   const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (onSearch) {
@@ -48,6 +50,8 @@ export default function Header({ onMenuToggle, onSearch }: HeaderProps) {
               placeholder="Search clients, projects, or docs"
               className="h-6 w-full bg-transparent text-sm text-black placeholder:text-gray-400 focus:outline-none"
               onChange={handleInput}
+              onFocus={onSearchOpen}
+              value={searchValue ?? ''}
             />
           </div>
         </div>
@@ -57,6 +61,7 @@ export default function Header({ onMenuToggle, onSearch }: HeaderProps) {
             type="button"
             className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-black sm:hidden"
             aria-label="Search"
+            onClick={onSearchOpen}
           >
             <Search className="h-5 w-5" aria-hidden="true" />
           </button>

--- a/components/nav/SearchOverlay.tsx
+++ b/components/nav/SearchOverlay.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from 'react'
+import Link from 'next/link'
+import * as Icons from 'lucide-react'
+
+import { MAIN_NAV } from '@/lib/navigation'
+
+export type SearchOverlayProps = {
+  open: boolean
+  query: string
+  onQueryChange: (value: string) => void
+  onClose: () => void
+}
+
+export default function SearchOverlay({ open, query, onQueryChange, onClose }: SearchOverlayProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!open) {
+      document.body.style.overflow = ''
+      return
+    }
+    document.body.style.overflow = 'hidden'
+    const timer = window.setTimeout(() => inputRef.current?.focus(), 80)
+    return () => {
+      document.body.style.overflow = ''
+      window.clearTimeout(timer)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  const results = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) {
+      return MAIN_NAV
+    }
+    return MAIN_NAV.filter((item) => item.label.toLowerCase().includes(trimmed))
+  }, [query])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 pb-10 pt-24 sm:pt-28"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="w-full max-w-xl rounded-2xl border border-gray-200 bg-white shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3">
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search clients, projects, or destinations"
+            className="h-10 flex-1 bg-transparent text-sm text-black placeholder:text-gray-400 focus:outline-none"
+            aria-label="Search across TRS RevenueOS"
+          />
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-black"
+          >
+            Esc
+          </button>
+        </div>
+        <div className="max-h-80 overflow-y-auto px-2 py-3">
+          {results.length === 0 ? (
+            <p className="px-3 py-8 text-center text-sm text-gray-500">
+              No matches yet. Try searching for pipeline, partners, or a workspace.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {results.map((item) => {
+                const Icon = (Icons[item.icon as keyof typeof Icons] ?? Icons.Search) as Icons.LucideIcon
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className="flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+                      onClick={(event) => {
+                        if (
+                          event.defaultPrevented ||
+                          event.button !== 0 ||
+                          event.metaKey ||
+                          event.ctrlKey ||
+                          event.shiftKey ||
+                          event.altKey
+                        ) {
+                          return
+                        }
+                        onClose()
+                      }}
+                    >
+                      <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 text-gray-600">
+                        <Icon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                      <div className="flex flex-1 flex-col items-start">
+                        <span>{item.label}</span>
+                        <span className="text-xs text-gray-500">{item.href}</span>
+                      </div>
+                      <span className="text-[10px] uppercase tracking-wide text-gray-400">Go</span>
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -88,11 +88,11 @@ export const MAIN_NAV: NavItem[] = [
 ]
 
 export const BOTTOM_NAV_ITEMS: NavItem[] = [
-  { label: 'Home', href: '/', icon: 'Home' },
   { label: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard' },
   { label: 'Pipeline', href: '/pipeline', icon: 'TrendingUp' },
   { label: 'Clients', href: '/clients', icon: 'Users' },
-  { label: 'Settings', href: '/settings', icon: 'Settings' },
+  { label: 'Projects', href: '/projects', icon: 'Kanban' },
+  { label: 'Partners', href: '/partners', icon: 'Building2' },
 ]
 
 export const APP_TITLE = 'TRS Internal SaaS'


### PR DESCRIPTION
## Summary
- close the hamburger drawer reliably from menu links and escape and keep background scroll locked
- wire the header search controls into a new global search overlay with navigation shortcuts
- update the mobile bottom bar to show dashboard, pipeline, clients, projects, and partners icons

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e9f782edcc8324959f1c0c9b347c9d