### PR TITLE
fix: guard client owner metadata

### DIFF
--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -75,6 +75,10 @@ export default async function ClientPage({
   if (strategyRows.error) throw strategyRows.error
   if (deliverableRows.error) throw deliverableRows.error
 
+  const ownerRecord = Array.isArray(clientRow.owner)
+    ? clientRow.owner[0] ?? null
+    : (clientRow.owner ?? null)
+
   const client: ClientWorkspaceClient = {
     id: clientRow.id,
     name: clientRow.name,
@@ -86,8 +90,8 @@ export default async function ClientPage({
     phase: clientRow.phase,
     status: clientRow.status,
     notes: clientRow.notes,
-    ownerName: clientRow.owner?.name ?? null,
-    ownerEmail: clientRow.owner?.email ?? null,
+    ownerName: ownerRecord?.name ?? null,
+    ownerEmail: ownerRecord?.email ?? null,
     qbrDate: clientRow.qbr_date,
   }
 


### PR DESCRIPTION
## Summary
- guard the owner join payload on the client workspace page so we read from a single record rather than the raw array

## Testing
- pnpm typecheck *(fails: existing mismatch in app/clients/[id]/tabs/DiscoveryTab.tsx:107)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0af9ea9c83248db30a5865860d7e