### PR TITLE
feat: implement supabase edge functions for realtime orchestration

### DIFF
--- a/supabase/functions/analytics-sync/index.ts
+++ b/supabase/functions/analytics-sync/index.ts
@@ -1,0 +1,215 @@
+import { createClient, type SupabaseClient, type User } from "https://esm.sh/@supabase/supabase-js@2.48.0?dts";
+
+type AnalyticsSyncRequest = {
+  organization_id?: string;
+  since_days?: number;
+  limit?: number;
+};
+
+type AnalyticsEventRecord = {
+  id: string;
+  organization_id: string | null;
+  event_type: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string | null;
+};
+
+type AuthenticatedContext = {
+  supabase: SupabaseClient;
+  user: User;
+};
+
+const ALLOWED_ORIGINS = new Set([
+  "https://trsrevos.vercel.app",
+  "http://localhost:3000",
+]);
+
+function getRequiredEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function createCorsHeaders(origin: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://trsrevos.vercel.app";
+  return new Headers({
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, x-client-info",
+    "Access-Control-Max-Age": "86400",
+    "Content-Type": "application/json",
+  });
+}
+
+function jsonResponse<T>(body: T, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+async function authenticateRequest(req: Request, corsHeaders: Headers): Promise<AuthenticatedContext | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return jsonResponse({ ok: false, error: "missing-token" }, { status: 401, headers: corsHeaders });
+  }
+
+  const supabaseUrl = getRequiredEnv("SUPABASE_URL");
+  const serviceKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const accessToken = authHeader.slice("bearer ".length).trim();
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  if (error || !data?.user) {
+    console.error("analytics-sync:auth-error", error);
+    return jsonResponse({ ok: false, error: "unauthorized" }, { status: 401, headers: corsHeaders });
+  }
+
+  return { supabase, user: data.user };
+}
+
+function clampDays(value: number | undefined) {
+  if (!value || Number.isNaN(value)) return 7;
+  return Math.min(Math.max(Math.floor(value), 1), 30);
+}
+
+function safeMetadata(input: Record<string, unknown> | null) {
+  return input ?? {};
+}
+
+function detectSeverity(metadata: Record<string, unknown>) {
+  const severity = typeof metadata.severity === "string" ? metadata.severity.toLowerCase() : "";
+  if (severity === "high" || severity === "critical") return severity;
+  return null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get("origin");
+  const corsHeaders = createCorsHeaders(origin);
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "method-not-allowed" }, { status: 405, headers: corsHeaders });
+  }
+
+  let payload: AnalyticsSyncRequest;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error("analytics-sync:invalid-json", error);
+    return jsonResponse({ ok: false, error: "invalid-json" }, { status: 400, headers: corsHeaders });
+  }
+
+  const authContext = await authenticateRequest(req, corsHeaders);
+  if (authContext instanceof Response) {
+    return authContext;
+  }
+
+  const { supabase } = authContext;
+  const sinceDays = clampDays(payload?.since_days);
+  const limit = payload?.limit && payload.limit > 0 ? Math.min(payload.limit, 5000) : 2000;
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - sinceDays);
+  const sinceIso = since.toISOString();
+
+  console.log(JSON.stringify({ event: "analytics-sync:start", payload: { ...payload, since_days: sinceDays, limit } }));
+
+  let query = supabase
+    .from("analytics_events")
+    .select("id, organization_id, event_type, entity_type, entity_id, metadata, created_at")
+    .gte("created_at", sinceIso)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (payload?.organization_id) {
+    query = query.eq("organization_id", payload.organization_id);
+  }
+
+  const { data: events, error } = await query;
+
+  if (error) {
+    console.error("analytics-sync:query-error", error);
+    return jsonResponse({ ok: false, error: "failed-to-load-events" }, { status: 500, headers: corsHeaders });
+  }
+
+  const records = (events ?? []) as AnalyticsEventRecord[];
+
+  const entityMap = new Map<string, { entity_type: string; entity_id: string; count: number; last_event_at: string | null }>();
+  const trendMap = new Map<string, Map<string, number>>();
+  const anomalies: Array<{ event_type: string; entity_type: string | null; entity_id: string | null; created_at: string | null; reason: string }> = [];
+
+  for (const record of records) {
+    const eventType = record.event_type ?? "unknown";
+    const entityType = record.entity_type ?? "unknown";
+    const entityId = record.entity_id ?? "unknown";
+    const key = `${entityType}:${entityId}`;
+    const metadata = safeMetadata(record.metadata);
+
+    const existing = entityMap.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.last_event_at = existing.last_event_at && record.created_at && existing.last_event_at > record.created_at
+        ? existing.last_event_at
+        : record.created_at;
+    } else {
+      entityMap.set(key, {
+        entity_type: entityType,
+        entity_id: entityId,
+        count: 1,
+        last_event_at: record.created_at,
+      });
+    }
+
+    const dayKey = (record.created_at ?? "").slice(0, 10);
+    if (dayKey) {
+      if (!trendMap.has(eventType)) {
+        trendMap.set(eventType, new Map<string, number>());
+      }
+      const eventTrend = trendMap.get(eventType)!;
+      eventTrend.set(dayKey, (eventTrend.get(dayKey) ?? 0) + 1);
+    }
+
+    const severity = detectSeverity(metadata);
+    const lowerType = eventType.toLowerCase();
+    if (severity || lowerType.includes("error") || lowerType.includes("alert")) {
+      anomalies.push({
+        event_type: eventType,
+        entity_type: record.entity_type,
+        entity_id: record.entity_id,
+        created_at: record.created_at,
+        reason: severity ? `metadata:${severity}` : `event_type:${eventType}`,
+      });
+    }
+  }
+
+  const topEntities = Array.from(entityMap.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  const trends = Array.from(trendMap.entries()).map(([eventType, dateMap]) => ({
+    event_type: eventType,
+    points: Array.from(dateMap.entries())
+      .map(([date, count]) => ({ date, count }))
+      .sort((a, b) => (a.date < b.date ? -1 : 1)),
+  }));
+
+  const response = {
+    ok: true,
+    since: sinceIso,
+    total_events: records.length,
+    top_entities: topEntities,
+    trends,
+    anomalies: anomalies.slice(0, 10),
+  };
+
+  console.log(JSON.stringify({ event: "analytics-sync:complete", totals: { events: records.length, top_entities: topEntities.length } }));
+
+  return jsonResponse(response, { status: 200, headers: corsHeaders });
+});

--- a/supabase/functions/dashboard-refresh/index.ts
+++ b/supabase/functions/dashboard-refresh/index.ts
@@ -1,0 +1,246 @@
+import { createClient, type SupabaseClient, type User } from "https://esm.sh/@supabase/supabase-js@2.48.0?dts";
+
+type DashboardRefreshRequest = {
+  organization_id: string;
+  time_scope?: string;
+  segment_filter?: Record<string, unknown>;
+};
+
+type DashboardMetrics = {
+  total_mrr: number;
+  deal_velocity_days: number;
+  average_project_progress: number;
+};
+
+type AuthenticatedContext = {
+  supabase: SupabaseClient;
+  user: User;
+};
+
+type ClientRecord = {
+  arr: number | null;
+  owner_id: string | null;
+};
+
+type OpportunityRecord = {
+  created_at: string | null;
+  close_date: string | null;
+  stage: string | null;
+  owner_id: string | null;
+};
+
+type ProjectRecord = {
+  progress: number | null;
+  status: string | null;
+  owner_id: string | null;
+};
+
+const ALLOWED_ORIGINS = new Set([
+  "https://trsrevos.vercel.app",
+  "http://localhost:3000",
+]);
+
+function getRequiredEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function createCorsHeaders(origin: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://trsrevos.vercel.app";
+  return new Headers({
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, x-client-info",
+    "Access-Control-Max-Age": "86400",
+    "Content-Type": "application/json",
+  });
+}
+
+function jsonResponse<T>(body: T, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+async function authenticateRequest(req: Request, corsHeaders: Headers): Promise<AuthenticatedContext | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return jsonResponse({ ok: false, error: "missing-token" }, { status: 401, headers: corsHeaders });
+  }
+
+  const supabaseUrl = getRequiredEnv("SUPABASE_URL");
+  const serviceKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const accessToken = authHeader.slice("bearer ".length).trim();
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  if (error || !data?.user) {
+    console.error("dashboard-refresh:auth-error", error);
+    return jsonResponse({ ok: false, error: "unauthorized" }, { status: 401, headers: corsHeaders });
+  }
+
+  return { supabase, user: data.user };
+}
+
+function average(values: number[]) {
+  if (values.length === 0) return 0;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
+
+function daysBetween(start: string | null, end: string | null) {
+  if (!start || !end) return null;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null;
+  const diffMs = endMs - startMs;
+  return diffMs > 0 ? diffMs / (1000 * 60 * 60 * 24) : null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get("origin");
+  const corsHeaders = createCorsHeaders(origin);
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "method-not-allowed" }, { status: 405, headers: corsHeaders });
+  }
+
+  let payload: DashboardRefreshRequest;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error("dashboard-refresh:invalid-json", error);
+    return jsonResponse({ ok: false, error: "invalid-json" }, { status: 400, headers: corsHeaders });
+  }
+
+  if (!payload || typeof payload.organization_id !== "string") {
+    return jsonResponse({ ok: false, error: "missing-organization" }, { status: 400, headers: corsHeaders });
+  }
+
+  const authContext = await authenticateRequest(req, corsHeaders);
+  if (authContext instanceof Response) {
+    return authContext;
+  }
+
+  const { supabase } = authContext;
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setUTCDate(ninetyDaysAgo.getUTCDate() - 90);
+  const ninetyDaysAgoIso = ninetyDaysAgo.toISOString();
+
+  console.log(JSON.stringify({ event: "dashboard-refresh:start", payload }));
+
+  const { data: orgUsers, error: orgUsersError } = await supabase
+    .from("users")
+    .select("id")
+    .eq("organization_id", payload.organization_id);
+
+  if (orgUsersError) {
+    console.error("dashboard-refresh:users-error", orgUsersError);
+    return jsonResponse({ ok: false, error: "failed-to-load-users" }, { status: 500, headers: corsHeaders });
+  }
+
+  const userIds = (orgUsers ?? []).map((user) => user.id);
+
+  const clientsPromise = userIds.length
+    ? supabase
+        .from("clients")
+        .select("arr, owner_id")
+        .in("owner_id", userIds)
+    : supabase
+        .from("clients")
+        .select("arr, owner_id")
+        .eq("owner_id", "00000000-0000-0000-0000-000000000000")
+        .limit(0);
+
+  const opportunitiesPromise = userIds.length
+    ? supabase
+        .from("opportunities")
+        .select("created_at, close_date, stage, owner_id")
+        .in("owner_id", userIds)
+        .gte("close_date", ninetyDaysAgoIso.slice(0, 10))
+        .in("stage", ["ClosedWon"])
+    : supabase
+        .from("opportunities")
+        .select("created_at, close_date, stage, owner_id")
+        .eq("owner_id", "00000000-0000-0000-0000-000000000000")
+        .limit(0);
+
+  const projectsPromise = userIds.length
+    ? supabase
+        .from("projects")
+        .select("progress, status, owner_id")
+        .in("owner_id", userIds)
+        .eq("status", "Active")
+    : supabase
+        .from("projects")
+        .select("progress, status, owner_id")
+        .eq("owner_id", "00000000-0000-0000-0000-000000000000")
+        .limit(0);
+
+  const [{ data: clients, error: clientsError }, { data: opportunities, error: opportunitiesError }, { data: projects, error: projectsError }] =
+    await Promise.all([clientsPromise, opportunitiesPromise, projectsPromise]);
+
+  if (clientsError || opportunitiesError || projectsError) {
+    console.error("dashboard-refresh:data-error", { clientsError, opportunitiesError, projectsError });
+    return jsonResponse({ ok: false, error: "failed-to-load-metrics" }, { status: 500, headers: corsHeaders });
+  }
+
+  const clientData = (clients ?? []) as ClientRecord[];
+  const totalArr = clientData.reduce((sum, client) => sum + (typeof client.arr === "number" ? client.arr : 0), 0);
+  const totalMrr = Number((totalArr / 12).toFixed(2));
+
+  const opportunityData = (opportunities ?? []) as OpportunityRecord[];
+  const velocitySamples = opportunityData
+    .map((deal) => daysBetween(deal.created_at, deal.close_date))
+    .filter((value): value is number => value !== null);
+  const averageVelocity = Number(average(velocitySamples).toFixed(1));
+
+  const projectData = (projects ?? []) as ProjectRecord[];
+  const progressSamples = projectData
+    .map((project) => (typeof project.progress === "number" ? project.progress : null))
+    .filter((value): value is number => value !== null);
+  const averageProgress = Number(average(progressSamples).toFixed(1));
+
+  const metrics: DashboardMetrics = {
+    total_mrr: totalMrr,
+    deal_velocity_days: averageVelocity,
+    average_project_progress: averageProgress,
+  };
+
+  const insertPayload = {
+    organization_id: payload.organization_id,
+    time_scope: payload.time_scope ?? "real_time",
+    segment_filter: payload.segment_filter ?? {},
+    metrics,
+  };
+
+  const { data: snapshot, error: snapshotError } = await supabase
+    .from("dashboard_snapshots")
+    .insert(insertPayload)
+    .select("id, computed_at")
+    .single();
+
+  if (snapshotError) {
+    console.error("dashboard-refresh:insert-error", snapshotError);
+    return jsonResponse({ ok: false, error: "failed-to-write-snapshot" }, { status: 500, headers: corsHeaders });
+  }
+
+  console.log(JSON.stringify({ event: "dashboard-refresh:complete", metrics, snapshot }));
+
+  return jsonResponse(
+    {
+      ok: true,
+      metrics,
+      snapshot,
+    },
+    { status: 200, headers: corsHeaders },
+  );
+});

--- a/supabase/functions/morning-brief/index.ts
+++ b/supabase/functions/morning-brief/index.ts
@@ -1,150 +1,359 @@
-const MORNING_BRIEF_ALLOWED_ORIGINS = new Set([
-  'https://trsrevos.vercel.app',
-  'http://localhost:3000',
-]);
+import { createClient, type SupabaseClient, type User } from "https://esm.sh/@supabase/supabase-js@2.48.0?dts";
 
-type MorningBriefInput = {
+type MorningBriefRequest = {
   user_id: string;
   organization_id: string;
   time_horizon?: string;
 };
 
-type MorningBriefResponse = {
-  ok: boolean;
-  data?: Record<string, unknown>;
-  error?: string;
+type MorningBriefSummary = {
+  date: string;
+  momentum: "accelerating" | "steady" | "rebuilding";
+  summary: {
+    pipeline_change: string;
+    win_rate: string;
+    invoices_sent: number;
+    focus_sessions: number;
+  };
+  priorities: Array<{ title: string; type: string; context?: string }>;
 };
 
-function createMorningBriefCorsHeaders(origin: string | null) {
-  const resolvedOrigin = origin && MORNING_BRIEF_ALLOWED_ORIGINS.has(origin)
-    ? origin
-    : 'https://trsrevos.vercel.app';
+type OpportunityRecord = {
+  id: string;
+  name: string;
+  amount: number | null;
+  stage: string | null;
+  probability: number | null;
+  updated_at: string | null;
+  close_date?: string | null;
+  client_id?: string | null;
+};
 
+type ClientRecord = {
+  id: string;
+  name: string;
+  health: number | null;
+  churn_risk: number | null;
+};
+
+type ProjectRecord = {
+  id: string;
+  name: string;
+  progress: number | null;
+  status: string | null;
+  due_date: string | null;
+  client_id: string | null;
+};
+
+type FocusSessionCount = {
+  count: number | null;
+};
+
+type AuthenticatedContext = {
+  supabase: SupabaseClient;
+  user: User;
+};
+
+const ALLOWED_ORIGINS = new Set([
+  "https://trsrevos.vercel.app",
+  "http://localhost:3000",
+]);
+
+const USD_COMPACT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function getRequiredEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function createCorsHeaders(origin: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://trsrevos.vercel.app";
   return new Headers({
-    'Access-Control-Allow-Origin': resolvedOrigin,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info',
-    'Access-Control-Max-Age': '86400',
-    'Content-Type': 'application/json',
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, x-client-info",
+    "Access-Control-Max-Age": "86400",
+    "Content-Type": "application/json",
   });
 }
 
-function respondWithMorningBrief(
-  body: MorningBriefResponse,
-  init: ResponseInit & { headers: Headers },
-) {
+function jsonResponse<T>(body: T, init: ResponseInit & { headers: Headers }) {
   return new Response(JSON.stringify(body, null, 2), init);
 }
 
-function logMorningBriefRequest(req: Request, functionName: string) {
-  console.info(
-    JSON.stringify({
-      event: `${functionName}:request`,
-      timestamp: new Date().toISOString(),
-      method: req.method,
-      url: req.url,
-    }),
-  );
+function startOfDay(date: Date) {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
 }
 
-function isValidMorningBriefInput(payload: unknown): payload is MorningBriefInput {
-  if (!payload || typeof payload !== 'object') return false;
-  const data = payload as Record<string, unknown>;
-  return typeof data.user_id === 'string' && typeof data.organization_id === 'string';
+function addDays(date: Date, days: number) {
+  const copy = new Date(date);
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function formatCurrencyDelta(delta: number) {
+  const sign = delta >= 0 ? "+" : "-";
+  const absolute = Math.abs(delta);
+  if (absolute === 0) {
+    return "+$0";
+  }
+  const formatted = USD_COMPACT.format(absolute).replace("US$", "$");
+  return `${sign}${formatted}`;
+}
+
+function formatPercent(value: number) {
+  if (!Number.isFinite(value)) return "0%";
+  return `${Math.round(value * 100)}%`;
+}
+
+function sumAmounts(records: Array<{ amount: number | null | undefined }>) {
+  return records.reduce((total, record) => total + (typeof record.amount === "number" ? record.amount : 0), 0);
+}
+
+function deriveMomentum(pipelineDelta: number, focusSessions: number, winRate: number) {
+  if (pipelineDelta > 5000 && focusSessions >= 2 && winRate >= 0.6) {
+    return "accelerating" as const;
+  }
+  if (pipelineDelta < -2500 || winRate < 0.4) {
+    return "rebuilding" as const;
+  }
+  return "steady" as const;
+}
+
+async function authenticateRequest(req: Request, corsHeaders: Headers): Promise<AuthenticatedContext | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return jsonResponse({ ok: false, error: "missing-token" }, { status: 401, headers: corsHeaders });
+  }
+
+  const supabaseUrl = getRequiredEnv("SUPABASE_URL");
+  const serviceKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const accessToken = authHeader.slice("bearer ".length).trim();
+  const { data: userResult, error } = await supabase.auth.getUser(accessToken);
+  if (error || !userResult?.user) {
+    console.error("morning-brief:auth-error", error);
+    return jsonResponse({ ok: false, error: "unauthorized" }, { status: 401, headers: corsHeaders });
+  }
+
+  return { supabase, user: userResult.user };
+}
+
+function selectTopPriorities(options: {
+  pipeline: OpportunityRecord[];
+  clients: ClientRecord[];
+  projects: ProjectRecord[];
+}) {
+  const priorities: Array<{ title: string; type: string; context?: string }> = [];
+
+  const sortedPipeline = options.pipeline
+    .filter((deal) => deal.stage && !["ClosedWon", "ClosedLost"].includes(deal.stage))
+    .sort((a, b) => (Number(b.amount ?? 0) || 0) - (Number(a.amount ?? 0) || 0));
+  if (sortedPipeline.length > 0) {
+    const topDeal = sortedPipeline[0];
+    const probability = typeof topDeal.probability === "number" ? `${topDeal.probability}%` : "";
+    priorities.push({
+      title: `Advance ${topDeal.name}`,
+      type: "Pipeline",
+      context: probability ? `Probability ${probability}` : undefined,
+    });
+  }
+
+  const stressedClients = options.clients
+    .filter((client) => typeof client.health === "number" || typeof client.churn_risk === "number")
+    .map((client) => ({
+      client,
+      riskScore: Math.max(
+        100 - (typeof client.health === "number" ? client.health : 100),
+        typeof client.churn_risk === "number" ? client.churn_risk : 0,
+      ),
+    }))
+    .filter((entry) => entry.riskScore >= 30)
+    .sort((a, b) => b.riskScore - a.riskScore);
+  if (stressedClients.length > 0) {
+    const { client, riskScore } = stressedClients[0];
+    priorities.push({
+      title: `Stabilize ${client.name}`,
+      type: "Client",
+      context: `Risk score ${Math.round(riskScore)}`,
+    });
+  }
+
+  const activeProjects = options.projects
+    .filter((project) => project.status === "Active")
+    .sort((a, b) => (Number(a.progress ?? 100) || 100) - (Number(b.progress ?? 100) || 100));
+  if (activeProjects.length > 0) {
+    const project = activeProjects[0];
+    const dueContext = project.due_date ? `Due ${project.due_date}` : undefined;
+    const progressContext = typeof project.progress === "number" ? `Progress ${project.progress}%` : undefined;
+    priorities.push({
+      title: `Unblock ${project.name}`,
+      type: "Projects",
+      context: dueContext ?? progressContext,
+    });
+  }
+
+  return priorities.slice(0, 3);
 }
 
 Deno.serve(async (req) => {
-  const origin = req.headers.get('origin');
-  const headers = createMorningBriefCorsHeaders(origin);
+  const origin = req.headers.get("origin");
+  const corsHeaders = createCorsHeaders(origin);
 
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers });
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
   }
 
-  logMorningBriefRequest(req, 'morning-brief');
-
-  if (req.method !== 'POST') {
-    return respondWithMorningBrief({ ok: false, error: 'Method not allowed' }, { status: 405, headers });
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "method-not-allowed" }, { status: 405, headers: corsHeaders });
   }
 
-  let payload: unknown;
+  let payload: MorningBriefRequest;
   try {
     payload = await req.json();
   } catch (error) {
-    console.error('morning-brief:invalid-json', error);
-    return respondWithMorningBrief({ ok: false, error: 'Invalid JSON payload' }, { status: 400, headers });
+    console.error("morning-brief:invalid-json", error);
+    return jsonResponse({ ok: false, error: "invalid-json" }, { status: 400, headers: corsHeaders });
   }
 
-  if (!isValidMorningBriefInput(payload)) {
-    return respondWithMorningBrief(
-      { ok: false, error: 'Missing required fields: user_id, organization_id' },
-      { status: 400, headers },
-    );
+  if (!payload || typeof payload.user_id !== "string" || typeof payload.organization_id !== "string") {
+    return jsonResponse({ ok: false, error: "missing-fields" }, { status: 400, headers: corsHeaders });
   }
 
-  const { user_id, organization_id, time_horizon } = payload;
+  const authContext = await authenticateRequest(req, corsHeaders);
+  if (authContext instanceof Response) {
+    return authContext;
+  }
 
-  console.info(
-    JSON.stringify({
-      event: 'morning-brief:payload-received',
-      timestamp: new Date().toISOString(),
-      user_id,
-      organization_id,
-      time_horizon,
-    }),
-  );
+  const { supabase } = authContext;
+  const today = startOfDay(new Date());
+  const yesterday = addDays(today, -1);
+  const thirtyDaysAgo = addDays(today, -30);
+  const tomorrow = addDays(today, 1);
 
-  // TODO: assemble prioritized focus plan.
-  // Required tables: daily_plans, priority_items, focus_sessions, events, clients, opportunities,
-  // cash_flow_entries, projects.
-  // Example workflow:
-  // 1. Load latest daily_plan for user & organization.
-  // 2. Compute ROI/effort scoring referencing opportunities & cash_flow_entries.
-  // 3. Persist focus_sessions skeleton entries for the returned plan.
+  const todayIso = today.toISOString();
+  const yesterdayIso = yesterday.toISOString();
+  const tomorrowIso = tomorrow.toISOString();
+  const todayDate = todayIso.slice(0, 10);
+  const tomorrowDate = tomorrowIso.slice(0, 10);
+  const thirtyDaysAgoIso = thirtyDaysAgo.toISOString();
 
-  const placeholderBrief = {
-    priorities: [
-      {
-        id: 'pri-1',
-        title: 'Schedule QBR with Helio',
-        why: 'High churn signal from health telemetry',
-        roi_dollars: 18000,
-        effort: 'Low',
-        owner: 'You',
-        status: 'Ready',
-      },
-      {
-        id: 'pri-2',
-        title: 'Finalize ReggieAI pricing tiers',
-        why: 'Margin expansion opportunity',
-        roi_dollars: 8000,
-        effort: 'Med',
-        owner: 'You',
-        status: 'Ready',
-      },
-      {
-        id: 'pri-3',
-        title: 'Collections outreach batch',
-        why: 'Reduce DSO by 5 days',
-        roi_dollars: 5000,
-        effort: 'Low',
-        owner: 'You',
-        status: 'Ready',
-      },
-    ],
-    diagnostics: {
-      referenced_tables: [
-        'daily_plans',
-        'priority_items',
-        'focus_sessions',
-        'events',
-        'clients',
-        'opportunities',
-        'cash_flow_entries',
-        'projects',
-      ],
+  console.log(JSON.stringify({ event: "morning-brief:start", payload }));
+
+  const [{ data: clients, error: clientsError }, { data: pipelineDeals, error: pipelineError }, { data: openPipeline, error: openPipelineError }, { data: projects, error: projectsError }] =
+    await Promise.all([
+      supabase
+        .from("clients")
+        .select("id, name, health, churn_risk")
+        .eq("owner_id", payload.user_id),
+      supabase
+        .from("opportunities")
+        .select("id, name, amount, stage, probability, updated_at, client_id")
+        .eq("owner_id", payload.user_id)
+        .gte("updated_at", yesterdayIso),
+      supabase
+        .from("opportunities")
+        .select("id, name, amount, stage, probability, updated_at, client_id")
+        .eq("owner_id", payload.user_id)
+        .not("stage", "in", "(ClosedWon,ClosedLost)"),
+      supabase
+        .from("projects")
+        .select("id, name, progress, status, due_date, client_id")
+        .eq("owner_id", payload.user_id),
+    ]);
+
+  if (clientsError || pipelineError || openPipelineError || projectsError) {
+    console.error("morning-brief:query-error", { clientsError, pipelineError, openPipelineError, projectsError });
+    return jsonResponse({ ok: false, error: "failed-to-load-data" }, { status: 500, headers: corsHeaders });
+  }
+
+  const clientIds = (clients ?? []).map((client) => client.id);
+
+  const invoicesPromise = clientIds.length
+    ? supabase
+        .from("invoices")
+        .select("id", { count: "exact", head: true })
+        .in("client_id", clientIds)
+        .eq("status", "sent")
+        .gte("issue_date", todayDate)
+        .lt("issue_date", tomorrowDate)
+    : Promise.resolve({ count: 0, error: null } as FocusSessionCount & { error: null });
+
+  const focusSessionsPromise = supabase
+    .from("focus_sessions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", payload.user_id)
+    .gte("started_at", todayIso)
+    .lt("started_at", tomorrowIso);
+
+  const winRatePromise = supabase
+    .from("opportunities")
+    .select("id, stage, created_at, close_date")
+    .eq("owner_id", payload.user_id)
+    .gte("updated_at", thirtyDaysAgoIso)
+    .in("stage", ["ClosedWon", "ClosedLost"]);
+
+  const [{ count: invoicesSent = 0, error: invoicesError }, { count: focusSessions = 0, error: focusSessionsError }, { data: closedDeals, error: closedDealsError }] =
+    await Promise.all([invoicesPromise, focusSessionsPromise, winRatePromise]);
+
+  if (invoicesError || focusSessionsError || closedDealsError) {
+    console.error("morning-brief:aggregate-error", { invoicesError, focusSessionsError, closedDealsError });
+    return jsonResponse({ ok: false, error: "aggregate-failed" }, { status: 500, headers: corsHeaders });
+  }
+
+  const pipelineData = pipelineDeals ?? [];
+  const openData = openPipeline ?? [];
+  const projectsData = projects ?? [];
+  const clientsData = clients ?? [];
+
+  const todaysPipeline = pipelineData.filter((deal) => (deal.updated_at ?? "") >= todayIso);
+  const yesterdaysPipeline = pipelineData.filter((deal) => (deal.updated_at ?? "") < todayIso);
+
+  const pipelineDelta = sumAmounts(todaysPipeline) - sumAmounts(yesterdaysPipeline);
+  const winRateData = closedDeals ?? [];
+  const wins = winRateData.filter((deal) => deal.stage === "ClosedWon").length;
+  const losses = winRateData.filter((deal) => deal.stage === "ClosedLost").length;
+  const winRate = wins + losses === 0 ? 0 : wins / (wins + losses);
+
+  const momentum = deriveMomentum(pipelineDelta, focusSessions ?? 0, winRate);
+  let priorities = selectTopPriorities({ pipeline: openData, clients: clientsData, projects: projectsData });
+  const fallbackPriorities = [
+    { title: "Review pipeline commitments", type: "Pipeline" },
+    { title: "Check finance run-rate", type: "Finance" },
+    { title: "Plan focus blocks", type: "Projects" },
+  ];
+  for (const fallback of fallbackPriorities) {
+    if (priorities.length >= 3) break;
+    priorities.push({ title: fallback.title, type: fallback.type });
+  }
+
+  const response: MorningBriefSummary = {
+    date: todayDate,
+    momentum,
+    summary: {
+      pipeline_change: formatCurrencyDelta(pipelineDelta),
+      win_rate: formatPercent(winRate),
+      invoices_sent: invoicesSent ?? 0,
+      focus_sessions: focusSessions ?? 0,
     },
+    priorities,
   };
 
-  return respondWithMorningBrief({ ok: true, data: placeholderBrief }, { status: 200, headers });
+  console.log(JSON.stringify({ event: "morning-brief:complete", response }));
+
+  return jsonResponse(response, { status: 200, headers: corsHeaders });
 });

--- a/supabase/functions/notify-agent/index.ts
+++ b/supabase/functions/notify-agent/index.ts
@@ -1,0 +1,285 @@
+import { createClient, type SupabaseClient, type User } from "https://esm.sh/@supabase/supabase-js@2.48.0?dts";
+
+type NotifyAgentRequest = {
+  agent_id: string;
+  message: string;
+  context?: Record<string, unknown>;
+  channel?: string;
+  organization_id?: string;
+};
+
+type IntegrationRecord = {
+  id: string;
+  provider: string | null;
+  status: string | null;
+  settings: Record<string, unknown> | null;
+  organization_id: string | null;
+};
+
+type AuthenticatedContext = {
+  supabase: SupabaseClient;
+  user: User;
+};
+
+const ALLOWED_ORIGINS = new Set([
+  "https://trsrevos.vercel.app",
+  "http://localhost:3000",
+]);
+
+function getRequiredEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function createCorsHeaders(origin: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://trsrevos.vercel.app";
+  return new Headers({
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, x-client-info",
+    "Access-Control-Max-Age": "86400",
+    "Content-Type": "application/json",
+  });
+}
+
+function jsonResponse<T>(body: T, init: ResponseInit & { headers: Headers }) {
+  return new Response(JSON.stringify(body, null, 2), init);
+}
+
+async function authenticateRequest(req: Request, corsHeaders: Headers): Promise<AuthenticatedContext | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return jsonResponse({ ok: false, error: "missing-token" }, { status: 401, headers: corsHeaders });
+  }
+
+  const supabaseUrl = getRequiredEnv("SUPABASE_URL");
+  const serviceKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const accessToken = authHeader.slice("bearer ".length).trim();
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  if (error || !data?.user) {
+    console.error("notify-agent:auth-error", error);
+    return jsonResponse({ ok: false, error: "unauthorized" }, { status: 401, headers: corsHeaders });
+  }
+
+  return { supabase, user: data.user };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+}
+
+function resolveWebhook(
+  integration: IntegrationRecord,
+  agentId: string,
+  preferredChannel?: string,
+): { webhookUrl: string; channel: string } | null {
+  const settings = asRecord(integration.settings) ?? {};
+
+  const channels = asRecord(settings.channels) as Record<string, unknown> | null;
+  if (preferredChannel && channels) {
+    const target = channels[preferredChannel];
+    if (typeof target === "string") {
+      return { webhookUrl: target, channel: preferredChannel };
+    }
+    const targetRecord = asRecord(target);
+    const targetUrl = targetRecord && typeof targetRecord.webhook_url === "string" ? targetRecord.webhook_url : null;
+    if (targetUrl) {
+      const channelName = typeof targetRecord?.channel === "string" ? targetRecord.channel : preferredChannel;
+      return { webhookUrl: targetUrl, channel: channelName };
+    }
+  }
+
+  const agentRoutes = (asRecord(settings.agent_routes) ?? asRecord(settings.webhooks)) as Record<string, unknown> | null;
+  if (agentRoutes) {
+    const route = agentRoutes[agentId];
+    if (typeof route === "string") {
+      return { webhookUrl: route, channel: preferredChannel ?? integration.provider ?? "webhook" };
+    }
+    const routeRecord = asRecord(route);
+    if (routeRecord) {
+      const url = typeof routeRecord.webhook_url === "string" ? routeRecord.webhook_url : typeof routeRecord.url === "string"
+        ? routeRecord.url
+        : null;
+      if (url) {
+        const channelName = typeof routeRecord.channel === "string"
+          ? routeRecord.channel
+          : preferredChannel ?? integration.provider ?? "webhook";
+        return { webhookUrl: url, channel: channelName };
+      }
+    }
+  }
+
+  const directUrl = typeof settings.webhook_url === "string" ? settings.webhook_url : null;
+  if (directUrl) {
+    return { webhookUrl: directUrl, channel: preferredChannel ?? integration.provider ?? "webhook" };
+  }
+
+  return null;
+}
+
+async function resolveOrganizationId(
+  supabase: SupabaseClient,
+  fallbackUserId: string,
+  explicitOrganizationId?: string,
+  context?: Record<string, unknown>,
+) {
+  if (explicitOrganizationId && explicitOrganizationId.length > 0) {
+    return explicitOrganizationId;
+  }
+  const contextOrg = context && typeof context["organization_id"] === "string"
+    ? (context["organization_id"] as string)
+    : null;
+  if (contextOrg) {
+    return contextOrg;
+  }
+  const { data, error } = await supabase
+    .from("users")
+    .select("organization_id")
+    .eq("id", fallbackUserId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("notify-agent:user-lookup-error", error);
+    return null;
+  }
+
+  return data?.organization_id ?? null;
+}
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get("origin");
+  const corsHeaders = createCorsHeaders(origin);
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ ok: false, error: "method-not-allowed" }, { status: 405, headers: corsHeaders });
+  }
+
+  let payload: NotifyAgentRequest;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error("notify-agent:invalid-json", error);
+    return jsonResponse({ ok: false, error: "invalid-json" }, { status: 400, headers: corsHeaders });
+  }
+
+  if (!payload || typeof payload.agent_id !== "string" || typeof payload.message !== "string") {
+    return jsonResponse({ ok: false, error: "missing-fields" }, { status: 400, headers: corsHeaders });
+  }
+
+  const authContext = await authenticateRequest(req, corsHeaders);
+  if (authContext instanceof Response) {
+    return authContext;
+  }
+
+  const { supabase, user } = authContext;
+  const organizationId = await resolveOrganizationId(supabase, user.id, payload.organization_id, payload.context);
+
+  if (!organizationId) {
+    return jsonResponse({ ok: false, error: "missing-organization" }, { status: 400, headers: corsHeaders });
+  }
+
+  console.log(JSON.stringify({ event: "notify-agent:start", payload: { ...payload, organization_id: organizationId } }));
+
+  const { data: integrations, error: integrationsError } = await supabase
+    .from("integrations")
+    .select("id, provider, status, settings, organization_id")
+    .eq("status", "connected")
+    .or(`organization_id.eq.${organizationId},organization_id.is.null`);
+
+  if (integrationsError) {
+    console.error("notify-agent:integration-error", integrationsError);
+    return jsonResponse({ ok: false, error: "failed-to-load-integrations" }, { status: 500, headers: corsHeaders });
+  }
+
+  const integrationRecords = (integrations ?? []) as IntegrationRecord[];
+
+  let selected: { integration: IntegrationRecord; webhookUrl: string; channel: string } | null = null;
+  for (const integration of integrationRecords) {
+    const resolved = resolveWebhook(integration, payload.agent_id, payload.channel);
+    if (resolved) {
+      selected = { integration, ...resolved };
+      break;
+    }
+  }
+
+  let deliveryStatus: "sent" | "failed" | "skipped" = "skipped";
+  let httpStatus: number | null = null;
+  let deliveryError: string | null = null;
+
+  if (selected) {
+    try {
+      const response = await fetch(selected.webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: payload.agent_id,
+          message: payload.message,
+          context: payload.context ?? {},
+          channel: selected.channel,
+        }),
+      });
+      httpStatus = response.status;
+      deliveryStatus = response.ok ? "sent" : "failed";
+      if (!response.ok) {
+        deliveryError = await response.text();
+      }
+    } catch (error) {
+      deliveryStatus = "failed";
+      deliveryError = (error as Error).message;
+    }
+  }
+
+  const analyticsInsert = await supabase.from("analytics_events").insert({
+    organization_id: organizationId,
+    user_id: user.id,
+    event_type: "agent_notification",
+    entity_type: "agent",
+    entity_id: payload.agent_id,
+    metadata: {
+      message: payload.message,
+      channel: payload.channel ?? selected?.channel ?? null,
+      delivered: deliveryStatus === "sent",
+      delivery_status: deliveryStatus,
+      http_status: httpStatus,
+      integration_id: selected?.integration.id ?? null,
+      error: deliveryError,
+      context: payload.context ?? {},
+    },
+  });
+
+  if (analyticsInsert.error) {
+    console.error("notify-agent:analytics-error", analyticsInsert.error);
+  }
+
+  console.log(JSON.stringify({
+    event: "notify-agent:complete",
+    delivery_status: deliveryStatus,
+    integration_id: selected?.integration.id ?? null,
+    http_status: httpStatus,
+  }));
+
+  const statusCode = deliveryStatus === "failed" ? 502 : 200;
+  return jsonResponse(
+    {
+      ok: deliveryStatus !== "failed",
+      delivery_status: deliveryStatus,
+      http_status: httpStatus,
+      integration_id: selected?.integration.id ?? null,
+      error: deliveryError,
+    },
+    { status: statusCode, headers: corsHeaders },
+  );
+});


### PR DESCRIPTION
## Summary
- implement a production-ready morning-brief edge function that authenticates the caller, aggregates pipeline, finance, and focus activity metrics, and returns prioritized actions
- add dashboard-refresh and analytics-sync functions to compute live KPIs, persist dashboard snapshots, and roll up analytics event trends
- introduce a notify-agent webhook dispatcher that routes messages through connected integrations and records delivery outcomes in analytics_events

## Testing
- not run (Supabase edge functions require deployed infrastructure for end-to-end execution)


------
https://chatgpt.com/codex/tasks/task_e_68ea838c121c832491c5b281790a216a