### PR TITLE
Remove placeholder data from Morning Brief views

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,6 +60,68 @@ export default function MorningPage() {
     month: "short",
     day: "numeric",
   });
+  const agentNote = s.note.trim();
+  const planComputed = s.priorities.length > 0;
+  const momentumLabels = {
+    down: "Declining",
+    steady: "Steady",
+    up: "Improving",
+  } as const;
+  const formatCurrency = (value: number) =>
+    new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(value);
+  const weeklyInsights: string[] = [
+    `Momentum signal: ${momentumLabels[s.momentum]}`,
+    `Pipeline advanced today: ${formatCurrency(s.kpis.pipelineDollars)}`,
+    `Win rate (30d): ${s.kpis.winRatePct}%`,
+    `Price realization: ${s.kpis.priceRealizationPct}%`,
+    `Focus sessions logged today: ${s.kpis.focusSessionsToday}`,
+  ];
+  if (agentNote) {
+    weeklyInsights.push(`Agent note: ${agentNote}`);
+  }
+  const priorityOutlook = s.priorities.map((p) => {
+    const statusLabel =
+      p.status === "Done"
+        ? "Completed"
+        : p.status === "Deferred"
+          ? "Deferred"
+          : "Active";
+    const why = p.why ? ` — ${p.why}` : "";
+    return `${p.title} • ${statusLabel}${why}`;
+  });
+  const focusSuggestions = s.priorities
+    .filter((p) => p.status === "Ready" || p.status === "InProgress")
+    .map((p) => {
+      const why = p.why ? ` Next step: ${p.why}` : "";
+      return `Block ${p.effort.toLowerCase()} effort to advance ${p.title}.${why}`;
+    });
+  const completedSummaries = s.priorities
+    .filter((p) => p.status === "Done")
+    .map((p) => {
+      const why = p.why ? ` — ${p.why}` : "";
+      return `Completed ${p.title}${why}`;
+    });
+  const riskAlerts = s.priorities
+    .filter((p) => p.status === "Deferred")
+    .map((p) => {
+      const why = p.why ? ` (${p.why})` : "";
+      return `Deferred: ${p.title}${why}`;
+    });
+  const followUpChecks = planComputed
+    ? s.priorities.map((p) => {
+        if (p.status === "Deferred") {
+          return `Review ${p.title} after new data arrives.`;
+        }
+        if (p.status === "Done") {
+          return `Capture learnings from ${p.title}.`;
+        }
+        return `Check in on ${p.title} after the scheduled focus block.`;
+      })
+    : [];
 
   const renderTasks = () => (
     <div className={cn(TRS_CARD, "p-3")}>
@@ -105,8 +167,8 @@ export default function MorningPage() {
             <div className="space-y-2">
               <PageTitle>Morning Brief</PageTitle>
               <PageDescription>
-                Good morning — {greeting}. Daily revenue operating briefing curated by the
-                Morning Agent. {s.note}.
+                Good morning — {greeting}. Daily revenue operating briefing curated by the Morning Agent
+                {agentNote ? `. ${agentNote}` : "."}
               </PageDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -173,85 +235,25 @@ export default function MorningPage() {
         <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <div className={cn(TRS_CARD, "p-4")}>
             <div className="mb-3 text-sm font-semibold text-black">
-              Weekly Momentum Plan
+              Signals &amp; Highlights
             </div>
-            <ul className="space-y-3 text-[13px] text-gray-700">
-              <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Close $1.8M in expansion
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  Target accounts: Northwind, Globex, Wayfinder
-                </div>
-                <div className="mt-2 text-[11px] text-gray-500">
-                  Owner: Enterprise pod • Status: Tracking
-                </div>
-              </li>
-              <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Accelerate collections cycle
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  Launch outreach to all invoices &gt; 30 days
-                </div>
-                <div className="mt-2 text-[11px] text-gray-500">
-                  Owner: Finance • Status: In motion
-                </div>
-              </li>
-              <li className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Ship updated pricing guardrails
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  Align deal desk + enablement by Thursday
-                </div>
-                <div className="mt-2 text-[11px] text-gray-500">
-                  Owner: Pricing committee • Status: On track
-                </div>
-              </li>
-            </ul>
+            {planComputed ? (
+              <SummaryFeed items={weeklyInsights} />
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                Compute your plan to unlock weekly insights.
+              </p>
+            )}
           </div>
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">
-              Key Metrics Watchlist
-            </div>
-            <div className="space-y-3 text-[13px] text-gray-700">
-              <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">
-                    Pipeline Coverage
-                  </div>
-                  <div className="text-[12px] text-gray-600">
-                    Goal: 4.5x • Current: 4.1x
-                  </div>
-                </div>
-                <span className="text-[12px] text-emerald-600">
-                  Trending up
-                </span>
-              </div>
-              <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">Bookings Pace</div>
-                  <div className="text-[12px] text-gray-600">
-                    Goal: $420K/week • Current: $395K
-                  </div>
-                </div>
-                <span className="text-[12px] text-amber-600">
-                  Needs attention
-                </span>
-              </div>
-              <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">Focus Sessions</div>
-                  <div className="text-[12px] text-gray-600">
-                    Goal: 15 • Completed: {s.kpis.focusSessionsToday}
-                  </div>
-                </div>
-                <span className="text-[12px] text-gray-500">
-                  Mid-week review tomorrow
-                </span>
-              </div>
-            </div>
+            <div className="mb-3 text-sm font-semibold text-black">Priority Outlook</div>
+            {planComputed ? (
+              <SummaryFeed items={priorityOutlook} />
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                No priorities yet. Run Compute Plan to populate this view.
+              </p>
+            )}
           </div>
         </section>
       )}
@@ -259,84 +261,35 @@ export default function MorningPage() {
       {activeTab === "Focus Blocks" && (
         <section className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">
-              Planned Deep Work
-            </div>
-            <div className="space-y-3 text-[13px] text-gray-700">
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Strategic accounts review
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  90m • Owner: You
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Outcome: Confirm expansion roadmap
-                </div>
-              </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Pricing guardrails draft
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  60m • Owner: Deal desk
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Outcome: Package scenarios for review
-                </div>
-              </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Collections acceleration
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  45m • Owner: Finance
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Outcome: Prioritize $380K backlog
-                </div>
-              </div>
-            </div>
+            <div className="mb-3 text-sm font-semibold text-black">Focus Recommendations</div>
+            {focusSuggestions.length > 0 ? (
+              <SummaryFeed items={focusSuggestions} />
+            ) : planComputed ? (
+              <p className="text-[13px] text-gray-600">
+                All priorities are complete or deferred. Monitor for new signals.
+              </p>
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                Compute your plan to receive focus block recommendations.
+              </p>
+            )}
           </div>
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">
-              Recent Sessions
+            <div className="mb-3 text-sm font-semibold text-black">Sessions Logged Today</div>
+            <div className="mb-2 text-[13px] text-gray-600">
+              {s.kpis.focusSessionsToday === 0
+                ? "No focus sessions recorded today."
+                : `${s.kpis.focusSessionsToday} focus session${s.kpis.focusSessionsToday === 1 ? "" : "s"} completed today.`}
             </div>
-            <ul className="space-y-3 text-[13px] text-gray-700">
-              <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">
-                    Partner activation audit
-                  </div>
-                  <div className="text-[12px] text-gray-600">
-                    Completed yesterday • 75m
-                  </div>
-                </div>
-                <span className="text-[12px] text-emerald-600">Complete</span>
-              </li>
-              <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">
-                    Forecast calibration
-                  </div>
-                  <div className="text-[12px] text-gray-600">
-                    Completed Monday • 60m
-                  </div>
-                </div>
-                <span className="text-[12px] text-emerald-600">Complete</span>
-              </li>
-              <li className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-3">
-                <div>
-                  <div className="font-semibold text-black">
-                    Team enablement sync
-                  </div>
-                  <div className="text-[12px] text-gray-600">
-                    Scheduled Thursday • 45m
-                  </div>
-                </div>
-                <span className="text-[12px] text-amber-600">Upcoming</span>
-              </li>
-            </ul>
+            {completedSummaries.length > 0 ? (
+              <SummaryFeed items={completedSummaries} />
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                {planComputed
+                  ? "Mark priorities complete to capture what was accomplished."
+                  : "Focus session history will populate after you compute today’s plan."}
+              </p>
+            )}
           </div>
         </section>
       )}
@@ -344,56 +297,30 @@ export default function MorningPage() {
       {activeTab === "Risks" && (
         <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">
-              Top Risks
-            </div>
-            <div className="space-y-3 text-[13px] text-gray-700">
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Collections slip in enterprise
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  $540K outstanding &gt; 45 days
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Mitigation: Finance sprint + AE escalation
-                </div>
-              </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Pricing pressure in EMEA
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  Win rate down 6 pts week-over-week
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Mitigation: Launch value-based play
-                </div>
-              </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-3">
-                <div className="text-sm font-semibold text-black">
-                  Enablement backlog
-                </div>
-                <div className="text-[12px] text-gray-600">
-                  New reps lacking updated collateral
-                </div>
-                <div className="mt-1 text-[11px] text-gray-500">
-                  Mitigation: Publish draft by Friday
-                </div>
-              </div>
-            </div>
+            <div className="mb-3 text-sm font-semibold text-black">Alerts &amp; Signals</div>
+            {planComputed ? (
+              riskAlerts.length > 0 ? (
+                <SummaryFeed items={riskAlerts} />
+              ) : (
+                <p className="text-[13px] text-gray-600">
+                  No risks flagged from today’s plan.
+                </p>
+              )
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                Compute your plan to surface risk alerts.
+              </p>
+            )}
           </div>
           <div className={cn(TRS_CARD, "p-4")}>
-            <div className="mb-3 text-sm font-semibold text-black">
-              Alerts & Signals
-            </div>
-            <SummaryFeed
-              items={[
-                "3 high-value renewals without active champions.",
-                "Partner-sourced pipeline pacing below commit line.",
-                "Marketing qualified pipeline flat week-over-week.",
-              ]}
-            />
+            <div className="mb-3 text-sm font-semibold text-black">Next Checks</div>
+            {planComputed ? (
+              <SummaryFeed items={followUpChecks} />
+            ) : (
+              <p className="text-[13px] text-gray-600">
+                Compute your plan to queue upcoming reviews.
+              </p>
+            )}
           </div>
         </section>
       )}

--- a/core/morning/store.ts
+++ b/core/morning/store.ts
@@ -3,10 +3,15 @@ import { MorningState, Priority } from "./types";
 let _state: MorningState = {
   date: new Date().toISOString(),
   momentum: "steady",
-  note: "Price realization improved to 94% this month",
+  note: "",
   planLocked: false,
   priorities: [],
-  kpis: { pipelineDollars: 12000, winRatePct: 72, priceRealizationPct: 94, focusSessionsToday: 0 }
+  kpis: {
+    pipelineDollars: 0,
+    winRatePct: 0,
+    priceRealizationPct: 0,
+    focusSessionsToday: 0,
+  },
 };
 
 export function getMorning(): MorningState { return _state; }

--- a/supabase/functions/morning-brief/index.ts
+++ b/supabase/functions/morning-brief/index.ts
@@ -330,16 +330,7 @@ Deno.serve(async (req) => {
   const winRate = wins + losses === 0 ? 0 : wins / (wins + losses);
 
   const momentum = deriveMomentum(pipelineDelta, focusSessions ?? 0, winRate);
-  let priorities = selectTopPriorities({ pipeline: openData, clients: clientsData, projects: projectsData });
-  const fallbackPriorities = [
-    { title: "Review pipeline commitments", type: "Pipeline" },
-    { title: "Check finance run-rate", type: "Finance" },
-    { title: "Plan focus blocks", type: "Projects" },
-  ];
-  for (const fallback of fallbackPriorities) {
-    if (priorities.length >= 3) break;
-    priorities.push({ title: fallback.title, type: fallback.type });
-  }
+  const priorities = selectTopPriorities({ pipeline: openData, clients: clientsData, projects: projectsData });
 
   const response: MorningBriefSummary = {
     date: todayDate,


### PR DESCRIPTION
## Summary
- remove hard-coded Morning Brief content and derive sections from the day’s generated plan data
- clear the local fallback state and Supabase function defaults so no dummy priorities appear by default

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eae3531e708324aa10d2c8a05de687