### PR TITLE
feat: productionize clients flow

### DIFF
--- a/app/clients/ClientsSearch.tsx
+++ b/app/clients/ClientsSearch.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Input } from "@/ui/input";
+
+export function ClientsSearch({ initialValue }: { initialValue: string }) {
+  const [value, setValue] = useState(initialValue);
+  const router = useRouter();
+  const params = useSearchParams();
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const next = new URLSearchParams(params.toString());
+      if (value) {
+        next.set("q", value);
+      } else {
+        next.delete("q");
+      }
+      router.replace(next.size ? `/clients?${next.toString()}` : "/clients");
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [value, router, params]);
+
+  return (
+    <Input
+      className="w-64"
+      placeholder="Search clients"
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+    />
+  );
+}

--- a/app/clients/[id]/actions.ts
+++ b/app/clients/[id]/actions.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createServerClient } from "@/lib/supabase/server";
+
+export async function ensureOnboarding(clientId: string) {
+  const supabase = createServerClient()
+  const { error } = await supabase.rpc("rpc_ensure_client_onboarding", {
+    p_client_id: clientId,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/clients/${clientId}`)
+}
+
+export async function setClientPhase(
+  clientId: string,
+  phase: "Onboarding" | "Active"
+) {
+  const supabase = createServerClient()
+  const { error } = await supabase
+    .from("clients")
+    .update({ phase, updated_at: new Date().toISOString() })
+    .eq("id", clientId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/clients/${clientId}`)
+  revalidatePath("/clients")
+}

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -1,29 +1,333 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import ClientDetailView from "./ClientDetailView";
-import { actionGetClient, actionListClientFinancials, actionListDeliverables } from "@/core/clients/actions";
-import { getProjectsByClient } from "@/core/projects/store";
+import { ensureOnboarding, setClientPhase } from "./actions";
+import { createServerClient } from "@/lib/supabase/server";
+import { Button } from "@/ui/button";
+import { Card, CardContent } from "@/ui/card";
 
-export default async function ClientPage({ params }: { params: { id: string } }) {
-  // Fetch client from Supabase
-  const client = await actionGetClient(params.id);
+const TAB_ITEMS = [
+  { key: "overview", label: "Overview" },
+  { key: "deliverables", label: "Deliverables" },
+  { key: "finance", label: "Finance" },
+  { key: "onboarding", label: "Onboarding" },
+];
+
+const DEFAULT_DELIVERABLES = [
+  "Executive Dashboard",
+  "Operating KPIs",
+  "Quarterly Review",
+];
+
+export default async function ClientPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams?: { tab?: string };
+}) {
+  const supabase = createServerClient();
+  const activeTab = (searchParams?.tab ?? "overview").toLowerCase();
+
+  const { data: client, error: clientError } = await supabase
+    .from("clients")
+    .select(
+      "*, owner:users!clients_owner_id_fkey(name, email)"
+    )
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (clientError) {
+    throw clientError;
+  }
 
   if (!client) {
     notFound();
   }
 
-  const projects = getProjectsByClient(params.id);
-  const [deliverables, financials] = await Promise.all([
-    actionListDeliverables(params.id),
-    actionListClientFinancials(params.id),
-  ]);
+  const [{ data: projects }, { data: deliverables }, { data: finance }, { data: events }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select("id, name, status, phase, health, progress, updated_at")
+        .eq("client_id", client.id)
+        .order("updated_at", { ascending: false }),
+      supabase
+        .from("client_deliverables")
+        .select("id, title, type, status, url, created_at")
+        .eq("client_id", client.id)
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("finance")
+        .select("id, monthly_recurring_revenue, outstanding_invoices, updated_at")
+        .eq("client_id", client.id)
+        .maybeSingle(),
+      supabase
+        .from("analytics_events")
+        .select("id, event_type, created_at, metadata")
+        .eq("entity_type", "client")
+        .eq("entity_id", client.id)
+        .order("created_at", { ascending: false })
+        .limit(5),
+    ]);
+
+  const projectList = projects ?? [];
+  const deliverableList = deliverables ?? [];
+  const financeRow = finance ?? null;
+  const eventList = events ?? [];
+
+  const hasImplementationProject = projectList.some(
+    (project) => project.name === "RevOS Implementation"
+  );
+  const deliverableTitles = new Set(deliverableList.map((d) => d.title));
+  const hasDefaultDeliverables = DEFAULT_DELIVERABLES.every((name) =>
+    deliverableTitles.has(name)
+  );
+  const hasOwner = Boolean(client.owner_id);
+  const hasQbrDate = Boolean(client.qbr_date);
+
+  const startOnboarding = async () => {
+    "use server";
+    await ensureOnboarding(params.id);
+    await setClientPhase(params.id, "Onboarding");
+  };
+
+  const markComplete = async () => {
+    "use server";
+    await setClientPhase(params.id, "Active");
+  };
 
   return (
-    <ClientDetailView
-      client={client}
-      projects={projects}
-      deliverables={deliverables}
-      financials={financials}
-    />
+    <div className="min-h-screen bg-white text-black">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
+        <header className="space-y-1">
+          <p className="text-[11px] uppercase tracking-wide text-gray-500">Client Profile</p>
+          <h1 className="text-2xl font-semibold text-black">{client.name}</h1>
+          <p className="text-sm text-gray-600">
+            {client.segment ?? "Segment unknown"} • Owner {client.owner?.name ?? "Unassigned"}
+          </p>
+        </header>
+
+        <nav className="flex items-center gap-2 text-sm">
+          {TAB_ITEMS.map((tab) => {
+            const paramsCopy = new URLSearchParams(searchParams as Record<string, string> ?? {});
+            if (tab.key === "overview") {
+              paramsCopy.delete("tab");
+            } else {
+              paramsCopy.set("tab", tab.key);
+            }
+            const href = paramsCopy.size
+              ? `/clients/${client.id}?${paramsCopy.toString()}`
+              : `/clients/${client.id}`;
+            const isActive = activeTab === tab.key;
+            return (
+              <Link
+                key={tab.key}
+                href={href}
+                className={`rounded-full border px-3 py-1 transition ${
+                  isActive
+                    ? "border-gray-900 bg-gray-900 text-white"
+                    : "border-gray-300 bg-white text-gray-600 hover:border-gray-400"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <Card className="border-gray-200 lg:col-span-2">
+            <CardContent className="space-y-3 p-4">
+              <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
+                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
+                  Phase {client.phase ?? "—"}
+                </span>
+                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
+                  Status {client.status ?? "—"}
+                </span>
+                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
+                  ARR ${client.arr ? client.arr.toLocaleString() : "0"}
+                </span>
+                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
+                  Health {client.health ?? "—"}
+                </span>
+              </div>
+              <div className="text-sm text-gray-600">
+                {client.notes ??
+                  "Command center for deliverables, analytics, and onboarding milestones."}
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-gray-200">
+            <CardContent className="space-y-2 p-4">
+              <h2 className="text-sm font-semibold text-black">Recent Activity</h2>
+              <ul className="space-y-2 text-sm text-gray-700">
+                {eventList.length === 0 && (
+                  <li className="text-gray-500">No analytics events yet.</li>
+                )}
+                {eventList.map((event) => (
+                  <li key={event.id} className="flex justify-between">
+                    <span className="font-medium text-black">{event.event_type}</span>
+                    <span className="text-xs text-gray-500">
+                      {event.created_at ? new Date(event.created_at).toLocaleDateString() : "—"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </section>
+
+        {activeTab === "deliverables" && (
+          <Card className="border-gray-200">
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-sm font-semibold text-black">Deliverables</h2>
+                <Button variant="outline" size="sm">
+                  New Deliverable
+                </Button>
+              </div>
+              <div className="mt-4 space-y-3">
+                {deliverableList.length === 0 ? (
+                  <p className="text-sm text-gray-500">No deliverables yet.</p>
+                ) : (
+                  deliverableList.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white p-3 text-sm"
+                    >
+                      <div>
+                        <div className="font-medium text-black">{item.title}</div>
+                        <div className="text-xs text-gray-500">
+                          {item.status ?? "Planned"} • {item.type ?? "dashboard"}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button variant="outline" size="sm" disabled={!item.url}>
+                          Open
+                        </Button>
+                        <Button variant="ghost" size="sm">
+                          Edit
+                        </Button>
+                        <Button variant="ghost" size="sm">
+                          Share
+                        </Button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTab === "finance" && (
+          <Card className="border-gray-200">
+            <CardContent className="space-y-4 p-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-sm font-semibold text-black">Finance Summary</h2>
+                <Button variant="outline" size="sm">
+                  Create invoice
+                </Button>
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <Metric label="MRR" value={`$${(financeRow?.monthly_recurring_revenue ?? 0).toLocaleString()}`} />
+                <Metric label="Outstanding" value={`$${(financeRow?.outstanding_invoices ?? 0).toLocaleString()}`} />
+                <Metric label="Updated" value={financeRow?.updated_at ? new Date(financeRow.updated_at).toLocaleDateString() : "—"} />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTab === "onboarding" && (
+          <Card className="border-gray-200">
+            <CardContent className="space-y-4 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold text-black">Onboarding Checklist</h2>
+                {client.phase !== "Onboarding" ? (
+                  <form action={startOnboarding}>
+                    <Button type="submit" size="sm" variant="outline">
+                      Start Onboarding
+                    </Button>
+                  </form>
+                ) : (
+                  <form action={markComplete}>
+                    <Button type="submit" size="sm" variant="outline">
+                      Mark Complete
+                    </Button>
+                  </form>
+                )}
+              </div>
+              <ul className="space-y-3 text-sm text-gray-700">
+                <ChecklistItem label="RevOS Implementation project" complete={hasImplementationProject} />
+                <ChecklistItem label="Default deliverables created" complete={hasDefaultDeliverables} />
+                <ChecklistItem label="Client owner assigned" complete={hasOwner} />
+                <ChecklistItem label="First QBR scheduled" complete={hasQbrDate} />
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTab === "overview" && (
+          <Card className="border-gray-200">
+            <CardContent className="grid gap-4 p-4 md:grid-cols-2">
+              <div className="space-y-3">
+                <h2 className="text-sm font-semibold text-black">Projects</h2>
+                <div className="space-y-2 text-sm text-gray-700">
+                  {projectList.length === 0 ? (
+                    <p className="text-gray-500">No active projects yet.</p>
+                  ) : (
+                    projectList.slice(0, 4).map((project) => (
+                      <div key={project.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                        <div className="font-medium text-black">{project.name}</div>
+                        <div className="text-xs text-gray-500">
+                          {project.status} • {project.phase ?? "Discovery"} • Health {project.health ?? "—"}
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+              <div className="space-y-3">
+                <h2 className="text-sm font-semibold text-black">Deliverables</h2>
+                <div className="space-y-2 text-sm text-gray-700">
+                  {deliverableList.length === 0 ? (
+                    <p className="text-gray-500">No deliverables yet.</p>
+                  ) : (
+                    deliverableList.slice(0, 4).map((deliverable) => (
+                      <div key={deliverable.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                        <div className="font-medium text-black">{deliverable.title}</div>
+                        <div className="text-xs text-gray-500">
+                          {deliverable.status ?? "Planned"} • {deliverable.type ?? "dashboard"}
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-[11px] text-gray-500">{label}</div>
+      <div className="text-lg font-semibold text-black">{value}</div>
+    </div>
+  );
+}
+
+function ChecklistItem({ label, complete }: { label: string; complete: boolean }) {
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3">
+      <span className="text-lg">{complete ? "✅" : "○"}</span>
+      <span className="text-sm text-gray-700">{label}</span>
+    </li>
   );
 }

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,860 +1,188 @@
-"use client";
+import Link from "next/link";
 
-import { useCallback, useMemo, useState, useTransition } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { createServerClient } from "@/lib/supabase/server";
+import { ClientsSearch } from "./ClientsSearch";
 
-import { PageTabs } from "@/components/layout/PageTabs";
-import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/ui/card";
-import { Input } from "@/ui/input";
-import { PageDescription, PageTitle } from "@/ui/page-header";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/ui/table";
-import { cn } from "@/lib/utils";
-import { TRS_CARD, TRS_SECTION_TITLE, TRS_SUBTITLE } from "@/lib/style";
-import { resolveTabs } from "@/lib/tabs";
-import { syncClientHealth } from "@/core/clients/actions";
-import { getClients, getClientStats } from "@/core/clients/store";
-
-const healthLabel = (value: number) => {
-  if (value >= 80) return { label: "Healthy", tone: "success" as const };
-  if (value >= 60) return { label: "Monitoring", tone: "default" as const };
-  return { label: "At risk", tone: "outline" as const };
-};
-
-const formatCurrency = (value?: number) =>
-  value != null ? `$${value.toLocaleString()}` : "—";
-
-export default function ClientsPage() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
-  const activeTab = useMemo(() => {
-    const current = searchParams.get("tab");
-    return current && tabs.includes(current) ? current : tabs[0];
-  }, [searchParams, tabs]);
-
-  const buildTabHref = useCallback(
-    (tab: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("tab", tab);
-      return `${pathname}?${params.toString()}`;
-    },
-    [pathname, searchParams],
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-[11px] text-gray-500">{label}</div>
+      <div className="text-2xl font-semibold text-black">{value}</div>
+    </div>
   );
+}
 
-  const router = useRouter();
-  const [syncMessage, setSyncMessage] = useState<string | null>(null);
-  const [syncPending, startSync] = useTransition();
-  const clients = useMemo(() => getClients(), []);
-  const stats = useMemo(() => getClientStats(), []);
+export default async function ClientsPage({
+  searchParams,
+}: {
+  searchParams?: { q?: string; phase?: string };
+}) {
+  const supabase = createServerClient();
+  const search = searchParams?.q?.trim() ?? "";
+  const phaseFilter = (searchParams?.phase ?? "all").toLowerCase();
 
-  const [search, setSearch] = useState("");
-  const [segmentFilter, setSegmentFilter] = useState("all");
-  const [ownerFilter, setOwnerFilter] = useState("all");
-  const [sortBy, setSortBy] = useState("arr-desc");
+  let query = supabase
+    .from("clients")
+    .select(
+      "id, name, status, phase, owner_id, arr, health, created_at, owner:users!clients_owner_id_fkey(name)"
+    )
+    .order("created_at", { ascending: false })
+    .limit(200);
 
-  const segments = useMemo(
-    () => Array.from(new Set(clients.map((client) => client.segment))),
-    [clients],
-  );
-  const owners = useMemo(
-    () => Array.from(new Set(clients.map((client) => client.owner))),
-    [clients],
-  );
+  if (search) {
+    const pattern = `%${search.replace(/%/g, "\\%")}%`;
+    query = query.or(
+      `name.ilike.${pattern},industry.ilike.${pattern},region.ilike.${pattern}`
+    );
+  }
+
+  const { data: clientsData, error } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  const clients = (clientsData ?? []).filter((client) => {
+    if (phaseFilter === "onboarding") {
+      return client.phase === "Onboarding";
+    }
+    if (phaseFilter === "active") {
+      return client.status === "active";
+    }
+    if (phaseFilter === "churned") {
+      return client.status === "churned";
+    }
+    return true;
+  });
+
+  const ids = clients.map((c) => c.id);
+  const overviewMap = new Map<string, any>();
+
+  if (ids.length) {
+    const { data: overviewRows } = await supabase
+      .from("vw_client_overview")
+      .select("client_id, pipeline_stage, pipeline_value, weighted_value, probability, mrr, ar_outstanding")
+      .in("client_id", ids);
+
+    overviewRows?.forEach((row) => {
+      overviewMap.set(row.client_id, row);
+    });
+  }
 
   const totalArr = clients.reduce((sum, client) => sum + (client.arr ?? 0), 0);
-  const expansionPipeline = clients.reduce(
-    (sum, client) =>
-      sum +
-      client.opportunities.reduce(
-        (value, opportunity) => value + (opportunity.amount ?? 0),
-        0,
-      ),
-    0,
-  );
-  const upcomingQbrs = clients
-    .filter((client) => client.qbrDate)
-    .sort(
-      (a, b) =>
-        new Date(a.qbrDate ?? "").getTime() -
-        new Date(b.qbrDate ?? "").getTime(),
-    );
-  const outstandingInvoices = clients.flatMap(
-    (client) =>
-      client.invoices
-        ?.filter((invoice) => invoice.status !== "Paid")
-        .map((invoice) => ({
-          ...invoice,
-          clientName: client.name,
-          clientId: client.id,
-        })) ?? [],
-  );
-
-  const filteredClients = useMemo(() => {
-    let list = clients;
-
-    if (search.trim()) {
-      const term = search.trim().toLowerCase();
-      list = list.filter(
-        (client) =>
-          client.name.toLowerCase().includes(term) ||
-          (client.industry ?? "").toLowerCase().includes(term) ||
-          (client.owner ?? "").toLowerCase().includes(term),
-      );
-    }
-
-    if (segmentFilter !== "all") {
-      list = list.filter((client) => client.segment === segmentFilter);
-    }
-
-    if (ownerFilter !== "all") {
-      list = list.filter((client) => client.owner === ownerFilter);
-    }
-
-    return [...list].sort((a, b) => {
-      switch (sortBy) {
-        case "arr-asc":
-          return (a.arr ?? 0) - (b.arr ?? 0);
-        case "health-desc":
-          return (b.health ?? 0) - (a.health ?? 0);
-        case "health-asc":
-          return (a.health ?? 0) - (b.health ?? 0);
-        case "name-asc":
-          return a.name.localeCompare(b.name);
-        case "name-desc":
-          return b.name.localeCompare(a.name);
-        default:
-          return (b.arr ?? 0) - (a.arr ?? 0);
-      }
-    });
-  }, [clients, search, segmentFilter, ownerFilter, sortBy]);
-
-  const dataCoverage = useMemo(() => {
-    const totals = { collected: 0, available: 0, missing: 0 };
-    clients.forEach((client) => {
-      client.data.forEach((source) => {
-        if (source.status === "Collected") totals.collected += 1;
-        else if (source.status === "Available") totals.available += 1;
-        else totals.missing += 1;
-      });
-    });
-    return totals;
-  }, [clients]);
-
-  const churnSignals = useMemo(
-    () => clients.filter((client) => (client.churnRisk ?? 0) >= 15),
-    [clients],
-  );
+  const avgHealth = clients.length
+    ? Math.round(
+        clients.reduce((sum, client) => sum + (client.health ?? 0), 0) /
+          clients.length,
+      )
+    : 0;
+  const onboardingCount = clients.filter((client) => client.phase === "Onboarding").length;
 
   return (
-    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
-      <section className="space-y-3">
-        <div className="space-y-1">
-          <PageTitle className="text-xl font-semibold text-black">
-            Client Portfolio
-          </PageTitle>
-          <PageDescription className="text-sm text-gray-500">
-            Full-funnel visibility into active customers, health trends, and
-            expansion momentum across TRS RevenueOS.
-          </PageDescription>
+    <div className="min-h-screen bg-white text-black">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold text-black">Clients</h1>
+          <p className="text-sm text-gray-600">
+            Production view of customers and onboarding progress powered by Supabase.
+          </p>
+        </header>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm">
+            {[
+              { label: "All", value: "all" },
+              { label: "Onboarding", value: "onboarding" },
+              { label: "Active", value: "active" },
+              { label: "Churned", value: "churned" },
+            ].map((tab) => {
+              const isActive = phaseFilter === tab.value;
+              const params = new URLSearchParams(searchParams as Record<string, string> ?? {});
+              if (tab.value === "all") {
+                params.delete("phase");
+              } else {
+                params.set("phase", tab.value);
+              }
+              const href = params.size ? `/clients?${params.toString()}` : "/clients";
+
+              return (
+                <Link
+                  key={tab.value}
+                  href={href}
+                  className={`rounded-full border px-3 py-1 transition ${
+                    isActive
+                      ? "border-gray-900 bg-gray-900 text-white"
+                      : "border-gray-300 bg-white text-gray-600 hover:border-gray-400"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+          <ClientsSearch initialValue={search} />
         </div>
 
-        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
-
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
-          <Card className={cn(TRS_CARD)}>
-            <CardContent className="p-4 space-y-2">
-              <div className={TRS_SUBTITLE}>Portfolio ARR</div>
-              <div className="text-2xl font-semibold text-black">
-                {formatCurrency(totalArr)}
-              </div>
-              <div className="text-xs text-gray-600">
-                Across {clients.length} active clients
-              </div>
-            </CardContent>
-          </Card>
-          <Card className={cn(TRS_CARD)}>
-            <CardContent className="p-4 space-y-2">
-              <div className={TRS_SUBTITLE}>Average Health</div>
-              <div className="text-2xl font-semibold text-black">
-                {stats.avgHealth}%
-              </div>
-              <div className="text-xs text-gray-600">
-                {stats.atRisk} accounts monitored closely
-              </div>
-            </CardContent>
-          </Card>
-          <Card className={cn(TRS_CARD)}>
-            <CardContent className="p-4 space-y-2">
-              <div className={TRS_SUBTITLE}>Expansion Pipeline</div>
-              <div className="text-2xl font-semibold text-black">
-                {formatCurrency(expansionPipeline)}
-              </div>
-              <div className="text-xs text-gray-600">
-                {stats.expansions} active expansion motions
-              </div>
-            </CardContent>
-          </Card>
-          <Card className={cn(TRS_CARD)}>
-            <CardContent className="p-4 space-y-2">
-              <div className={TRS_SUBTITLE}>Upcoming QBRs</div>
-              <div className="text-2xl font-semibold text-black">
-                {upcomingQbrs.slice(0, 3).length}
-              </div>
-              <div className="text-xs text-gray-600">
-                within the next 45 days
-              </div>
-            </CardContent>
-          </Card>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <SummaryCard label="Total ARR" value={`$${totalArr.toLocaleString()}`} />
+          <SummaryCard label="Average Health" value={`${avgHealth}%`} />
+          <SummaryCard label="Onboarding" value={`${onboardingCount}`} />
         </div>
 
-        {activeTab === "Overview" && (
-          <div className="space-y-4">
-            <Card className={cn(TRS_CARD, "p-4 space-y-4")}>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div className="space-y-1">
-                  <PageTitle className="text-lg font-semibold text-black">
-                    Customer Health Command Center
-                  </PageTitle>
-                  <PageDescription className="text-sm text-gray-500">
-                    Blend renewal signals, enablement gaps, and expansion bets
-                    into one decisive view.
-                  </PageDescription>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    disabled={syncPending}
-                    onClick={() =>
-                      startSync(async () => {
-                        const result = await syncClientHealth();
-                        setSyncMessage(
-                          result.ok
-                            ? `Health sync captured ${result.processed ?? 0} snapshots`
-                            : "Health sync failed"
-                        );
-                      })
-                    }
-                  >
-                    {syncPending ? "Syncing…" : "Run health sync"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => router.push("/partners")}
-                  >
-                    Sync partners
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => router.push("/projects")}
-                  >
-                    Open delivery board
-                  </Button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-                <div className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className={TRS_SECTION_TITLE}>Health spotlight</div>
-                  {syncMessage ? (
-                    <div className="mt-2 text-xs text-gray-500">{syncMessage}</div>
-                  ) : null}
-                  <ul className="mt-3 space-y-2 text-sm text-gray-700">
-                    {clients
-                      .slice()
-                      .sort((a, b) => (a.health ?? 0) - (b.health ?? 0))
-                      .slice(0, 3)
-                      .map((client) => (
-                        <li
-                          key={client.id}
-                          className="flex items-center justify-between"
-                        >
-                          <div>
-                            <div className="font-medium text-black">
-                              {client.name}
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              Owner {client.owner}
-                            </div>
-                          </div>
-                          <Badge variant={healthLabel(client.health ?? 0).tone}>
-                            {client.health}%
-                          </Badge>
-                        </li>
-                      ))}
-                  </ul>
-                </div>
-                <div className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className={TRS_SECTION_TITLE}>Next 30 days</div>
-                  <ul className="mt-3 space-y-2 text-sm text-gray-700">
-                    {upcomingQbrs.slice(0, 4).map((client) => (
-                      <li
-                        key={client.id}
-                        className="flex items-center justify-between"
-                      >
-                        <div>
-                          <div className="font-medium text-black">
-                            {client.name}
-                          </div>
-                          <div className="text-xs text-gray-500">
-                            QBR • {client.phase}
-                          </div>
-                        </div>
-                        <span className="text-xs text-gray-600">
-                          {new Date(client.qbrDate ?? "").toLocaleDateString(
-                            "en-US",
-                            { month: "short", day: "numeric" },
-                          )}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="rounded-lg border border-gray-200 bg-white p-3">
-                  <div className={TRS_SECTION_TITLE}>Expansion focus</div>
-                  <div className="mt-3 space-y-2 text-sm text-gray-700">
-                    {clients
-                      .filter((client) => client.isExpansion)
-                      .slice(0, 3)
-                      .map((client) => (
-                        <div
-                          key={client.id}
-                          className="flex items-center justify-between"
-                        >
-                          <div>
-                            <div className="font-medium text-black">
-                              {client.name}
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              {client.opportunities[0]?.stage ?? "Discovery"} •{" "}
-                              {client.opportunities[0]?.name ?? "Expansion"}
-                            </div>
-                          </div>
-                          <span className="text-xs text-gray-600">
-                            {formatCurrency(client.opportunities[0]?.amount)}
-                          </span>
-                        </div>
-                      ))}
-                  </div>
-                </div>
-              </div>
-            </Card>
-
-            <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-              <Card className={cn(TRS_CARD)}>
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    Outstanding invoices
-                  </CardTitle>
-                  <CardDescription>
-                    Cash flow watchlist across the portfolio.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  {outstandingInvoices.length === 0 ? (
-                    <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-600">
-                      No invoices outstanding.
-                    </div>
-                  ) : (
-                    outstandingInvoices.map((invoice) => (
-                      <div
-                        key={invoice.id}
-                        className="rounded-lg border border-gray-200 bg-white p-3"
-                      >
-                        <div className="flex items-center justify-between text-sm">
-                          <span className="font-semibold text-black">
-                            {invoice.clientName}
-                          </span>
-                          <span className="text-xs text-gray-500">
-                            {invoice.status}
-                          </span>
-                        </div>
-                        <div className="mt-1 text-xs text-gray-500">
-                          Invoice {invoice.id}
-                        </div>
-                        <div className="mt-2 flex items-center justify-between text-sm text-gray-700">
-                          <span>{formatCurrency(invoice.amount)}</span>
-                          {invoice.dueAt && (
-                            <span>
-                              Due{" "}
-                              {new Date(invoice.dueAt).toLocaleDateString(
-                                "en-US",
-                                { month: "short", day: "numeric" },
-                              )}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    ))
-                  )}
-                </CardContent>
-              </Card>
-
-              <Card className={cn(TRS_CARD)}>
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    Data coverage
-                  </CardTitle>
-                  <CardDescription>
-                    Ensure every client powers the RevOS decision loop.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-3">
-                    {["collected", "available", "missing"].map((band) => (
-                      <div key={band} className="flex items-center gap-3">
-                        <div className="w-20 text-xs font-semibold uppercase text-gray-400">
-                          {band}
-                        </div>
-                        <div className="flex-1">
-                          <div className="h-2 rounded-full bg-gray-100">
-                            <div
-                              className={`h-full ${
-                                band === "collected"
-                                  ? "bg-gray-900"
-                                  : band === "available"
-                                    ? "bg-gray-700"
-                                    : "bg-gray-500"
-                              }`}
-                              style={{
-                                width: `${
-                                  dataCoverage.collected +
-                                  dataCoverage.available +
-                                  dataCoverage.missing
-                                    ? (dataCoverage[
-                                        band as keyof typeof dataCoverage
-                                      ] /
-                                        (dataCoverage.collected +
-                                          dataCoverage.available +
-                                          dataCoverage.missing)) *
-                                      100
-                                    : 0
-                                }%`,
-                              }}
-                            />
-                          </div>
-                        </div>
-                        <div className="w-10 text-right text-xs text-gray-500">
-                          {dataCoverage[band as keyof typeof dataCoverage]}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                  <p className="text-sm text-gray-600">
-                    Rally data integrations ahead of QBRs so every renewal
-                    conversation is grounded in performance proof.
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        )}
-
-        {activeTab === "Accounts" && (
-          <Card className={cn(TRS_CARD)}>
-            <CardHeader>
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                <div>
-                  <CardTitle>Client accounts</CardTitle>
-                  <CardDescription>
-                    Sort by health, ARR, or owner to plan your touchpoints.
-                  </CardDescription>
-                </div>
-                <div className="flex flex-col gap-2 md:flex-row md:items-center">
-                  <Input
-                    value={search}
-                    onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Search by name, owner, or industry"
-                    className="h-9 md:w-72"
-                  />
-                  <div className="flex flex-wrap items-center gap-2">
-                    <select
-                      value={segmentFilter}
-                      onChange={(event) => setSegmentFilter(event.target.value)}
-                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                    >
-                      <option value="all">All Segments</option>
-                      {segments.map((segment) => (
-                        <option key={segment} value={segment}>
-                          {segment}
-                        </option>
-                      ))}
-                    </select>
-                    <select
-                      value={ownerFilter}
-                      onChange={(event) => setOwnerFilter(event.target.value)}
-                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                    >
-                      <option value="all">All Owners</option>
-                      {owners.map((owner) => (
-                        <option key={owner} value={owner}>
-                          {owner}
-                        </option>
-                      ))}
-                    </select>
-                    <select
-                      value={sortBy}
-                      onChange={(event) => setSortBy(event.target.value)}
-                      className="h-9 rounded-md border border-gray-200 bg-white px-3 text-sm"
-                    >
-                      <option value="arr-desc">ARR (High to Low)</option>
-                      <option value="arr-asc">ARR (Low to High)</option>
-                      <option value="health-desc">Health (High to Low)</option>
-                      <option value="health-asc">Health (Low to High)</option>
-                      <option value="name-asc">Name (A-Z)</option>
-                      <option value="name-desc">Name (Z-A)</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="overflow-hidden">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Client</TableHead>
-                    <TableHead>Owner</TableHead>
-                    <TableHead>Segment</TableHead>
-                    <TableHead>Phase</TableHead>
-                    <TableHead className="text-right">ARR</TableHead>
-                    <TableHead className="text-right">Health</TableHead>
-                    <TableHead className="text-right">Churn Risk</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredClients.map((client) => (
-                    <TableRow
-                      key={client.id}
-                      className="cursor-pointer transition hover:bg-gray-50"
-                      onClick={() => router.push(`/clients/${client.id}`)}
-                    >
-                      <TableCell>
-                        <div className="font-medium text-black">
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr className="text-left text-[12px] text-gray-500">
+                <th className="px-3 py-2">Client</th>
+                <th className="px-3 py-2">Phase</th>
+                <th className="px-3 py-2">Owner</th>
+                <th className="px-3 py-2">Pipeline Stage</th>
+                <th className="px-3 py-2">MRR</th>
+                <th className="px-3 py-2">ARR</th>
+                <th className="px-3 py-2">Health</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {clients.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
+                    No clients found. Close a deal from pipeline to see it here.
+                  </td>
+                </tr>
+              ) : (
+                clients.map((client) => {
+                  const overview = overviewMap.get(client.id);
+                  const ownerRecord = Array.isArray(client.owner)
+                    ? client.owner[0]
+                    : client.owner;
+                  const ownerName = ownerRecord?.name ?? client.owner_id ?? "—";
+                  return (
+                    <tr key={client.id} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 font-medium text-black">
+                        <Link href={`/clients/${client.id}`} className="hover:underline">
                           {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          {client.industry ?? "—"}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-sm text-gray-700">
-                        {client.owner}
-                      </TableCell>
-                      <TableCell className="text-sm text-gray-700">
-                        {client.segment}
-                      </TableCell>
-                      <TableCell className="text-sm text-gray-700">
-                        {client.phase}
-                      </TableCell>
-                      <TableCell className="text-right font-medium text-black">
-                        {formatCurrency(client.arr)}
-                      </TableCell>
-                      <TableCell className="text-right text-sm text-gray-700">
-                        {client.health}%
-                      </TableCell>
-                      <TableCell className="text-right text-sm text-gray-700">
-                        {client.churnRisk != null
-                          ? `${client.churnRisk}%`
-                          : "—"}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
-        )}
-
-        {activeTab === "Engagement" && (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Discovery & enablement
-                </CardTitle>
-                <CardDescription>
-                  Progress through the RevOS methodology.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-gray-700">
-                {clients.map((client) => (
-                  <div
-                    key={client.id}
-                    className="rounded-lg border border-gray-200 bg-white p-3"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="font-semibold text-black">
-                          {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Phase {client.phase}
-                        </div>
-                      </div>
-                      <Badge
-                        variant={
-                          client.discovery.some((qa) => qa.answer)
-                            ? "success"
-                            : "outline"
-                        }
-                      >
-                        {client.discovery.some((qa) => qa.answer)
-                          ? "In motion"
-                          : "Pending"}
-                      </Badge>
-                    </div>
-                    <div className="mt-2 text-xs text-gray-500">
-                      {client.discovery.filter((qa) => qa.answer).length}{" "}
-                      answered • {client.discovery.length} prompts
-                    </div>
-                    <div className="mt-2 text-xs text-gray-600">
-                      Top lever:{" "}
-                      {client.discovery.find((qa) => qa.answer)?.answer ??
-                        "To be defined"}
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Product adoption signals
-                </CardTitle>
-                <CardDescription>
-                  Key drivers fueling retention and growth.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-gray-700">
-                {clients.map((client) => (
-                  <div
-                    key={client.id}
-                    className="rounded-lg border border-gray-200 bg-white p-3"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="font-semibold text-black">
-                          {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Net new this quarter
-                        </div>
-                      </div>
-                      <span className="text-sm font-medium text-black">
-                        {formatCurrency(client.compounding?.netNew)}
-                      </span>
-                    </div>
-                    <div className="mt-2 text-xs text-gray-500">
-                      Baseline MRR{" "}
-                      {formatCurrency(client.compounding?.baselineMRR)} →
-                      Current {formatCurrency(client.compounding?.currentMRR)}
-                    </div>
-                    <ul className="mt-2 space-y-1 text-xs text-gray-600">
-                      {client.compounding?.drivers.map((driver) => (
-                        <li key={driver.name}>
-                          • {driver.name}: +{formatCurrency(driver.delta)}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {activeTab === "Renewals" && (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Renewal calendar
-                </CardTitle>
-                <CardDescription>
-                  QBRs and contract checkpoints on deck.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-gray-700">
-                {upcomingQbrs.map((client) => (
-                  <div
-                    key={client.id}
-                    className="rounded-lg border border-gray-200 bg-white p-3"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="font-semibold text-black">
-                          {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Owner {client.owner}
-                        </div>
-                      </div>
-                      <span className="text-xs text-gray-600">
-                        {new Date(client.qbrDate ?? "").toLocaleDateString(
-                          "en-US",
-                          { month: "short", day: "numeric" },
-                        )}
-                      </span>
-                    </div>
-                    <div className="mt-2 text-xs text-gray-500">
-                      Plan {client.commercials?.plan ?? "—"}
-                    </div>
-                    <div className="mt-2 text-xs text-gray-600">
-                      Next step:{" "}
-                      {client.opportunities[0]?.nextStep ?? "Confirm agenda"}
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Commercial posture
-                </CardTitle>
-                <CardDescription>
-                  Pricing, term, and approval guardrails at a glance.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-gray-700">
-                {clients.map((client) => (
-                  <div
-                    key={client.id}
-                    className="rounded-lg border border-gray-200 bg-white p-3"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="font-semibold text-black">
-                          {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Term {client.commercials?.termMonths ?? "—"} months
-                        </div>
-                      </div>
-                      <span className="text-xs text-gray-600">
-                        Discount {client.commercials?.discountPct ?? 0}%
-                      </span>
-                    </div>
-                    <div className="mt-2 text-xs text-gray-500">
-                      Approvals:{" "}
-                      {client.commercials?.approvals?.join(", ") ?? "N/A"}
-                    </div>
-                    <div className="mt-2 text-xs text-gray-600">
-                      Payment terms:{" "}
-                      {client.commercials?.paymentTerms ?? "Standard"}
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {activeTab === "Signals" && (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Churn watchlist
-                </CardTitle>
-                <CardDescription>
-                  Accounts requiring proactive outreach.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {churnSignals.length === 0 ? (
-                  <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-600">
-                    No high-risk accounts. Keep the momentum.
-                  </div>
-                ) : (
-                  churnSignals.map((client) => (
-                    <div
-                      key={client.id}
-                      className="rounded-lg border border-gray-200 bg-white p-3"
-                    >
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="font-semibold text-black">
-                          {client.name}
-                        </span>
-                        <Badge variant="outline">
-                          {client.churnRisk}% risk
-                        </Badge>
-                      </div>
-                      <div className="mt-1 text-xs text-gray-500">
-                        Owner {client.owner}
-                      </div>
-                      <div className="mt-2 text-xs text-gray-600">
-                        Latest note: {client.notes ?? "Schedule executive sync"}
-                      </div>
-                    </div>
-                  ))
-                )}
-              </CardContent>
-            </Card>
-
-            <Card className={cn(TRS_CARD)}>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Partner leverage
-                </CardTitle>
-                <CardDescription>
-                  Who can help reinforce retention stories.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-gray-700">
-                {clients.map((client) => (
-                  <div
-                    key={client.id}
-                    className="rounded-lg border border-gray-200 bg-white p-3"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="font-semibold text-black">
-                          {client.name}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Partners: {client.qra?.partners?.join(", ") ?? "TBD"}
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-7 px-3 text-xs"
-                        onClick={() => router.push(`/partners?tab=Directory`)}
-                      >
-                        Explore partners
-                      </Button>
-                    </div>
-                    <div className="mt-2 text-xs text-gray-600">
-                      Retention plays:{" "}
-                      {client.qra?.retention?.join(", ") ??
-                        "Add retention plan"}
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          </div>
-        )}
-      </section>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">{client.phase ?? "—"}</td>
+                      <td className="px-3 py-2 text-gray-700">{ownerName}</td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {overview?.pipeline_stage ?? "—"}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        ${overview?.mrr ? overview.mrr.toLocaleString() : "0"}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        ${client.arr ? client.arr.toLocaleString() : "0"}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">{client.health ?? "—"}</td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/pipeline/PipelineClient.tsx
+++ b/app/pipeline/PipelineClient.tsx
@@ -9,6 +9,7 @@ import { AddProspectModal } from "@/components/pipeline/AddProspectModal";
 import { ImportProspectsModal } from "@/components/pipeline/ImportProspectsModal";
 import { PipelineFilters } from "@/components/pipeline/PipelineFilters";
 import { PipelineKanban } from "@/components/pipeline/PipelineKanban";
+import { markClosedWon } from "@/app/pipeline/actions";
 import type { OpportunityWithNotes } from "@/core/pipeline/actions";
 import { syncPipelineAnalytics } from "@/core/pipeline/actions";
 import { Badge } from "@/ui/badge";
@@ -42,6 +43,20 @@ export default function PipelineClient({
     useState<OpportunityWithNotes[]>(opportunities);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [syncPending, startSync] = useTransition();
+  const sampleOpportunity = useMemo(
+    () => opportunities.find((opp) => opp.stage !== "ClosedWon" && opp.stage !== "ClosedLost"),
+    [opportunities],
+  );
+  const sampleClosedWonAction = useMemo(
+    () =>
+      sampleOpportunity
+        ? markClosedWon.bind(null, {
+            pipelineId: undefined,
+            opportunityId: sampleOpportunity.id,
+          })
+        : null,
+    [sampleOpportunity],
+  );
 
   const handleSync = () => {
     startSync(async () => {
@@ -208,6 +223,13 @@ export default function PipelineClient({
           >
             {syncPending ? "Syncing…" : "Sync analytics"}
           </Button>
+          {sampleClosedWonAction ? (
+            <form action={sampleClosedWonAction} className="inline-flex">
+              <Button variant="outline" size="sm" type="submit">
+                Playground: Closed Won
+              </Button>
+            </form>
+          ) : null}
           <Button variant="outline" size="sm" onClick={handleOpenImport}>
             Import CSV
           </Button>

--- a/app/pipeline/actions.ts
+++ b/app/pipeline/actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { createServerClient } from "@/lib/supabase/server";
+
+export async function markClosedWon({
+  pipelineId,
+  opportunityId,
+}: {
+  pipelineId?: string
+  opportunityId?: string
+}) {
+  const supabase = createServerClient()
+  const { data, error } = await supabase.rpc("rpc_convert_won_to_client", {
+    p_pipeline_id: pipelineId ?? null,
+    p_opportunity_id: opportunityId ?? null,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  redirect(`/clients/${data}`)
+}

--- a/components/pipeline/DealDetailModal.tsx
+++ b/components/pipeline/DealDetailModal.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/ui/card";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Badge } from "@/ui/badge";
+import { markClosedWon } from "@/app/pipeline/actions";
 import {
   updateOpportunity,
   deleteOpportunity,
@@ -107,6 +108,11 @@ export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps)
     });
   };
 
+  const markClosedWonAction = markClosedWon.bind(null, {
+    opportunityId: deal.id,
+    pipelineId: undefined,
+  });
+
   const getDaysInStage = () => {
     const updated = new Date(deal.updated_at);
     const now = new Date();
@@ -147,9 +153,16 @@ export function DealDetailModal({ deal, onClose, userId }: DealDetailModalProps)
                 <span>{getDaysInStage()} days in stage</span>
               </div>
             </div>
-            <Button variant="ghost" size="sm" onClick={onClose} disabled={isPending}>
-              ✕
-            </Button>
+            <div className="flex items-center gap-2">
+              <form action={markClosedWonAction}>
+                <Button type="submit" size="sm" variant="primary">
+                  Mark Closed Won
+                </Button>
+              </form>
+              <Button variant="ghost" size="sm" onClick={onClose} disabled={isPending}>
+                ✕
+              </Button>
+            </div>
           </div>
 
           {/* Main Content Grid */}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,29 +1,35 @@
-import { createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import { createServerClient as createSupabaseServerClient } from '@supabase/ssr'
+import { cookies, headers } from 'next/headers'
+
+export function createServerClient() {
+  const cookieStore = cookies()
+  const headerStore = headers()
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+  return createSupabaseServerClient(url, anon, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options)
+          })
+        } catch (error) {
+          // Server Components cannot set cookies directly; middleware will refresh sessions.
+        }
+      },
+    },
+    global: {
+      headers: {
+        'x-trs-host': headerStore.get('host') ?? '',
+      },
+    },
+  })
+}
 
 export async function createClient() {
-  const cookieStore = await cookies()
-
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll()
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options)
-            })
-          } catch (error) {
-            // The `set` method was called from a Server Component.
-            // This can be ignored if you have middleware refreshing
-            // user sessions.
-          }
-        },
-      },
-    }
-  )
+  return createServerClient()
 }

--- a/supabase/sql/clients/001_rpc_convert_won_to_client.sql
+++ b/supabase/sql/clients/001_rpc_convert_won_to_client.sql
@@ -1,0 +1,256 @@
+-- Ensure client phase supports onboarding lifecycle
+ALTER TABLE public.clients
+  DROP CONSTRAINT IF EXISTS clients_phase_check;
+ALTER TABLE public.clients
+  ADD CONSTRAINT clients_phase_check
+  CHECK (
+    phase IS NULL
+    OR phase IN (
+      'Discovery',
+      'Data',
+      'Algorithm',
+      'Architecture',
+      'Compounding',
+      'Onboarding',
+      'Active'
+    )
+  );
+
+-- Allow projects table to store planned onboarding workstreams
+ALTER TABLE public.projects
+  DROP CONSTRAINT IF EXISTS projects_status_check;
+ALTER TABLE public.projects
+  ADD CONSTRAINT projects_status_check
+  CHECK (
+    status IN ('Planned', 'Active', 'On Hold', 'Completed', 'Cancelled')
+  );
+
+ALTER TABLE public.projects
+  DROP CONSTRAINT IF EXISTS projects_health_check;
+ALTER TABLE public.projects
+  ADD CONSTRAINT projects_health_check
+  CHECK (
+    health IS NULL
+    OR health IN ('green', 'yellow', 'red', 'Green')
+  );
+
+-- Create client deliverables table if missing
+CREATE TABLE IF NOT EXISTS public.client_deliverables (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id UUID NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  type TEXT DEFAULT 'dashboard',
+  url TEXT,
+  status TEXT DEFAULT 'Planned',
+  meta JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_deliverables_client
+  ON public.client_deliverables(client_id);
+
+CREATE OR REPLACE FUNCTION public.rpc_convert_won_to_client(
+  p_pipeline_id UUID,
+  p_opportunity_id UUID DEFAULT NULL
+) RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public
+AS $$
+DECLARE
+  v_client_id UUID;
+  v_client record;
+  v_pipeline record;
+  v_opportunity record;
+  v_owner_id UUID;
+  v_org_id UUID;
+  v_client_name TEXT;
+  v_source TEXT := NULL;
+  v_source_id UUID := NULL;
+  v_project_id UUID;
+  v_finance_id UUID;
+  v_has_deliverables BOOLEAN;
+  v_now TIMESTAMPTZ := timezone('utc', now());
+  v_metadata JSONB;
+  v_default_deliverables CONSTANT TEXT[] := ARRAY[
+    'Executive Dashboard',
+    'Operating KPIs',
+    'Quarterly Review'
+  ];
+BEGIN
+  IF p_opportunity_id IS NOT NULL THEN
+    SELECT
+      o.*,
+      c.id AS existing_client_id,
+      c.owner_id AS existing_owner_id,
+      c.name AS existing_client_name,
+      u.organization_id
+    INTO v_opportunity
+    FROM public.opportunities o
+    LEFT JOIN public.clients c ON c.id = o.client_id
+    LEFT JOIN public.users u ON u.id = o.owner_id
+    WHERE o.id = p_opportunity_id;
+
+    IF FOUND THEN
+      v_source := 'opportunities';
+      v_source_id := v_opportunity.id;
+      v_client_id := v_opportunity.existing_client_id;
+      v_owner_id := COALESCE(v_opportunity.existing_owner_id, v_opportunity.owner_id);
+      v_org_id := v_opportunity.organization_id;
+      v_client_name := COALESCE(v_opportunity.existing_client_name, v_opportunity.company, v_opportunity.name);
+    END IF;
+  END IF;
+
+  IF v_client_id IS NULL AND p_pipeline_id IS NOT NULL THEN
+    SELECT
+      p.*,
+      c.id AS existing_client_id,
+      c.owner_id AS existing_owner_id,
+      c.name AS existing_client_name,
+      u.organization_id
+    INTO v_pipeline
+    FROM public.pipeline p
+    LEFT JOIN public.clients c ON c.id = p.client_id
+    LEFT JOIN public.users u ON u.id = p.user_id
+    WHERE p.id = p_pipeline_id;
+
+    IF FOUND THEN
+      v_source := COALESCE(v_source, 'pipeline');
+      v_source_id := COALESCE(v_source_id, v_pipeline.id);
+      v_client_id := COALESCE(v_pipeline.existing_client_id, v_client_id);
+      v_owner_id := COALESCE(v_pipeline.existing_owner_id, v_pipeline.user_id, v_owner_id);
+      v_org_id := COALESCE(v_pipeline.organization_id, v_org_id);
+      v_client_name := COALESCE(v_pipeline.existing_client_name, v_client_name);
+    END IF;
+  END IF;
+
+  IF v_client_id IS NOT NULL THEN
+    SELECT * INTO v_client FROM public.clients WHERE id = v_client_id;
+  END IF;
+
+  v_owner_id := COALESCE(v_client.owner_id, v_owner_id, v_opportunity.owner_id, v_pipeline.user_id);
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'Unable to resolve owner for client conversion';
+  END IF;
+
+  IF v_client IS NULL THEN
+    INSERT INTO public.clients (name, owner_id, status, phase, created_at, updated_at)
+    VALUES (
+      COALESCE(v_client_name, 'New Client'),
+      v_owner_id,
+      'active',
+      'Onboarding',
+      v_now,
+      v_now
+    )
+    RETURNING * INTO v_client;
+    v_client_id := v_client.id;
+  ELSE
+    UPDATE public.clients
+    SET
+      status = 'active',
+      phase = COALESCE(NULLIF(v_client.phase, ''), 'Onboarding'),
+      updated_at = v_now
+    WHERE id = v_client.id
+    RETURNING * INTO v_client;
+
+    IF v_client.phase IS DISTINCT FROM 'Onboarding' THEN
+      UPDATE public.clients
+      SET phase = 'Onboarding', updated_at = v_now
+      WHERE id = v_client.id;
+      v_client.phase := 'Onboarding';
+    END IF;
+  END IF;
+
+  v_client_name := v_client.name;
+
+  -- Ensure implementation project exists
+  SELECT id
+  INTO v_project_id
+  FROM public.projects
+  WHERE client_id = v_client_id AND name = 'RevOS Implementation'
+  LIMIT 1;
+
+  IF v_project_id IS NULL THEN
+    INSERT INTO public.projects (
+      name,
+      client_id,
+      description,
+      owner_id,
+      status,
+      phase,
+      health,
+      progress,
+      start_date,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      'RevOS Implementation',
+      v_client_id,
+      'Foundational implementation project created during onboarding.',
+      v_owner_id,
+      'Planned',
+      'Discovery',
+      'Green',
+      0,
+      current_date,
+      v_now,
+      v_now
+    )
+    RETURNING id INTO v_project_id;
+  END IF;
+
+  -- Ensure finance record exists
+  SELECT id
+  INTO v_finance_id
+  FROM public.finance
+  WHERE client_id = v_client_id
+  LIMIT 1;
+
+  IF v_finance_id IS NULL THEN
+    INSERT INTO public.finance (client_id, monthly_recurring_revenue, outstanding_invoices, user_id, updated_at)
+    VALUES (v_client_id, 0, 0, v_owner_id, v_now)
+    RETURNING id INTO v_finance_id;
+  END IF;
+
+  -- Ensure default deliverables exist
+  SELECT EXISTS (
+    SELECT 1 FROM public.client_deliverables WHERE client_id = v_client_id
+  ) INTO v_has_deliverables;
+
+  IF NOT v_has_deliverables THEN
+    INSERT INTO public.client_deliverables (client_id, title, type, status)
+    SELECT v_client_id, d, 'dashboard', 'Planned'
+    FROM unnest(v_default_deliverables) AS d;
+  END IF;
+
+  -- Log analytics event
+  v_metadata := jsonb_build_object(
+    'source', COALESCE(v_source, 'pipeline'),
+    'source_id', v_source_id,
+    'created_by', v_owner_id
+  );
+
+  INSERT INTO public.analytics_events (
+    organization_id,
+    user_id,
+    event_type,
+    entity_type,
+    entity_id,
+    metadata,
+    created_at
+  )
+  VALUES (
+    v_org_id,
+    v_owner_id,
+    'client_created_from_pipeline',
+    'client',
+    v_client_id::text,
+    v_metadata,
+    v_now
+  );
+
+  RETURN v_client_id;
+END;
+$$;

--- a/supabase/sql/clients/002_rpc_ensure_onboarding.sql
+++ b/supabase/sql/clients/002_rpc_ensure_onboarding.sql
@@ -1,0 +1,98 @@
+CREATE OR REPLACE FUNCTION public.rpc_ensure_client_onboarding(
+  p_client_id UUID
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public
+AS $$
+DECLARE
+  v_client record;
+  v_owner_id UUID;
+  v_now TIMESTAMPTZ := timezone('utc', now());
+  v_project_id UUID;
+  v_has_deliverables BOOLEAN;
+  v_default_deliverables CONSTANT TEXT[] := ARRAY[
+    'Executive Dashboard',
+    'Operating KPIs',
+    'Quarterly Review'
+  ];
+BEGIN
+  SELECT * INTO v_client FROM public.clients WHERE id = p_client_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Client % not found', p_client_id;
+  END IF;
+
+  v_owner_id := v_client.owner_id;
+
+  IF v_client.phase IS DISTINCT FROM 'Onboarding' OR v_client.phase IS NULL THEN
+    UPDATE public.clients
+    SET phase = 'Onboarding', updated_at = v_now
+    WHERE id = p_client_id;
+  END IF;
+
+  SELECT id
+  INTO v_project_id
+  FROM public.projects
+  WHERE client_id = p_client_id AND name = 'RevOS Implementation'
+  LIMIT 1;
+
+  IF v_project_id IS NULL THEN
+    INSERT INTO public.projects (
+      name,
+      client_id,
+      description,
+      owner_id,
+      status,
+      phase,
+      health,
+      progress,
+      start_date,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      'RevOS Implementation',
+      p_client_id,
+      'Foundational implementation project created during onboarding.',
+      v_owner_id,
+      'Planned',
+      'Discovery',
+      'Green',
+      0,
+      current_date,
+      v_now,
+      v_now
+    )
+    RETURNING id INTO v_project_id;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.client_deliverables WHERE client_id = p_client_id
+  ) INTO v_has_deliverables;
+
+  IF NOT v_has_deliverables THEN
+    INSERT INTO public.client_deliverables (client_id, title, type, status)
+    SELECT p_client_id, d, 'dashboard', 'Planned'
+    FROM unnest(v_default_deliverables) AS d;
+  END IF;
+
+  INSERT INTO public.analytics_events (
+    organization_id,
+    user_id,
+    event_type,
+    entity_type,
+    entity_id,
+    metadata,
+    created_at
+  )
+  VALUES (
+    NULL,
+    v_owner_id,
+    'client_onboarding_ensured',
+    'client',
+    p_client_id::text,
+    jsonb_build_object('project_id', v_project_id),
+    v_now
+  );
+END;
+$$;

--- a/supabase/sql/clients/003_views_clients.sql
+++ b/supabase/sql/clients/003_views_clients.sql
@@ -1,0 +1,41 @@
+DROP VIEW IF EXISTS public.vw_client_overview;
+
+CREATE VIEW public.vw_client_overview AS
+SELECT
+  c.id AS client_id,
+  c.name AS client_name,
+  c.segment AS client_type,
+  NULLIF(to_jsonb(c) ->> 'organization_id', '')::uuid AS organization_id,
+  c.owner_id,
+  pip.id AS pipeline_id,
+  pip.stage AS pipeline_stage,
+  pip.amount AS pipeline_value,
+  CASE
+    WHEN pip.amount IS NOT NULL AND pip.probability IS NOT NULL THEN
+      pip.amount * (pip.probability::numeric / 100)
+    ELSE NULL
+  END AS weighted_value,
+  pip.probability,
+  fin.id AS finance_id,
+  fin.monthly_recurring_revenue AS mrr,
+  fin.outstanding_invoices AS ar_outstanding,
+  COALESCE(
+    NULLIF((to_jsonb(fin) ->> 'ar_collected'), '')::numeric,
+    NULLIF((to_jsonb(fin) ->> 'total_collected'), '')::numeric,
+    0::numeric
+  ) AS ar_collected
+FROM public.clients c
+LEFT JOIN LATERAL (
+  SELECT o.id, o.stage, o.amount, o.probability
+  FROM public.opportunities o
+  WHERE o.client_id = c.id
+  ORDER BY o.updated_at DESC NULLS LAST, o.created_at DESC NULLS LAST
+  LIMIT 1
+) pip ON TRUE
+LEFT JOIN LATERAL (
+  SELECT f.*
+  FROM public.finance f
+  WHERE f.client_id = c.id
+  ORDER BY f.updated_at DESC NULLS LAST
+  LIMIT 1
+) fin ON TRUE;


### PR DESCRIPTION
## Summary
- replace the clients index with live Supabase data, server-side search, and grayscale layout
- rebuild the client detail experience with Supabase-backed tabs, onboarding actions, and analytics
- add pipeline closed-won server action, update UI triggers, and publish supporting Supabase RPCs/views

## Testing
- pnpm typecheck
- NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68eaf573a0848324b5ef2d168fc5bbe4