### PR TITLE
feat: connect dashboard metrics to supabase views

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,8 +1,113 @@
-import { getExecDashboard, exportBoardDeck } from "@/core/exec/actions";
-import DashboardClient from "./DashboardClient";
+// app/dashboard/page.tsx
+import { listClientOverview, getPipelineForecast } from "@/lib/queries";
+
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-[11px] text-gray-500">{label}</div>
+      <div className="text-2xl font-semibold text-black">{value}</div>
+    </div>
+  );
+}
+
+const Th = ({ children }: { children: React.ReactNode }) => (
+  <th className="px-3 py-2 text-left text-gray-600 text-[12px]">{children}</th>
+);
+const Td = ({ children }: { children: React.ReactNode }) => (
+  <td className="px-3 py-2">{children}</td>
+);
 
 export default async function DashboardPage() {
-  const d = await getExecDashboard();
+  const [clients, forecast] = await Promise.all([
+    listClientOverview(),
+    getPipelineForecast(),
+  ]);
 
-  return <DashboardClient data={d} exportAction={exportBoardDeck} />;
+  const totalMRR = clients.reduce((s, c) => s + (c.mrr ?? 0), 0);
+  const totalAR = clients.reduce((s, c) => s + (c.ar_outstanding ?? 0), 0);
+  const weighted = forecast.length ? (forecast[0].all_weighted_value ?? 0) : 0;
+
+  return (
+    <div className="w-full min-h-screen bg-white text-black">
+      {/* Top masthead is assumed to be part of your layout; keep page content simple */}
+      <div className="p-4">
+        {/* KPI Row */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Kpi label="Total MRR" value={`$${totalMRR.toLocaleString()}`} />
+          <Kpi label="A/R Outstanding" value={`$${totalAR.toLocaleString()}`} />
+          <Kpi label="Weighted Pipeline" value={`$${weighted.toLocaleString()}`} />
+        </div>
+
+        {/* Clients table */}
+        <div className="mt-6 rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <Th>Client</Th>
+                <Th>Type</Th>
+                <Th>Stage</Th>
+                <Th>MRR</Th>
+                <Th>AR</Th>
+                <Th>Weighted</Th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {(clients.length ? clients : []).map((c) => (
+                <tr key={c.client_id} className="hover:bg-gray-50">
+                  <Td>{c.client_name}</Td>
+                  <Td>{c.client_type ?? "-"}</Td>
+                  <Td>{c.pipeline_stage ?? "-"}</Td>
+                  <Td>${(c.mrr ?? 0).toLocaleString()}</Td>
+                  <Td>${(c.ar_outstanding ?? 0).toLocaleString()}</Td>
+                  <Td>${(c.weighted_value ?? 0).toLocaleString()}</Td>
+                </tr>
+              ))}
+              {!clients.length && (
+                <tr>
+                  <td className="p-6 text-center text-gray-500" colSpan={6}>
+                    No data yet. Add clients or pipeline to see live metrics.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pipeline summary (optional read-out) */}
+        <div className="mt-6 rounded-xl border border-gray-200 bg-white p-3">
+          <div className="text-sm font-medium mb-2">Pipeline by Stage</div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <Th>Stage</Th>
+                  <Th>Deals</Th>
+                  <Th>Total</Th>
+                  <Th>Weighted</Th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {(forecast.length ? forecast : []).map((r) => (
+                  <tr key={r.stage}>
+                    <Td>{r.stage}</Td>
+                    <Td>{r.deals}</Td>
+                    <Td>${(r.total_value ?? 0).toLocaleString()}</Td>
+                    <Td>${(r.weighted_value ?? 0).toLocaleString()}</Td>
+                  </tr>
+                ))}
+                {!forecast.length && (
+                  <tr>
+                    <td className="p-6 text-center text-gray-500" colSpan={4}>
+                      No pipeline yet. Add opportunities to populate this view.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
 }

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
+import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
 import { PageTemplate } from "@/components/layout/PageTemplate";
 import { PageTabs } from "@/components/layout/PageTabs";
 import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
 import {
   Card,
   CardContent,
@@ -16,6 +16,7 @@ import {
 } from "@/ui/card";
 import { TRS_CARD } from "@/lib/style";
 import { resolveTabs } from "@/lib/tabs";
+import { cn } from "@/lib/utils";
 
 const pricingScenarios = [
   {
@@ -40,6 +41,9 @@ const pricingScenarios = [
     packaging: "Seats + governance + support",
   },
 ];
+
+const outlineButtonClass =
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-outline)] border border-[color:var(--color-outline)] bg-white text-[color:var(--color-text)] hover:bg-[color:var(--color-surface-muted)] h-9 px-4 text-sm";
 
 const revenueDrivers = [
   { id: "rd1", name: "Net new ARR", amount: 185000, change: "+12% MoM" },
@@ -194,12 +198,12 @@ export default function ResourcesPage() {
                         <dd>{scenario.discountGuard}</dd>
                       </div>
                     </dl>
-                    <Button
-                      variant="outline"
-                      className="mt-4 self-start text-sm"
+                    <Link
+                      href="/content?tab=Pipeline"
+                      className={cn(outlineButtonClass, "mt-4 self-start")}
                     >
                       Export playbook
-                    </Button>
+                    </Link>
                   </div>
                 ))}
               </div>
@@ -359,9 +363,12 @@ export default function ResourcesPage() {
                   {item}
                 </div>
               ))}
-              <Button variant="outline" className="self-start text-sm">
+              <Link
+                href="/finance?tab=Cash%20Flow"
+                className={cn(outlineButtonClass, "self-start")}
+              >
                 Open planner workspace
-              </Button>
+              </Link>
             </CardContent>
           </Card>
         </div>
@@ -443,9 +450,12 @@ export default function ResourcesPage() {
                     </p>
                     <p className="mt-1 text-sm text-gray-600">{pack.summary}</p>
                   </div>
-                  <Button variant="outline" className="mt-4 self-start text-sm">
+                  <Link
+                    href="/dashboard?tab=Reports"
+                    className={cn(outlineButtonClass, "mt-4 self-start")}
+                  >
                     Generate pack
-                  </Button>
+                  </Link>
                 </div>
               ))}
             </CardContent>

--- a/components/nav/AdminSidebar.tsx
+++ b/components/nav/AdminSidebar.tsx
@@ -5,9 +5,8 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import {
   BarChart3,
-  Book,
   Bot,
-  CalendarDays,
+  Building2,
   FileText,
   ListChecks,
   Settings as SettingsIcon,
@@ -28,15 +27,14 @@ type NavItem = {
 const NAV_ITEMS: NavItem[] = [
   { label: "Morning Brief", href: "/", icon: Sun },
   { label: "Pipeline", href: "/pipeline", icon: TrendingUp },
-  { label: "Clients", href: "/clients", icon: Users },
   { label: "Projects", href: "/projects", icon: ListChecks },
-  { label: "Dashboard", href: "/dashboard", icon: BarChart3 },
-  { label: "Agents", href: "/agents", icon: Bot },
   { label: "Content", href: "/content", icon: FileText },
-  { label: "Resources", href: "/resources", icon: Book },
-  { label: "Mail & Calendar", href: "/mail-calendar", icon: CalendarDays },
   { label: "Finance", href: "/finance", icon: Wallet },
+  { label: "Partners", href: "/partners", icon: Building2 },
+  { label: "Clients", href: "/clients", icon: Users },
+  { label: "Agents", href: "/agents", icon: Bot },
   { label: "Settings", href: "/settings", icon: SettingsIcon },
+  { label: "Dashboard", href: "/dashboard", icon: BarChart3 },
 ]
 
 export default function AdminSidebar() {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -20,27 +20,9 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
   },
   {
-    label: 'Dashboard',
-    href: '/dashboard',
-    icon: 'LayoutDashboard',
-    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
-  },
-  {
     label: 'Pipeline',
     href: '/pipeline',
     icon: 'TrendingUp',
-    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
-  },
-  {
-    label: 'Clients',
-    href: '/clients',
-    icon: 'Users',
-    roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
-  },
-  {
-    label: 'Content',
-    href: '/content',
-    icon: 'FileText',
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
@@ -50,21 +32,15 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
+    label: 'Content',
+    href: '/content',
+    icon: 'FileText',
+    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
+  },
+  {
     label: 'Finance',
     href: '/finance',
     icon: 'PiggyBank',
-    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
-  },
-  {
-    label: 'Settings',
-    href: '/settings',
-    icon: 'Settings',
-    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
-  },
-  {
-    label: 'Agents',
-    href: '/agents',
-    icon: 'Bot',
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
@@ -74,25 +50,37 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
-    label: 'Resources',
-    href: '/resources',
-    icon: 'BookOpen',
+    label: 'Clients',
+    href: '/clients',
+    icon: 'Users',
+    roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
+  },
+  {
+    label: 'Agents',
+    href: '/agents',
+    icon: 'Bot',
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
-    label: 'Mail & Calendar',
-    href: '/mail-calendar',
-    icon: 'CalendarClock',
+    label: 'Settings',
+    href: '/settings',
+    icon: 'Settings',
+    roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
+  },
+  {
+    label: 'Dashboard',
+    href: '/dashboard',
+    icon: 'LayoutDashboard',
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
 ]
 
 export const BOTTOM_NAV_ITEMS: NavItem[] = [
-  { label: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard' },
+  { label: 'Morning Brief', href: '/', icon: 'Sun' },
   { label: 'Pipeline', href: '/pipeline', icon: 'TrendingUp' },
-  { label: 'Clients', href: '/clients', icon: 'Users' },
   { label: 'Projects', href: '/projects', icon: 'Kanban' },
-  { label: 'Partners', href: '/partners', icon: 'Building2' },
+  { label: 'Clients', href: '/clients', icon: 'Users' },
+  { label: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard' },
 ]
 
 export const APP_TITLE = 'TRS Internal SaaS'

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,0 +1,32 @@
+// lib/queries.ts
+import { getServerSupabase } from "@/lib/supabase";
+import type { VwClientOverview, VwPipelineForecast } from "@/lib/types";
+
+export async function listClientOverview(): Promise<VwClientOverview[]> {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    return [];
+  }
+  const sb = getServerSupabase();
+  const { data, error } = await sb
+    .from("vw_client_overview")
+    .select("*")
+    .order("client_name");
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getPipelineForecast(): Promise<VwPipelineForecast[]> {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    return [];
+  }
+  const sb = getServerSupabase();
+  const { data, error } = await sb.from("vw_pipeline_forecast").select("*");
+  if (error) throw error;
+  return data ?? [];
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,29 @@
+// lib/supabase.ts
+import { createBrowserClient, createServerClient } from "@supabase/ssr";
+import { cookies, headers } from "next/headers";
+
+export function getServerSupabase() {
+  const cookieStore = cookies();
+  const headerStore = headers();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createServerClient(url, anon, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(_cookies) {}, // no-op for SSR fetch
+    },
+    global: {
+      headers: {
+        "x-trs-host": headerStore.get("host") ?? "",
+      },
+    },
+  });
+}
+
+export function getBrowserSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createBrowserClient(url, anon);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,28 @@
+// lib/types.ts
+export type VwClientOverview = {
+  client_id: string;
+  client_name: string;
+  client_type: string | null;
+  organization_id: string | null;
+  owner_id: string | null;
+
+  pipeline_id: string | null;
+  pipeline_stage: string | null;
+  pipeline_value: number | null;
+  weighted_value: number | null;
+  probability: number | null;
+
+  finance_id: string | null;
+  mrr: number | null;
+  ar_outstanding: number | null;
+  ar_collected: number | null;
+};
+
+export type VwPipelineForecast = {
+  stage: string;
+  deals: number;
+  total_value: number;
+  weighted_value: number;
+  all_total_value: number;
+  all_weighted_value: number;
+};


### PR DESCRIPTION
## Summary
- add shared Supabase client helpers, view types, and query functions for pipeline and client overview data
- render the dashboard KPIs and tables from live Supabase views with zero-data fallbacks
- align navigation items with canonical routes and convert resource CTA buttons into working links

## Testing
- pnpm run typecheck
- CI=1 TERM=dumb pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68eaabc2c7108324a80eb7f7ab63a90a