### PR TITLE
Fix prospect creation to use authenticated Supabase session

### DIFF
--- a/core/pipeline/actions.ts
+++ b/core/pipeline/actions.ts
@@ -311,12 +311,7 @@ export async function createProspect(input: {
   contactPhone?: string;
   nextStep?: string;
 }): Promise<{ success: boolean; opportunity?: Opportunity; error?: string }> {
-  const supabase = await createClient();
-
-  // Get the authenticated user
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await requireAuth({ redirectTo: "/login?next=/pipeline" });
 
   if (!user) {
     return { success: false, error: "User not authenticated" };


### PR DESCRIPTION
## Summary
- use the shared requireAuth helper in the pipeline createProspect action so the server request carries the authenticated session
- keep the owner assignment tied to the authenticated user to satisfy the clients table row-level security policy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ea988784bc8324bec786f4c4190a2a