### PR TITLE
feat: launch tabbed client workspace

### DIFF
--- a/app/clients/[id]/ClientWorkspace.tsx
+++ b/app/clients/[id]/ClientWorkspace.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+
+import {
+  ActivityItem,
+  ClientDeliverable,
+  ClientStrategy,
+  DataRequirement,
+  DiscoveryResponse,
+  QRARun,
+} from '@/core/clients/types'
+import { StrategyVariant } from '@/core/qra/engine'
+
+import DiscoveryTab from './tabs/DiscoveryTab'
+import DataTab from './tabs/DataTab'
+import AlgorithmTab from './tabs/AlgorithmTab'
+import ArchitectureTab from './tabs/ArchitectureTab'
+import DeliverablesTab from './tabs/DeliverablesTab'
+import FinanceTab from './tabs/FinanceTab'
+import ActivityTab from './tabs/ActivityTab'
+
+const TAB_ITEMS: { key: TabKey; label: string }[] = [
+  { key: 'discovery', label: 'Discovery' },
+  { key: 'data', label: 'Data' },
+  { key: 'algorithm', label: 'Algorithm' },
+  { key: 'architecture', label: 'Architecture' },
+  { key: 'deliverables', label: 'Deliverables' },
+  { key: 'finance', label: 'Finance' },
+  { key: 'activity', label: 'Activity' },
+]
+
+export type TabKey =
+  | 'discovery'
+  | 'data'
+  | 'algorithm'
+  | 'architecture'
+  | 'deliverables'
+  | 'finance'
+  | 'activity'
+
+export type ClientWorkspaceClient = {
+  id: string
+  name: string
+  segment: string | null
+  industry: string | null
+  region: string | null
+  arr: number | null
+  health: number | null
+  phase: string | null
+  status: string | null
+  notes: string | null
+  ownerName: string | null
+  ownerEmail: string | null
+  qbrDate: string | null
+}
+
+export type ClientFinance = {
+  id?: string
+  client_id?: string
+  arrangement_type?: string | null
+  equity_stake_pct?: number | null
+  projection_mrr?: number | null
+  monthly_recurring_revenue?: number | null
+  outstanding_invoices?: number | null
+  updated_at?: string | null
+}
+
+type ClientWorkspaceProps = {
+  client: ClientWorkspaceClient
+  finance: ClientFinance | null
+  discoveryResponses: DiscoveryResponse[]
+  dataRequirements: DataRequirement[]
+  qraRuns: QRARun[]
+  strategies: ClientStrategy[]
+  deliverables: ClientDeliverable[]
+  activity: ActivityItem[]
+  generatedStrategies?: StrategyVariant[]
+  initialTab: TabKey
+}
+
+const healthFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+})
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+})
+
+export default function ClientWorkspace({
+  client,
+  finance,
+  discoveryResponses,
+  dataRequirements,
+  qraRuns,
+  strategies,
+  deliverables,
+  activity,
+  generatedStrategies,
+  initialTab,
+}: ClientWorkspaceProps) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  const [activeTab, setActiveTab] = useState<TabKey>(initialTab)
+
+  const activeStrategy = useMemo(
+    () => strategies.find((strategy) => strategy.status === 'active') ?? null,
+    [strategies],
+  )
+
+  const latestQraRun = useMemo(() => (qraRuns.length ? qraRuns[0] : null), [qraRuns])
+
+  const handleTabChange = (value: string) => {
+    const key = TAB_ITEMS.find((item) => item.key === value)?.key ?? initialTab
+    setActiveTab(key)
+    const params = new URLSearchParams(searchParams.toString())
+    if (key === 'discovery') {
+      params.delete('tab')
+    } else {
+      params.set('tab', key)
+    }
+    const query = params.toString()
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="rounded-2xl border border-[color:var(--color-outline)] bg-white px-6 py-5 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <Badge variant="outline" className="uppercase tracking-wide">
+              Client Workspace
+            </Badge>
+            <h1 className="text-2xl font-semibold text-[color:var(--color-text)]">{client.name}</h1>
+            <p className="text-sm text-[color:var(--color-text-muted)]">
+              {client.segment ?? 'Segment TBD'} • {client.industry ?? 'Industry TBD'} • Owner{' '}
+              {client.ownerName ?? 'Unassigned'}
+            </p>
+            {client.notes ? (
+              <p className="text-sm text-[color:var(--color-text-muted)]">{client.notes}</p>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryPill label="Phase" value={client.phase ?? '—'} />
+            <SummaryPill label="Status" value={client.status ?? '—'} />
+            <SummaryPill
+              label="ARR"
+              value={client.arr != null ? currencyFormatter.format(client.arr) : '—'}
+            />
+            <SummaryPill
+              label="Health"
+              value={client.health != null ? `${healthFormatter.format(client.health)}%` : '—'}
+            />
+          </div>
+        </div>
+        {client.qbrDate ? (
+          <p className="mt-4 text-xs text-[color:var(--color-text-muted)]">
+            Next QBR: {new Date(client.qbrDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+          </p>
+        ) : null}
+      </header>
+
+      <Tabs value={activeTab} onValueChange={handleTabChange} defaultValue={initialTab}>
+        <TabsList>
+          {TAB_ITEMS.map((tab) => (
+            <TabsTrigger key={tab.key} value={tab.key}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="discovery" className="border border-dashed border-[color:var(--color-outline)]">
+          <DiscoveryTab clientId={client.id} responses={discoveryResponses} />
+        </TabsContent>
+        <TabsContent value="data" className="border border-dashed border-[color:var(--color-outline)]">
+          <DataTab clientId={client.id} requirements={dataRequirements} />
+        </TabsContent>
+        <TabsContent value="algorithm" className="border border-dashed border-[color:var(--color-outline)]">
+          <AlgorithmTab
+            clientId={client.id}
+            latestRun={latestQraRun}
+            strategies={strategies}
+            generatedStrategies={generatedStrategies}
+          />
+        </TabsContent>
+        <TabsContent value="architecture" className="border border-dashed border-[color:var(--color-outline)]">
+          <ArchitectureTab activeStrategy={activeStrategy} />
+        </TabsContent>
+        <TabsContent value="deliverables" className="border border-dashed border-[color:var(--color-outline)]">
+          <DeliverablesTab clientId={client.id} items={deliverables} />
+        </TabsContent>
+        <TabsContent value="finance" className="border border-dashed border-[color:var(--color-outline)]">
+          <FinanceTab clientId={client.id} finance={finance} />
+        </TabsContent>
+        <TabsContent value="activity" className="border border-dashed border-[color:var(--color-outline)]">
+          <ActivityTab items={activity} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function SummaryPill({ label, value }: { label: string; value: string }) {
+  return (
+    <Card className="border-none bg-[color:var(--color-surface-muted)] px-3 py-2 text-left shadow-none">
+      <CardHeader className="px-0 py-0">
+        <p className="text-[10px] font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">
+          {label}
+        </p>
+      </CardHeader>
+      <CardContent className="px-0 py-0">
+        <CardTitle className="text-sm font-semibold text-[color:var(--color-text)]">{value}</CardTitle>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -1,333 +1,120 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound } from 'next/navigation'
 
-import { ensureOnboarding, setClientPhase } from "./actions";
-import { createServerClient } from "@/lib/supabase/server";
-import { Button } from "@/ui/button";
-import { Card, CardContent } from "@/ui/card";
+import { getActivity } from '@/core/clients/actions'
+import type { ActivityItem, ClientDeliverable, ClientStrategy, DataRequirement, DiscoveryResponse, QRARun } from '@/core/clients/types'
+import ClientWorkspace, { ClientFinance, ClientWorkspaceClient, TabKey } from './ClientWorkspace'
+import { createServerClient } from '@/lib/supabase/server'
 
-const TAB_ITEMS = [
-  { key: "overview", label: "Overview" },
-  { key: "deliverables", label: "Deliverables" },
-  { key: "finance", label: "Finance" },
-  { key: "onboarding", label: "Onboarding" },
-];
-
-const DEFAULT_DELIVERABLES = [
-  "Executive Dashboard",
-  "Operating KPIs",
-  "Quarterly Review",
-];
+const TAB_KEYS: TabKey[] = ['discovery', 'data', 'algorithm', 'architecture', 'deliverables', 'finance', 'activity']
 
 export default async function ClientPage({
   params,
   searchParams,
 }: {
-  params: { id: string };
-  searchParams?: { tab?: string };
+  params: { id: string }
+  searchParams?: { tab?: string }
 }) {
-  const supabase = createServerClient();
-  const activeTab = (searchParams?.tab ?? "overview").toLowerCase();
+  const supabase = createServerClient()
+  const activeTabParam = (searchParams?.tab ?? '').toLowerCase()
+  const initialTab = (TAB_KEYS.includes(activeTabParam as TabKey) ? (activeTabParam as TabKey) : 'discovery') as TabKey
 
-  const { data: client, error: clientError } = await supabase
-    .from("clients")
+  const { data: clientRow, error: clientError } = await supabase
+    .from('clients')
     .select(
-      "*, owner:users!clients_owner_id_fkey(name, email)"
+      `id, name, segment, industry, region, arr, health, phase, status, notes, qbr_date, owner:users!clients_owner_id_fkey(name, email)`,
     )
-    .eq("id", params.id)
-    .maybeSingle();
+    .eq('id', params.id)
+    .maybeSingle()
 
   if (clientError) {
-    throw clientError;
+    throw clientError
   }
 
-  if (!client) {
-    notFound();
+  if (!clientRow) {
+    notFound()
   }
 
-  const [{ data: projects }, { data: deliverables }, { data: finance }, { data: events }] =
-    await Promise.all([
-      supabase
-        .from("projects")
-        .select("id, name, status, phase, health, progress, updated_at")
-        .eq("client_id", client.id)
-        .order("updated_at", { ascending: false }),
-      supabase
-        .from("client_deliverables")
-        .select("id, title, type, status, url, created_at")
-        .eq("client_id", client.id)
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("finance")
-        .select("id, monthly_recurring_revenue, outstanding_invoices, updated_at")
-        .eq("client_id", client.id)
-        .maybeSingle(),
-      supabase
-        .from("analytics_events")
-        .select("id, event_type, created_at, metadata")
-        .eq("entity_type", "client")
-        .eq("entity_id", client.id)
-        .order("created_at", { ascending: false })
-        .limit(5),
-    ]);
+  const [financeRow, discoveryRows, requirementRows, qraRows, strategyRows, deliverableRows, activity] = await Promise.all([
+    supabase
+      .from('finance')
+      .select('id, client_id, arrangement_type, equity_stake_pct, projection_mrr, monthly_recurring_revenue, outstanding_invoices, updated_at')
+      .eq('client_id', params.id)
+      .maybeSingle(),
+    supabase
+      .from('discovery_responses')
+      .select('*')
+      .eq('client_id', params.id)
+      .order('form_type', { ascending: true }),
+    supabase
+      .from('data_requirements')
+      .select('*')
+      .eq('client_id', params.id)
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('qra_runs')
+      .select('*')
+      .eq('client_id', params.id)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('client_strategies')
+      .select('*')
+      .eq('client_id', params.id)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('client_deliverables')
+      .select('id, client_id, title, name, type, url, link, share_expires_at, meta, created_at')
+      .eq('client_id', params.id)
+      .order('created_at', { ascending: false }),
+    getActivity(params.id),
+  ])
 
-  const projectList = projects ?? [];
-  const deliverableList = deliverables ?? [];
-  const financeRow = finance ?? null;
-  const eventList = events ?? [];
+  if (financeRow.error) throw financeRow.error
+  if (discoveryRows.error) throw discoveryRows.error
+  if (requirementRows.error) throw requirementRows.error
+  if (qraRows.error) throw qraRows.error
+  if (strategyRows.error) throw strategyRows.error
+  if (deliverableRows.error) throw deliverableRows.error
 
-  const hasImplementationProject = projectList.some(
-    (project) => project.name === "RevOS Implementation"
-  );
-  const deliverableTitles = new Set(deliverableList.map((d) => d.title));
-  const hasDefaultDeliverables = DEFAULT_DELIVERABLES.every((name) =>
-    deliverableTitles.has(name)
-  );
-  const hasOwner = Boolean(client.owner_id);
-  const hasQbrDate = Boolean(client.qbr_date);
+  const client: ClientWorkspaceClient = {
+    id: clientRow.id,
+    name: clientRow.name,
+    segment: clientRow.segment,
+    industry: clientRow.industry,
+    region: clientRow.region,
+    arr: clientRow.arr,
+    health: clientRow.health,
+    phase: clientRow.phase,
+    status: clientRow.status,
+    notes: clientRow.notes,
+    ownerName: clientRow.owner?.name ?? null,
+    ownerEmail: clientRow.owner?.email ?? null,
+    qbrDate: clientRow.qbr_date,
+  }
 
-  const startOnboarding = async () => {
-    "use server";
-    await ensureOnboarding(params.id);
-    await setClientPhase(params.id, "Onboarding");
-  };
+  const finance: ClientFinance | null = financeRow.data ?? null
 
-  const markComplete = async () => {
-    "use server";
-    await setClientPhase(params.id, "Active");
-  };
+  const discoveryResponses = (discoveryRows.data ?? []) as DiscoveryResponse[]
+  const dataRequirements = (requirementRows.data ?? []) as DataRequirement[]
+  const qraRuns = (qraRows.data ?? []) as QRARun[]
+  const strategies = (strategyRows.data ?? []) as ClientStrategy[]
+  const deliverables = (deliverableRows.data ?? []) as ClientDeliverable[]
+  const activityItems = activity as ActivityItem[]
 
   return (
     <div className="min-h-screen bg-white text-black">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
-        <header className="space-y-1">
-          <p className="text-[11px] uppercase tracking-wide text-gray-500">Client Profile</p>
-          <h1 className="text-2xl font-semibold text-black">{client.name}</h1>
-          <p className="text-sm text-gray-600">
-            {client.segment ?? "Segment unknown"} • Owner {client.owner?.name ?? "Unassigned"}
-          </p>
-        </header>
-
-        <nav className="flex items-center gap-2 text-sm">
-          {TAB_ITEMS.map((tab) => {
-            const paramsCopy = new URLSearchParams(searchParams as Record<string, string> ?? {});
-            if (tab.key === "overview") {
-              paramsCopy.delete("tab");
-            } else {
-              paramsCopy.set("tab", tab.key);
-            }
-            const href = paramsCopy.size
-              ? `/clients/${client.id}?${paramsCopy.toString()}`
-              : `/clients/${client.id}`;
-            const isActive = activeTab === tab.key;
-            return (
-              <Link
-                key={tab.key}
-                href={href}
-                className={`rounded-full border px-3 py-1 transition ${
-                  isActive
-                    ? "border-gray-900 bg-gray-900 text-white"
-                    : "border-gray-300 bg-white text-gray-600 hover:border-gray-400"
-                }`}
-              >
-                {tab.label}
-              </Link>
-            );
-          })}
-        </nav>
-
-        <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <Card className="border-gray-200 lg:col-span-2">
-            <CardContent className="space-y-3 p-4">
-              <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
-                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
-                  Phase {client.phase ?? "—"}
-                </span>
-                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
-                  Status {client.status ?? "—"}
-                </span>
-                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
-                  ARR ${client.arr ? client.arr.toLocaleString() : "0"}
-                </span>
-                <span className="rounded-full border border-gray-300 bg-white px-3 py-1 font-medium text-gray-700">
-                  Health {client.health ?? "—"}
-                </span>
-              </div>
-              <div className="text-sm text-gray-600">
-                {client.notes ??
-                  "Command center for deliverables, analytics, and onboarding milestones."}
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="border-gray-200">
-            <CardContent className="space-y-2 p-4">
-              <h2 className="text-sm font-semibold text-black">Recent Activity</h2>
-              <ul className="space-y-2 text-sm text-gray-700">
-                {eventList.length === 0 && (
-                  <li className="text-gray-500">No analytics events yet.</li>
-                )}
-                {eventList.map((event) => (
-                  <li key={event.id} className="flex justify-between">
-                    <span className="font-medium text-black">{event.event_type}</span>
-                    <span className="text-xs text-gray-500">
-                      {event.created_at ? new Date(event.created_at).toLocaleDateString() : "—"}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-        </section>
-
-        {activeTab === "deliverables" && (
-          <Card className="border-gray-200">
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between">
-                <h2 className="text-sm font-semibold text-black">Deliverables</h2>
-                <Button variant="outline" size="sm">
-                  New Deliverable
-                </Button>
-              </div>
-              <div className="mt-4 space-y-3">
-                {deliverableList.length === 0 ? (
-                  <p className="text-sm text-gray-500">No deliverables yet.</p>
-                ) : (
-                  deliverableList.map((item) => (
-                    <div
-                      key={item.id}
-                      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white p-3 text-sm"
-                    >
-                      <div>
-                        <div className="font-medium text-black">{item.title}</div>
-                        <div className="text-xs text-gray-500">
-                          {item.status ?? "Planned"} • {item.type ?? "dashboard"}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Button variant="outline" size="sm" disabled={!item.url}>
-                          Open
-                        </Button>
-                        <Button variant="ghost" size="sm">
-                          Edit
-                        </Button>
-                        <Button variant="ghost" size="sm">
-                          Share
-                        </Button>
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {activeTab === "finance" && (
-          <Card className="border-gray-200">
-            <CardContent className="space-y-4 p-4">
-              <div className="flex items-center justify-between">
-                <h2 className="text-sm font-semibold text-black">Finance Summary</h2>
-                <Button variant="outline" size="sm">
-                  Create invoice
-                </Button>
-              </div>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <Metric label="MRR" value={`$${(financeRow?.monthly_recurring_revenue ?? 0).toLocaleString()}`} />
-                <Metric label="Outstanding" value={`$${(financeRow?.outstanding_invoices ?? 0).toLocaleString()}`} />
-                <Metric label="Updated" value={financeRow?.updated_at ? new Date(financeRow.updated_at).toLocaleDateString() : "—"} />
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {activeTab === "onboarding" && (
-          <Card className="border-gray-200">
-            <CardContent className="space-y-4 p-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold text-black">Onboarding Checklist</h2>
-                {client.phase !== "Onboarding" ? (
-                  <form action={startOnboarding}>
-                    <Button type="submit" size="sm" variant="outline">
-                      Start Onboarding
-                    </Button>
-                  </form>
-                ) : (
-                  <form action={markComplete}>
-                    <Button type="submit" size="sm" variant="outline">
-                      Mark Complete
-                    </Button>
-                  </form>
-                )}
-              </div>
-              <ul className="space-y-3 text-sm text-gray-700">
-                <ChecklistItem label="RevOS Implementation project" complete={hasImplementationProject} />
-                <ChecklistItem label="Default deliverables created" complete={hasDefaultDeliverables} />
-                <ChecklistItem label="Client owner assigned" complete={hasOwner} />
-                <ChecklistItem label="First QBR scheduled" complete={hasQbrDate} />
-              </ul>
-            </CardContent>
-          </Card>
-        )}
-
-        {activeTab === "overview" && (
-          <Card className="border-gray-200">
-            <CardContent className="grid gap-4 p-4 md:grid-cols-2">
-              <div className="space-y-3">
-                <h2 className="text-sm font-semibold text-black">Projects</h2>
-                <div className="space-y-2 text-sm text-gray-700">
-                  {projectList.length === 0 ? (
-                    <p className="text-gray-500">No active projects yet.</p>
-                  ) : (
-                    projectList.slice(0, 4).map((project) => (
-                      <div key={project.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                        <div className="font-medium text-black">{project.name}</div>
-                        <div className="text-xs text-gray-500">
-                          {project.status} • {project.phase ?? "Discovery"} • Health {project.health ?? "—"}
-                        </div>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
-              <div className="space-y-3">
-                <h2 className="text-sm font-semibold text-black">Deliverables</h2>
-                <div className="space-y-2 text-sm text-gray-700">
-                  {deliverableList.length === 0 ? (
-                    <p className="text-gray-500">No deliverables yet.</p>
-                  ) : (
-                    deliverableList.slice(0, 4).map((deliverable) => (
-                      <div key={deliverable.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                        <div className="font-medium text-black">{deliverable.title}</div>
-                        <div className="text-xs text-gray-500">
-                          {deliverable.status ?? "Planned"} • {deliverable.type ?? "dashboard"}
-                        </div>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-6">
+        <ClientWorkspace
+          client={client}
+          finance={finance}
+          discoveryResponses={discoveryResponses}
+          dataRequirements={dataRequirements}
+          qraRuns={qraRuns}
+          strategies={strategies}
+          deliverables={deliverables}
+          activity={activityItems}
+          initialTab={initialTab}
+        />
       </div>
     </div>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-3">
-      <div className="text-[11px] text-gray-500">{label}</div>
-      <div className="text-lg font-semibold text-black">{value}</div>
-    </div>
-  );
-}
-
-function ChecklistItem({ label, complete }: { label: string; complete: boolean }) {
-  return (
-    <li className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3">
-      <span className="text-lg">{complete ? "✅" : "○"}</span>
-      <span className="text-sm text-gray-700">{label}</span>
-    </li>
-  );
+  )
 }

--- a/app/clients/[id]/tabs/ActivityTab.tsx
+++ b/app/clients/[id]/tabs/ActivityTab.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { ActivityItem } from '@/core/clients/types'
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+
+const TYPE_LABELS: Record<ActivityItem['type'], string> = {
+  event: 'Product Event',
+  email: 'Email',
+  meeting: 'Meeting',
+  note: 'Note',
+}
+
+type ActivityTabProps = {
+  items: ActivityItem[]
+}
+
+const formatTimestamp = (value: string | null) => {
+  if (!value) return 'Unknown'
+  const dt = new Date(value)
+  if (Number.isNaN(dt.getTime())) return value
+  return dt.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+export default function ActivityTab({ items }: ActivityTabProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Client activity timeline</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length ? (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={item.id} className="flex items-start gap-3 rounded-lg border border-[color:var(--color-outline)] px-4 py-3">
+                <Badge variant="outline">{TYPE_LABELS[item.type] ?? item.type}</Badge>
+                <div className="flex-1">
+                  <p className="text-sm font-medium text-[color:var(--color-text)]">{item.title}</p>
+                  <p className="text-xs text-[color:var(--color-text-muted)]">{formatTimestamp(item.occurred_at)}</p>
+                  {item.details ? (
+                    <pre className="mt-2 overflow-x-auto rounded-md bg-[color:var(--color-surface-muted)] px-3 py-2 text-xs text-[color:var(--color-text-muted)]">
+                      {JSON.stringify(item.details, null, 2)}
+                    </pre>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+            No recent activity for this client.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/clients/[id]/tabs/AlgorithmTab.tsx
+++ b/app/clients/[id]/tabs/AlgorithmTab.tsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+
+import { runQRA, selectStrategy } from '@/core/clients/actions'
+import { ClientStrategy, QRARun } from '@/core/clients/types'
+import { StrategyVariant } from '@/core/qra/engine'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Textarea } from '@/ui/textarea'
+
+const DEFAULT_QUANT = {
+  arr: 0,
+  growth_rate: 15,
+  churn_rate: 7,
+  win_rate: 30,
+  sales_cycle_days: 45,
+  acv: 40000,
+}
+
+const DEFAULT_QUAL = {
+  primary_goal: 'Accelerate revenue compounding',
+  champion: 'Revenue Lead',
+}
+
+type AlgorithmTabProps = {
+  clientId: string
+  latestRun: QRARun | null
+  strategies: ClientStrategy[]
+  generatedStrategies?: StrategyVariant[]
+}
+
+type ParsedInputs = {
+  quant: Record<string, unknown>
+  qual: Record<string, unknown>
+}
+
+export default function AlgorithmTab({ clientId, latestRun, strategies, generatedStrategies }: AlgorithmTabProps) {
+  const activeStrategy = useMemo(
+    () => strategies.find((strategy) => strategy.status === 'active') ?? null,
+    [strategies],
+  )
+
+  const lastInputs = useMemo<ParsedInputs>(() => {
+    if (latestRun?.inputs) {
+      const quant = (latestRun.inputs as ParsedInputs).quant ?? DEFAULT_QUANT
+      const qual = (latestRun.inputs as ParsedInputs).qual ?? DEFAULT_QUAL
+      return { quant, qual }
+    }
+    return { quant: DEFAULT_QUANT, qual: DEFAULT_QUAL }
+  }, [latestRun])
+
+  const lastVariants = useMemo<StrategyVariant[]>(() => {
+    if (generatedStrategies && generatedStrategies.length) {
+      return generatedStrategies
+    }
+    const output = latestRun?.outputs as { strategies?: StrategyVariant[] } | null | undefined
+    if (output?.strategies && Array.isArray(output.strategies)) {
+      return output.strategies as StrategyVariant[]
+    }
+    return []
+  }, [generatedStrategies, latestRun])
+
+  const [quantText, setQuantText] = useState(JSON.stringify(lastInputs.quant, null, 2))
+  const [qualText, setQualText] = useState(JSON.stringify(lastInputs.qual, null, 2))
+  const [variants, setVariants] = useState<StrategyVariant[]>(lastVariants)
+  const [error, setError] = useState<string | null>(null)
+  const [selectionKey, setSelectionKey] = useState<string | null>(activeStrategy?.key ?? null)
+  const [isPending, startTransition] = useTransition()
+  const [isSelecting, startSelectTransition] = useTransition()
+
+  const parseInputs = (): ParsedInputs | null => {
+    try {
+      const quant = quantText.trim() ? JSON.parse(quantText) : {}
+      const qual = qualText.trim() ? JSON.parse(qualText) : {}
+      return { quant, qual }
+    } catch (err) {
+      setError('Inputs must be valid JSON objects.')
+      return null
+    }
+  }
+
+  const handleRun = () => {
+    const parsed = parseInputs()
+    if (!parsed) return
+
+    setError(null)
+    startTransition(async () => {
+      const result = await runQRA(clientId, parsed)
+      if (result.strategies?.length) {
+        setVariants(result.strategies)
+      }
+    })
+  }
+
+  const handleSelect = (variant: StrategyVariant) => {
+    setSelectionKey(variant.key)
+    startSelectTransition(async () => {
+      await selectStrategy(clientId, variant.key, variant.body as unknown as Record<string, unknown>, variant.title)
+    })
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-5">
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle className="text-base">Quant & Qual Inputs</CardTitle>
+          <CardDescription>Use structured inputs to generate strategy variants.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="quant-input">
+              Quantitative Inputs
+            </label>
+            <Textarea
+              id="quant-input"
+              value={quantText}
+              onChange={(event) => setQuantText(event.target.value)}
+              className="min-h-[160px] font-mono"
+              spellCheck={false}
+            />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="qual-input">
+              Qualitative Inputs
+            </label>
+            <Textarea
+              id="qual-input"
+              value={qualText}
+              onChange={(event) => setQualText(event.target.value)}
+              className="min-h-[160px] font-mono"
+              spellCheck={false}
+            />
+          </div>
+          {error ? <p className="text-xs text-[color:var(--color-critical)]">{error}</p> : null}
+          <div className="flex justify-end">
+            <Button onClick={handleRun} disabled={isPending}>
+              {isPending ? 'Running QRA…' : 'Run QRA'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="lg:col-span-3 flex flex-col gap-4">
+        {activeStrategy ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                Current Strategy
+                <Badge variant="success">Active</Badge>
+              </CardTitle>
+              <CardDescription>{activeStrategy.title}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-[color:var(--color-text-muted)]">
+                Selected {new Date(activeStrategy.created_at).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {variants.length ? (
+            variants.map((variant) => (
+              <StrategyCard
+                key={variant.key}
+                variant={variant}
+                onSelect={() => handleSelect(variant)}
+                disabled={isSelecting}
+                isSelected={selectionKey === variant.key}
+              />
+            ))
+          ) : (
+            <p className="md:col-span-2 rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-10 text-center text-sm text-[color:var(--color-text-muted)]">
+              Run the QRA engine to generate strategy options.
+            </p>
+          )}
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Strategy Archive</CardTitle>
+            <CardDescription>Previous strategy selections are archived for reference.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {strategies.length ? (
+              strategies.map((strategy) => (
+                <div key={strategy.id} className="flex items-center justify-between rounded-lg border border-[color:var(--color-outline)] px-3 py-2 text-sm">
+                  <div>
+                    <p className="font-medium text-[color:var(--color-text)]">{strategy.title}</p>
+                    <p className="text-xs text-[color:var(--color-text-muted)]">
+                      {new Date(strategy.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                    </p>
+                  </div>
+                  <Badge variant={strategy.status === 'active' ? 'success' : 'outline'}>{strategy.status}</Badge>
+                </div>
+              ))
+            ) : (
+              <p className="rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-6 text-center text-sm text-[color:var(--color-text-muted)]">
+                No strategies saved yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+type StrategyCardProps = {
+  variant: StrategyVariant
+  onSelect: () => void
+  disabled: boolean
+  isSelected: boolean
+}
+
+function StrategyCard({ variant, onSelect, disabled, isSelected }: StrategyCardProps) {
+  const body = variant.body
+  return (
+    <Card className="flex h-full flex-col border-[color:var(--color-outline)]">
+      <CardHeader className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{variant.title}</CardTitle>
+          {isSelected ? <Badge variant="success">Selected</Badge> : null}
+        </div>
+        <CardDescription>{variant.headline}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <div>
+          <p className="text-sm font-medium text-[color:var(--color-text)]">Narrative</p>
+          <p className="text-sm text-[color:var(--color-text-muted)]">{body.narrative}</p>
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-[color:var(--color-text)]">Plays</p>
+          <ul className="space-y-2 text-sm text-[color:var(--color-text-muted)]">
+            {body.plays.map((play) => (
+              <li key={play.id} className="rounded-lg border border-[color:var(--color-outline)] px-3 py-2">
+                <p className="font-medium text-[color:var(--color-text)]">{play.title}</p>
+                <p>{play.description}</p>
+                <p className="text-xs text-[color:var(--color-text-muted)]">Owner {play.ownerHint} • {play.dueInDays} days</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-[color:var(--color-text)]">Key Metrics</p>
+          <ul className="space-y-1 text-sm text-[color:var(--color-text-muted)]">
+            {body.metrics.map((metric) => (
+              <li key={metric.label}>
+                <span className="font-medium text-[color:var(--color-text)]">{metric.label}</span>: {metric.baseline} → {metric.target}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="mt-auto flex justify-end">
+          <Button onClick={onSelect} disabled={disabled}>
+            {isSelected ? 'Selected' : 'Activate strategy'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/clients/[id]/tabs/ArchitectureTab.tsx
+++ b/app/clients/[id]/tabs/ArchitectureTab.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { ClientStrategy } from '@/core/clients/types'
+import { StrategyBody } from '@/core/qra/engine'
+import { Badge } from '@/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+
+const addDays = (days: number) => {
+  const now = new Date()
+  now.setUTCDate(now.getUTCDate() + days)
+  return now.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+type ArchitectureTabProps = {
+  activeStrategy: ClientStrategy | null
+}
+
+export default function ArchitectureTab({ activeStrategy }: ArchitectureTabProps) {
+  if (!activeStrategy) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-[color:var(--color-outline)] px-6 py-12 text-center">
+        <h3 className="text-base font-semibold text-[color:var(--color-text)]">No strategy selected yet</h3>
+        <p className="max-w-md text-sm text-[color:var(--color-text-muted)]">
+          Run the QRA engine, choose a strategy variant, and the execution architecture will render here with owners and due dates.
+        </p>
+      </div>
+    )
+  }
+
+  const body = (activeStrategy.body ?? {}) as StrategyBody
+  const checklist = body.checklist ?? []
+  const plays = body.plays ?? []
+  const metrics = body.metrics ?? []
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            {body.title}
+            <Badge variant="success">Active</Badge>
+          </CardTitle>
+          <CardDescription>{body.narrative}</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          <div>
+            <h4 className="text-sm font-semibold text-[color:var(--color-text)]">Key metrics</h4>
+            <ul className="mt-2 space-y-1 text-sm text-[color:var(--color-text-muted)]">
+              {metrics.map((metric) => (
+                <li key={metric.label}>
+                  <span className="font-medium text-[color:var(--color-text)]">{metric.label}</span>: {metric.baseline} → {metric.target}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="text-sm font-semibold text-[color:var(--color-text)]">Execution notes</h4>
+            <ul className="mt-2 space-y-2 text-sm text-[color:var(--color-text-muted)]">
+              {plays.map((play) => (
+                <li key={play.id} className="rounded-lg border border-[color:var(--color-outline)] px-3 py-2">
+                  <p className="font-medium text-[color:var(--color-text)]">{play.title}</p>
+                  <p>{play.description}</p>
+                  <p className="text-xs text-[color:var(--color-text-muted)]">Owner {play.ownerHint} • Target {addDays(play.dueInDays)}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Execution checklist</CardTitle>
+          <CardDescription>Track the rollout owners and due dates for the active strategy.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {checklist.map((item) => (
+            <div key={item.id} className="flex items-center justify-between gap-4 rounded-lg border border-[color:var(--color-outline)] px-4 py-3">
+              <div>
+                <p className="text-sm font-medium text-[color:var(--color-text)]">{item.label}</p>
+                <p className="text-xs text-[color:var(--color-text-muted)]">
+                  Owner {item.ownerHint ?? 'TBD'} • Target {item.dueInDays != null ? addDays(item.dueInDays) : 'TBD'}
+                </p>
+              </div>
+              <Badge variant="outline">Open</Badge>
+            </div>
+          ))}
+          {!checklist.length ? (
+            <p className="rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-6 text-center text-sm text-[color:var(--color-text-muted)]">
+              Checklist will populate when a strategy is activated.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/clients/[id]/tabs/DataTab.tsx
+++ b/app/clients/[id]/tabs/DataTab.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+
+import { setDataRequirement } from '@/core/clients/actions'
+import { DataRequirement } from '@/core/clients/types'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+import { Input } from '@/ui/input'
+import { Select } from '@/ui/select'
+import { Textarea } from '@/ui/textarea'
+
+const STATUS_LABELS: Record<DataRequirement['status'], string> = {
+  needed: 'Needed',
+  in_progress: 'In Progress',
+  collected: 'Collected',
+}
+
+type DataTabProps = {
+  clientId: string
+  requirements: DataRequirement[]
+}
+
+type DraftState = {
+  status: DataRequirement['status']
+  notes: string
+}
+
+export default function DataTab({ clientId, requirements }: DataTabProps) {
+  const [items, setItems] = useState(requirements)
+  const [drafts, setDrafts] = useState<Record<string, DraftState>>(() =>
+    requirements.reduce((acc, requirement) => {
+      acc[requirement.id] = {
+        status: requirement.status,
+        notes: requirement.notes ?? '',
+      }
+      return acc
+    }, {} as Record<string, DraftState>),
+  )
+  const [newSource, setNewSource] = useState('')
+  const [newNotes, setNewNotes] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  const grouped = useMemo(() => {
+    const requiredList = items.filter((item) => item.status !== 'collected')
+    const collectedList = items.filter((item) => item.status === 'collected')
+    return { requiredList, collectedList }
+  }, [items])
+
+  const updateDraft = (id: string, patch: Partial<DraftState>) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        ...patch,
+      },
+    }))
+  }
+
+  const upsertRequirement = (requirement: DataRequirement) => {
+    setItems((prev) => {
+      const existingIndex = prev.findIndex((item) => item.id === requirement.id)
+      if (existingIndex >= 0) {
+        const next = [...prev]
+        next[existingIndex] = requirement
+        return next
+      }
+      return [requirement, ...prev]
+    })
+    setDrafts((prev) => ({
+      ...prev,
+      [requirement.id]: {
+        status: requirement.status,
+        notes: requirement.notes ?? '',
+      },
+    }))
+  }
+
+  const handleSubmit = (requirement: DataRequirement) => {
+    const draft = drafts[requirement.id]
+    if (!draft) return
+
+    setPendingId(requirement.id)
+    startTransition(async () => {
+      const result = await setDataRequirement(
+        clientId,
+        requirement.source_name,
+        draft.status,
+        draft.notes.trim() ? draft.notes : undefined,
+      )
+      if (result) {
+        upsertRequirement(result)
+      }
+      setPendingId(null)
+    })
+  }
+
+  const handleCreate = () => {
+    if (!newSource.trim()) return
+    setPendingId('new')
+    startTransition(async () => {
+      const result = await setDataRequirement(clientId, newSource.trim(), 'needed', newNotes.trim() || undefined)
+      if (result) {
+        upsertRequirement(result)
+        setNewSource('')
+        setNewNotes('')
+      }
+      setPendingId(null)
+    })
+  }
+
+  const renderRequirement = (requirement: DataRequirement) => {
+    const draft = drafts[requirement.id]
+    return (
+      <Card key={requirement.id} className="flex flex-col gap-3 border-[color:var(--color-outline)] p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-sm font-semibold text-[color:var(--color-text)]">
+              {requirement.source_name}
+            </CardTitle>
+            <p className="text-xs text-[color:var(--color-text-muted)]">
+              Required by RevOS • Status {STATUS_LABELS[requirement.status]}
+            </p>
+          </div>
+          <Badge variant={requirement.status === 'collected' ? 'success' : 'outline'}>
+            {STATUS_LABELS[requirement.status]}
+          </Badge>
+        </div>
+        <div className="grid gap-2">
+          <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor={`${requirement.id}-status`}>
+            Status
+          </label>
+          <Select
+            id={`${requirement.id}-status`}
+            value={draft?.status ?? requirement.status}
+            onChange={(event) => updateDraft(requirement.id, { status: event.target.value as DataRequirement['status'] })}
+          >
+            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="grid gap-2">
+          <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor={`${requirement.id}-notes`}>
+            Notes
+          </label>
+          <Textarea
+            id={`${requirement.id}-notes`}
+            value={draft?.notes ?? requirement.notes ?? ''}
+            onChange={(event) => updateDraft(requirement.id, { notes: event.target.value })}
+            placeholder="Connection details, owners, or blockers"
+            className="min-h-[96px]"
+          />
+        </div>
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            onClick={() => handleSubmit(requirement)}
+            disabled={isPending && pendingId === requirement.id}
+          >
+            Save updates
+          </Button>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card className="border-[color:var(--color-outline)] bg-[color:var(--color-surface)]">
+        <CardHeader>
+          <CardTitle className="text-base">Add data requirement</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-3">
+          <div className="md:col-span-1">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="new-source">
+              Source name
+            </label>
+            <Input
+              id="new-source"
+              value={newSource}
+              onChange={(event) => setNewSource(event.target.value)}
+              placeholder="QuickBooks, Gmail, CSV Upload"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="new-notes">
+              Notes
+            </label>
+            <Textarea
+              id="new-notes"
+              value={newNotes}
+              onChange={(event) => setNewNotes(event.target.value)}
+              placeholder="Context for why this data unlocks the TRS engine"
+              className="min-h-[80px]"
+            />
+          </div>
+          <div className="md:col-span-3 flex justify-end">
+            <Button onClick={handleCreate} disabled={isPending && pendingId === 'new'}>
+              Link requirement
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-[color:var(--color-text)]">Required</h3>
+          {grouped.requiredList.length ? (
+            grouped.requiredList.map(renderRequirement)
+          ) : (
+            <p className="rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+              No outstanding requirements.
+            </p>
+          )}
+        </section>
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-[color:var(--color-text)]">Collected</h3>
+          {grouped.collectedList.length ? (
+            grouped.collectedList.map(renderRequirement)
+          ) : (
+            <p className="rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+              Nothing collected yet.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/clients/[id]/tabs/DeliverablesTab.tsx
+++ b/app/clients/[id]/tabs/DeliverablesTab.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+import { linkDeliverable, unlinkDeliverable } from '@/core/clients/actions'
+import { ClientDeliverable } from '@/core/clients/types'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Input } from '@/ui/input'
+
+const TYPE_OPTIONS = [
+  { value: 'content', label: 'Content' },
+  { value: 'dashboard', label: 'Dashboard' },
+  { value: 'doc', label: 'Doc' },
+  { value: 'link', label: 'External Link' },
+]
+
+type DeliverablesTabProps = {
+  clientId: string
+  items: ClientDeliverable[]
+}
+
+type DeliverableForm = {
+  title: string
+  type: string
+  url: string
+  share_expires_at: string
+}
+
+const initialForm: DeliverableForm = {
+  title: '',
+  type: 'content',
+  url: '',
+  share_expires_at: '',
+}
+
+export default function DeliverablesTab({ clientId, items: initialItems }: DeliverablesTabProps) {
+  const [items, setItems] = useState(initialItems)
+  const [form, setForm] = useState(initialForm)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = () => {
+    if (!form.title.trim()) return
+    setPendingId('new')
+    startTransition(async () => {
+      const result = await linkDeliverable({
+        clientId,
+        title: form.title.trim(),
+        type: form.type,
+        url: form.url.trim() || undefined,
+        share_expires_at: form.share_expires_at.trim() || undefined,
+      })
+      if (result) {
+        setItems((prev) => [result, ...prev])
+        setForm(initialForm)
+      }
+      setPendingId(null)
+    })
+  }
+
+  const handleRemove = (id: string) => {
+    setPendingId(id)
+    startTransition(async () => {
+      const success = await unlinkDeliverable(id)
+      if (success) {
+        setItems((prev) => prev.filter((item) => item.id !== id))
+      }
+      setPendingId(null)
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Link a deliverable</CardTitle>
+          <CardDescription>Surface the assets and dashboards that support this client.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-4">
+          <div className="md:col-span-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="deliverable-title">
+              Title
+            </label>
+            <Input
+              id="deliverable-title"
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="Board deck, Looker dashboard, etc."
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="deliverable-type">
+              Type
+            </label>
+            <select
+              id="deliverable-type"
+              value={form.type}
+              onChange={(event) => setForm((prev) => ({ ...prev, type: event.target.value }))}
+              className="w-full rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm"
+            >
+              {TYPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="deliverable-expiration">
+              Share expires on (optional)
+            </label>
+            <Input
+              id="deliverable-expiration"
+              type="date"
+              value={form.share_expires_at}
+              onChange={(event) => setForm((prev) => ({ ...prev, share_expires_at: event.target.value }))}
+            />
+          </div>
+          <div className="md:col-span-4">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="deliverable-url">
+              URL (optional)
+            </label>
+            <Input
+              id="deliverable-url"
+              value={form.url}
+              onChange={(event) => setForm((prev) => ({ ...prev, url: event.target.value }))}
+              placeholder="https://"
+            />
+          </div>
+          <div className="md:col-span-4 flex justify-end">
+            <Button onClick={handleSubmit} disabled={isPending && pendingId === 'new'}>
+              Link deliverable
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.length ? (
+          items.map((deliverable) => {
+            const title = deliverable.title ?? deliverable.name ?? 'Untitled'
+            const expires = deliverable.share_expires_at
+              ? new Date(deliverable.share_expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+              : null
+            return (
+              <Card key={deliverable.id} className="flex flex-col gap-3 border-[color:var(--color-outline)] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-sm font-semibold text-[color:var(--color-text)]">{title}</CardTitle>
+                    <p className="text-xs text-[color:var(--color-text-muted)]">{deliverable.url ?? deliverable.link ?? 'No link provided'}</p>
+                  </div>
+                  <Badge variant="outline">{deliverable.type ?? 'content'}</Badge>
+                </div>
+                {expires ? (
+                  <p className="text-xs text-[color:var(--color-text-muted)]">Share expires {expires}</p>
+                ) : null}
+                <div className="flex justify-end">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemove(deliverable.id)}
+                    disabled={isPending && pendingId === deliverable.id}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </Card>
+            )
+          })
+        ) : (
+          <p className="md:col-span-2 rounded-lg border border-dashed border-[color:var(--color-outline)] px-4 py-10 text-center text-sm text-[color:var(--color-text-muted)]">
+            No deliverables linked yet.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/clients/[id]/tabs/DiscoveryTab.tsx
+++ b/app/clients/[id]/tabs/DiscoveryTab.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+
+import { saveDiscovery } from '@/core/clients/actions'
+import { DiscoveryResponse } from '@/core/clients/types'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Textarea } from '@/ui/textarea'
+
+const FORM_DEFINITIONS: Array<{
+  key: DiscoveryResponse['form_type']
+  title: string
+  description: string
+}> = [
+  {
+    key: 'gap_selling',
+    title: 'Gap Selling Brief',
+    description: 'Capture the current state, desired future state, and quantified business impact across teams.',
+  },
+  {
+    key: 'clarity_gap',
+    title: 'Clarity Gap Diagnostic',
+    description: 'Surface gaps across data, enablement, and execution that limit the growth program.',
+  },
+  {
+    key: 'revenue_research',
+    title: 'Revenue Research Notes',
+    description: 'Document qualitative signal from customers, partners, and internal stakeholders.',
+  },
+]
+
+type DiscoveryTabProps = {
+  clientId: string
+  responses: DiscoveryResponse[]
+}
+
+type FormState = {
+  value: string
+  error: string | null
+  completed: boolean
+  updatedAt: string | null
+}
+
+const formatTimestamp = (value: string | null) => {
+  if (!value) return null
+  const dt = new Date(value)
+  if (Number.isNaN(dt.getTime())) return null
+  return dt.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+export default function DiscoveryTab({ clientId, responses }: DiscoveryTabProps) {
+  const responseMap = useMemo(() => {
+    const map = new Map<DiscoveryResponse['form_type'], DiscoveryResponse>()
+    responses.forEach((response) => map.set(response.form_type, response))
+    return map
+  }, [responses])
+
+  const initialState = useMemo<Record<string, FormState>>(
+    () =>
+      FORM_DEFINITIONS.reduce((acc, form) => {
+        const existing = responseMap.get(form.key)
+        acc[form.key] = {
+          value: existing ? JSON.stringify(existing.answers ?? {}, null, 2) : '{\n  "summary": ""\n}',
+          error: null,
+          completed: Boolean(existing?.completed_at),
+          updatedAt: existing?.updated_at ?? existing?.created_at ?? null,
+        }
+        return acc
+      }, {} as Record<string, FormState>),
+    [responseMap],
+  )
+
+  const [forms, setForms] = useState(initialState)
+  const [pendingKey, setPendingKey] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleChange = (key: string, value: string) => {
+    setForms((prev) => ({
+      ...prev,
+      [key]: {
+        ...prev[key],
+        value,
+        error: null,
+      },
+    }))
+  }
+
+  const handleSave = (key: string, markComplete: boolean) => {
+    const raw = forms[key]
+    if (!raw) return
+
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(raw.value)
+    } catch (error) {
+      setForms((prev) => ({
+        ...prev,
+        [key]: { ...prev[key], error: 'Answers must be valid JSON.' },
+      }))
+      return
+    }
+
+    setPendingKey(key)
+    startTransition(async () => {
+      const result = await saveDiscovery(key as DiscoveryResponse['form_type'], clientId, parsed, {
+        completed: markComplete,
+      })
+      setForms((prev) => ({
+        ...prev,
+        [key]: {
+          value: JSON.stringify(parsed, null, 2),
+          error: null,
+          completed: markComplete || Boolean(result?.completed_at),
+          updatedAt: result?.updated_at ?? result?.created_at ?? new Date().toISOString(),
+        },
+      }))
+      setPendingKey(null)
+    })
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {FORM_DEFINITIONS.map((form) => {
+        const state = forms[form.key]
+        const completedBadge = state?.completed
+          ? { label: 'Completed', variant: 'success' as const }
+          : { label: 'In Progress', variant: 'outline' as const }
+        return (
+          <Card key={form.key} className="flex flex-col border-[color:var(--color-outline)]">
+            <CardHeader className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <CardTitle>{form.title}</CardTitle>
+                <Badge variant={completedBadge.variant}>{completedBadge.label}</Badge>
+              </div>
+              <CardDescription>{form.description}</CardDescription>
+              {state?.updatedAt ? (
+                <p className="text-xs text-[color:var(--color-text-muted)]">
+                  Updated {formatTimestamp(state.updatedAt)}
+                </p>
+              ) : null}
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col gap-3">
+              <Textarea
+                value={state?.value ?? ''}
+                onChange={(event) => handleChange(form.key, event.target.value)}
+                className="min-h-[220px] font-mono"
+                spellCheck={false}
+              />
+              {state?.error ? (
+                <p className="text-xs text-[color:var(--color-critical)]">{state.error}</p>
+              ) : null}
+              <div className="mt-auto flex items-center justify-between gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleSave(form.key, false)}
+                  disabled={isPending && pendingKey === form.key}
+                >
+                  Save draft
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => handleSave(form.key, true)}
+                  disabled={isPending && pendingKey === form.key}
+                >
+                  Save & complete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/clients/[id]/tabs/FinanceTab.tsx
+++ b/app/clients/[id]/tabs/FinanceTab.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+
+import { saveFinanceTerms } from '@/core/clients/actions'
+import type { ClientFinance } from '../ClientWorkspace'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { Input } from '@/ui/input'
+
+const ARRANGEMENT_OPTIONS = [
+  { value: 'equity', label: 'Equity' },
+  { value: 'advisory', label: 'Advisory' },
+  { value: 'partnership', label: 'Partnership' },
+]
+
+type FinanceTabProps = {
+  clientId: string
+  finance: ClientFinance | null
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+})
+
+export default function FinanceTab({ clientId, finance }: FinanceTabProps) {
+  const [arrangement, setArrangement] = useState(finance?.arrangement_type ?? '')
+  const [equity, setEquity] = useState(finance?.equity_stake_pct != null ? String(finance.equity_stake_pct) : '')
+  const [projection, setProjection] = useState(finance?.projection_mrr != null ? String(finance.projection_mrr) : '')
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+
+  const mrr = useMemo(
+    () => (finance?.monthly_recurring_revenue != null ? currencyFormatter.format(finance.monthly_recurring_revenue) : '—'),
+    [finance?.monthly_recurring_revenue],
+  )
+
+  const outstanding = useMemo(
+    () => (finance?.outstanding_invoices != null ? currencyFormatter.format(finance.outstanding_invoices) : '—'),
+    [finance?.outstanding_invoices],
+  )
+
+  const handleSave = () => {
+    startTransition(async () => {
+      const result = await saveFinanceTerms({
+        clientId,
+        arrangement_type: arrangement || null,
+        equity_stake_pct: equity ? Number.parseFloat(equity) : null,
+        projection_mrr: projection ? Number.parseFloat(projection) : null,
+      })
+      if (result) {
+        setMessage('Finance terms updated')
+      }
+    })
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Commercial terms</CardTitle>
+          <CardDescription>Track the arrangement type, equity stake, and projected MRR.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="arrangement-type">
+              Arrangement type
+            </label>
+            <select
+              id="arrangement-type"
+              value={arrangement}
+              onChange={(event) => setArrangement(event.target.value)}
+              className="w-full rounded-md border border-[color:var(--color-outline)] bg-white px-3 py-2 text-sm"
+            >
+              <option value="">Select arrangement</option>
+              {ARRANGEMENT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="equity-stake">
+              Equity stake %
+            </label>
+            <Input
+              id="equity-stake"
+              type="number"
+              step="0.1"
+              value={equity}
+              onChange={(event) => setEquity(event.target.value)}
+              placeholder="5"
+            />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-xs font-medium text-[color:var(--color-text-muted)]" htmlFor="projection-mrr">
+              Projected MRR ($)
+            </label>
+            <Input
+              id="projection-mrr"
+              type="number"
+              step="1000"
+              value={projection}
+              onChange={(event) => setProjection(event.target.value)}
+              placeholder="50000"
+            />
+          </div>
+          {message ? <p className="text-xs text-[color:var(--color-positive)]">{message}</p> : null}
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={isPending}>
+              {isPending ? 'Saving…' : 'Save terms'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Financial snapshot</CardTitle>
+          <CardDescription>Automated metrics from Supabase finance tables.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          <div className="rounded-lg border border-[color:var(--color-outline)] px-3 py-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">Current MRR</p>
+            <p className="text-lg font-semibold text-[color:var(--color-text)]">{mrr}</p>
+          </div>
+          <div className="rounded-lg border border-[color:var(--color-outline)] px-3 py-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">Outstanding invoices</p>
+            <p className="text-lg font-semibold text-[color:var(--color-text)]">{outstanding}</p>
+          </div>
+          {finance?.updated_at ? (
+            <Badge variant="outline">Updated {new Date(finance.updated_at).toLocaleDateString('en-US')}</Badge>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/core/clients/types.ts
+++ b/core/clients/types.ts
@@ -111,14 +111,75 @@ export type Client = {
   notes?: string;
 };
 
+export type DiscoveryResponse = {
+  id: string;
+  client_id: string;
+  form_type: "gap_selling" | "clarity_gap" | "revenue_research" | string;
+  answers: Record<string, unknown>;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DataRequirementStatus = "needed" | "in_progress" | "collected";
+
+export type DataRequirement = {
+  id: string;
+  client_id: string;
+  source_name: string;
+  required: boolean;
+  status: DataRequirementStatus;
+  notes: string | null;
+  meta: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ClientStrategyStatus = "active" | "archived";
+
+export type ClientStrategy = {
+  id: string;
+  client_id: string;
+  title: string;
+  key: string | null;
+  body: Record<string, unknown>;
+  status: ClientStrategyStatus;
+  created_at: string;
+};
+
+export type QRARun = {
+  id: string;
+  client_id: string;
+  inputs: Record<string, unknown>;
+  outputs: Record<string, unknown>;
+  selected_strategy_key: string | null;
+  created_by: string | null;
+  created_at: string;
+};
+
+export type ActivityItemType = "event" | "email" | "meeting" | "note";
+
+export type ActivityItem = {
+  id: string;
+  type: ActivityItemType;
+  occurred_at: string | null;
+  title: string;
+  details?: Record<string, unknown>;
+};
+
 export type ClientDeliverable = {
   id: string;
   client_id: string;
-  name: string;
+  name?: string;
+  title?: string;
   type: string | null;
-  link: string | null;
-  status: string | null;
-  updated_at: string | null;
+  link?: string | null;
+  url?: string | null;
+  status?: string | null;
+  share_expires_at?: string | null;
+  meta?: Record<string, unknown> | null;
+  updated_at?: string | null;
+  created_at?: string | null;
 };
 
 export type ClientFinancialSnapshot = {

--- a/core/qra/engine.ts
+++ b/core/qra/engine.ts
@@ -1,0 +1,302 @@
+export type QRAInputs = {
+  quant?: Record<string, unknown>;
+  qual?: Record<string, unknown>;
+};
+
+export type StrategyPlay = {
+  id: string;
+  title: string;
+  description: string;
+  ownerHint: string;
+  dueInDays: number;
+};
+
+export type StrategyChecklistItem = {
+  id: string;
+  label: string;
+  ownerHint?: string;
+  dueInDays?: number;
+};
+
+export type StrategyMetric = {
+  label: string;
+  baseline: string;
+  target: string;
+};
+
+export type StrategyBody = {
+  key: 'speed' | 'price' | 'scale';
+  title: string;
+  narrative: string;
+  plays: StrategyPlay[];
+  checklist: StrategyChecklistItem[];
+  metrics: StrategyMetric[];
+};
+
+export type StrategyVariant = {
+  key: 'speed' | 'price' | 'scale';
+  title: string;
+  headline: string;
+  body: StrategyBody;
+};
+
+const formatCurrency = (value: number) =>
+  `$${value.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+
+function resolveNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function resolvePercent(value: unknown, fallback: number) {
+  const numeric = resolveNumber(value, fallback);
+  return Math.max(0, Math.min(100, numeric));
+}
+
+export function computeStrategies(inputs: QRAInputs): StrategyVariant[] {
+  const quant = inputs.quant ?? {};
+  const qual = inputs.qual ?? {};
+
+  const arr = resolveNumber(quant.arr, 0);
+  const growthRate = resolvePercent(quant.growth_rate ?? quant.growthRate, 12);
+  const churnRate = resolvePercent(quant.churn_rate ?? quant.churnRate, 6);
+  const salesCycle = resolveNumber(quant.sales_cycle_days ?? quant.salesCycleDays, 45);
+  const winRate = resolvePercent(quant.win_rate ?? quant.winRate, 28);
+  const acv = resolveNumber(quant.acv, arr > 0 ? arr / 12 : 40000);
+
+  const primaryGoal = typeof qual.primary_goal === 'string' ? qual.primary_goal : 'Accelerate revenue compounding';
+  const champion = typeof qual.champion === 'string' ? qual.champion : 'Client Operator';
+
+  const makePlayId = (key: string, index: number) => `${key}-play-${index + 1}`;
+  const makeChecklistId = (key: string, index: number) => `${key}-check-${index + 1}`;
+
+  const speedLift = Math.round(Math.max(8, 0.5 * winRate + 0.25 * (100 - churnRate)));
+  const priceLift = Math.round(Math.max(6, 0.4 * (100 - winRate) + 0.3 * (100 - churnRate)));
+  const scaleLift = Math.round(Math.max(10, 0.6 * growthRate + 0.2 * winRate));
+
+  const pipelineCoverage = Math.max(3, Math.round((100 - winRate) / 10));
+  const expectedARRSpeed = arr + (arr * speedLift) / 100;
+  const expectedARRPrice = arr + (arr * priceLift) / 100;
+  const expectedARRScale = arr + (arr * scaleLift) / 100;
+
+  const playsFor = (key: 'speed' | 'price' | 'scale'): StrategyPlay[] => {
+    switch (key) {
+      case 'speed':
+        return [
+          {
+            id: makePlayId(key, 0),
+            title: 'Compress sales cycle by 20%',
+            description: 'Deploy automated discovery briefs and live mutual action plans to remove stalls.',
+            ownerHint: 'Revenue Ops',
+            dueInDays: Math.max(21, Math.round(salesCycle / 2)),
+          },
+          {
+            id: makePlayId(key, 1),
+            title: 'Instrument decision committee proof',
+            description: 'Launch buyer enablement workspace and assign exec sponsor for every deal >$50k ACV.',
+            ownerHint: 'Client Champion',
+            dueInDays: 28,
+          },
+          {
+            id: makePlayId(key, 2),
+            title: 'Rebuild pipeline forecast hygiene',
+            description: 'Stand up weekly forecast readouts with stage exit criteria and call scoring.',
+            ownerHint: 'Sales Leadership',
+            dueInDays: 35,
+          },
+        ];
+      case 'price':
+        return [
+          {
+            id: makePlayId(key, 0),
+            title: 'Package outcome-based tiers',
+            description: 'Bundle adoption accelerators with premium support to justify 12% uplift.',
+            ownerHint: 'Product Marketing',
+            dueInDays: 30,
+          },
+          {
+            id: makePlayId(key, 1),
+            title: 'Launch value review rhythm',
+            description: 'Introduce quarterly business reviews with benchmarks to surface expansion triggers.',
+            ownerHint: 'Account Management',
+            dueInDays: 45,
+          },
+          {
+            id: makePlayId(key, 2),
+            title: 'Refine discount guardrails',
+            description: 'Implement deal desk approvals with floor pricing tied to margin targets.',
+            ownerHint: 'Finance Lead',
+            dueInDays: 32,
+          },
+        ];
+      case 'scale':
+      default:
+        return [
+          {
+            id: makePlayId(key, 0),
+            title: 'Stand up partner acquisition lane',
+            description: 'Activate top channel partners with co-selling kits and joint pipeline goals.',
+            ownerHint: 'Partnerships',
+            dueInDays: 60,
+          },
+          {
+            id: makePlayId(key, 1),
+            title: 'Expand coverage with pods',
+            description: 'Spin up an outbound pod focused on Tier 1 accounts with programmatic intent data.',
+            ownerHint: 'Growth Lead',
+            dueInDays: 50,
+          },
+          {
+            id: makePlayId(key, 2),
+            title: 'Operationalize product telemetry',
+            description: 'Wire product usage signals into CRM to prioritize expansion plays.',
+            ownerHint: 'Data Engineering',
+            dueInDays: 42,
+          },
+        ];
+    }
+  };
+
+  const checklistFor = (key: 'speed' | 'price' | 'scale'): StrategyChecklistItem[] =>
+    playsFor(key).map((play, index) => ({
+      id: makeChecklistId(key, index),
+      label: play.title,
+      ownerHint: play.ownerHint,
+      dueInDays: play.dueInDays,
+    }));
+
+  const metricsFor = (
+    key: 'speed' | 'price' | 'scale',
+    targetArr: number
+  ): StrategyMetric[] => {
+    switch (key) {
+      case 'speed':
+        return [
+          {
+            label: 'Sales Cycle (days)',
+            baseline: `${Math.round(salesCycle)} days`,
+            target: `${Math.round(salesCycle * 0.8)} days`,
+          },
+          {
+            label: 'Win Rate',
+            baseline: `${winRate}%`,
+            target: `${Math.min(70, winRate + 8)}%`,
+          },
+          {
+            label: 'ARR Run-Rate',
+            baseline: formatCurrency(arr),
+            target: formatCurrency(targetArr),
+          },
+        ];
+      case 'price':
+        return [
+          {
+            label: 'Average Contract Value',
+            baseline: formatCurrency(acv),
+            target: formatCurrency(acv * 1.12),
+          },
+          {
+            label: 'Discount Rate',
+            baseline: `${Math.max(0, 25 - winRate / 2).toFixed(1)}%`,
+            target: `${Math.max(0, 15 - winRate / 3).toFixed(1)}%`,
+          },
+          {
+            label: 'ARR Run-Rate',
+            baseline: formatCurrency(arr),
+            target: formatCurrency(targetArr),
+          },
+        ];
+      case 'scale':
+      default:
+        return [
+          {
+            label: 'Pipeline Coverage',
+            baseline: `${pipelineCoverage}x`,
+            target: `${pipelineCoverage + 1}x`,
+          },
+          {
+            label: 'Net Expansion',
+            baseline: `${Math.max(0, 100 - churnRate)}%`,
+            target: `${Math.min(140, 110 - churnRate / 2)}%`,
+          },
+          {
+            label: 'ARR Run-Rate',
+            baseline: formatCurrency(arr),
+            target: formatCurrency(targetArr),
+          },
+        ];
+    }
+  };
+
+  const headlineFor = (key: 'speed' | 'price' | 'scale', lift: number) => {
+    switch (key) {
+      case 'speed':
+        return `Accelerate revenue velocity by ${lift}% through tighter motion design`;
+      case 'price':
+        return `Monetize value moments to unlock ${lift}% more ARR per customer`;
+      case 'scale':
+      default:
+        return `Expand coverage lanes to generate ${lift}% growth with durable execution`;
+    }
+  };
+
+  const narrativeFor = (key: 'speed' | 'price' | 'scale'): string => {
+    switch (key) {
+      case 'speed':
+        return `${primaryGoal} with a focus on compressing the ${salesCycle}-day cycle and arming ${champion} with real-time insights.`;
+      case 'price':
+        return `Shift the monetization story to value realized, pairing stronger packaging with governance that protects margins.`;
+      case 'scale':
+      default:
+        return `Activate new growth lanes by combining partner leverage with instrumented expansion signals across the account base.`;
+    }
+  };
+
+  const variants: StrategyVariant[] = [
+    {
+      key: 'speed',
+      title: 'Velocity Blueprint',
+      headline: headlineFor('speed', speedLift),
+      body: {
+        key: 'speed',
+        title: 'Velocity Blueprint',
+        narrative: narrativeFor('speed'),
+        plays: playsFor('speed'),
+        checklist: checklistFor('speed'),
+        metrics: metricsFor('speed', expectedARRSpeed),
+      },
+    },
+    {
+      key: 'price',
+      title: 'Monetization Upgrade',
+      headline: headlineFor('price', priceLift),
+      body: {
+        key: 'price',
+        title: 'Monetization Upgrade',
+        narrative: narrativeFor('price'),
+        plays: playsFor('price'),
+        checklist: checklistFor('price'),
+        metrics: metricsFor('price', expectedARRPrice),
+      },
+    },
+    {
+      key: 'scale',
+      title: 'Scale Engine',
+      headline: headlineFor('scale', scaleLift),
+      body: {
+        key: 'scale',
+        title: 'Scale Engine',
+        narrative: narrativeFor('scale'),
+        plays: playsFor('scale'),
+        checklist: checklistFor('scale'),
+        metrics: metricsFor('scale', expectedARRScale),
+      },
+    },
+  ];
+
+  return variants;
+}

--- a/supabase/sql/2025-clients_tabs.sql
+++ b/supabase/sql/2025-clients_tabs.sql
@@ -1,0 +1,160 @@
+-- Client workspace schema extensions for 2025 tabbed experience
+
+-- === Discovery + Forms ===
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'discovery_responses'
+  ) THEN
+    CREATE TABLE public.discovery_responses (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      client_id uuid NOT NULL REFERENCES public.clients(id),
+      form_type text NOT NULL,
+      answers jsonb NOT NULL DEFAULT '{}'::jsonb,
+      completed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+      updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+    );
+    CREATE INDEX ON public.discovery_responses (client_id, form_type);
+  END IF;
+END$$;
+
+-- === Data Requirements / Collection ===
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'data_requirements'
+  ) THEN
+    CREATE TABLE public.data_requirements (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      client_id uuid NOT NULL REFERENCES public.clients(id),
+      source_name text NOT NULL,
+      required boolean NOT NULL DEFAULT true,
+      status text NOT NULL DEFAULT 'needed',
+      notes text,
+      meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+      updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+    );
+    CREATE UNIQUE INDEX uq_data_req_client_source ON public.data_requirements(client_id, source_name);
+  END IF;
+END$$;
+
+-- === QRA runs + saved strategies ===
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'qra_runs'
+  ) THEN
+    CREATE TABLE public.qra_runs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      client_id uuid NOT NULL REFERENCES public.clients(id),
+      inputs jsonb NOT NULL DEFAULT '{}'::jsonb,
+      outputs jsonb NOT NULL DEFAULT '{}'::jsonb,
+      selected_strategy_key text,
+      created_by uuid,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+    );
+    CREATE INDEX ON public.qra_runs (client_id, created_at DESC);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'client_strategies'
+  ) THEN
+    CREATE TABLE public.client_strategies (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      client_id uuid NOT NULL REFERENCES public.clients(id),
+      title text NOT NULL,
+      key text,
+      body jsonb NOT NULL DEFAULT '{}'::jsonb,
+      status text NOT NULL DEFAULT 'active',
+      created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+    );
+    CREATE INDEX ON public.client_strategies (client_id, status);
+  END IF;
+END$$;
+
+-- === Client Deliverables (link to existing content_items or external links) ===
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'client_deliverables'
+  ) THEN
+    CREATE TABLE public.client_deliverables (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      client_id uuid NOT NULL REFERENCES public.clients(id),
+      content_id uuid,
+      title text NOT NULL,
+      type text NOT NULL,
+      url text,
+      share_expires_at timestamptz,
+      meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+    );
+    CREATE INDEX ON public.client_deliverables (client_id, type);
+  ELSE
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'client_deliverables' AND column_name = 'content_id'
+    ) THEN
+      ALTER TABLE public.client_deliverables ADD COLUMN content_id uuid;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'client_deliverables' AND column_name = 'share_expires_at'
+    ) THEN
+      ALTER TABLE public.client_deliverables ADD COLUMN share_expires_at timestamptz;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'client_deliverables' AND column_name = 'type'
+    ) THEN
+      ALTER TABLE public.client_deliverables ADD COLUMN type text NOT NULL DEFAULT 'content';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'client_deliverables' AND column_name = 'url'
+    ) THEN
+      ALTER TABLE public.client_deliverables ADD COLUMN url text;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'client_deliverables' AND column_name = 'meta'
+    ) THEN
+      ALTER TABLE public.client_deliverables ADD COLUMN meta jsonb NOT NULL DEFAULT '{}'::jsonb;
+    END IF;
+  END IF;
+END$$;
+
+-- === Finance extensions (terms) ===
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'finance' AND column_name = 'arrangement_type'
+  ) THEN
+    ALTER TABLE public.finance ADD COLUMN arrangement_type text;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'finance' AND column_name = 'equity_stake_pct'
+  ) THEN
+    ALTER TABLE public.finance ADD COLUMN equity_stake_pct numeric(5,2);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'finance' AND column_name = 'projection_mrr'
+  ) THEN
+    ALTER TABLE public.finance ADD COLUMN projection_mrr numeric(14,2);
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- add an idempotent Supabase migration covering discovery responses, data requirements, QRA history, deliverables metadata, and finance terms
- extend client server actions with discovery/data/QRA/deliverable/finance helpers backed by a new deterministic strategy engine
- replace the client profile page with a multi-tab workspace that powers discovery, data, algorithm, architecture, deliverables, finance, and activity views

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eb048bc3d483248184361ed3b48df9