### PR TITLE
Fix missing useTransition import and tighten sync action types

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { PageTabs } from "@/components/layout/PageTabs";


### PR DESCRIPTION
## Summary
- import React's useTransition hook on the clients page to resolve build failure
- give sync actions explicit result types so downstream UI can safely read processed counts
- surface processed and invoice counts as optional numbers when sync succeeds

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ea05708e6483248f2ca18cb1af1f8f