### PR TITLE
Fix Projects hub Supabase integration and agent logging

### DIFF
--- a/app/api/agents/run/route.ts
+++ b/app/api/agents/run/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+
+import { createClient } from "@/lib/supabase/server"
+
+export async function POST(request: Request) {
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    payload = null
+  }
+
+  const body = (payload && typeof payload === "object" ? payload : {}) as {
+    kind?: string
+    entityType?: "projects" | "clients"
+    entityId?: string
+    metadata?: Record<string, unknown>
+  }
+
+  const kind = typeof body.kind === "string" && body.kind.trim() ? body.kind.trim() : "unknown"
+  const entityType = body.entityType ?? "projects"
+  const entityId = body.entityId ?? (entityType === "clients" ? "client_workspace" : "projects_hub")
+
+  try {
+    const supabase = await createClient()
+    const { error } = await supabase.from("analytics_events").insert({
+      event_type: "agent_run",
+      entity_type: entityType,
+      entity_id: entityId,
+      metadata: { kind, ...(body.metadata ?? {}) },
+    })
+
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 500 })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error"
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -76,8 +76,8 @@ export default async function ClientPage({
   if (deliverableRows.error) throw deliverableRows.error
 
   const ownerRecord = Array.isArray(clientRow.owner)
-    ? clientRow.owner[0] ?? null
-    : (clientRow.owner ?? null)
+    ? clientRow.owner[0]
+    : clientRow.owner
 
   const client: ClientWorkspaceClient = {
     id: clientRow.id,

--- a/app/projects/ProjectsPageClient.tsx
+++ b/app/projects/ProjectsPageClient.tsx
@@ -1,427 +1,231 @@
-"use client";
+"use client"
 
-import { useCallback, useMemo, useState, useTransition } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
-import Link from "next/link";
+import { useMemo, useState } from "react"
 
-import { PageTabs } from "@/components/layout/PageTabs";
-import { Card } from "@/components/kit/Card";
-import { resolveTabs } from "@/lib/tabs";
-import { cn } from "@/lib/utils";
-import { TRS_CARD, TRS_SUBTITLE } from "@/lib/style";
-import type { Project, ProjectMilestone, ProjectStats, ProjectUpdate } from "@/core/projects/types";
-import { actionSubmitProjectAgentPrompt } from "@/core/projects/actions";
+import { AgentsPanel } from "@/components/projects/AgentsPanel"
+import { FiltersBar, useProjectsFilters } from "@/components/projects/Filters"
+import { KpiStrip } from "@/components/projects/KpiStrip"
+import { ProjectBoard } from "@/components/projects/Board"
+import { ProjectTimeline, type TimelineItem } from "@/components/projects/Timeline"
+import { ProjectsTable } from "@/components/projects/ProjectsTable"
+import { PageTemplate } from "@/components/layout/PageTemplate"
+import { PageTabs } from "@/components/layout/PageTabs"
+import { Input } from "@/ui/input"
+import type {
+  ClientOverview,
+  ClientRow,
+  OpportunityRecord,
+  OwnerRow,
+  ProjectRecord,
+} from "@/core/projects/queries"
 
-type ActivityData = {
-  updates: ProjectUpdate[];
-  milestones: ProjectMilestone[];
-};
+const PAGE_TABS = ["Overview", "Board", "Timeline", "Agents", "Reports"] as const
 
-type ForecastData = {
-  metrics: { label: string; value: string; context?: string }[];
-  timeline: { period: string; count: number; highlight: string }[];
-};
+type Tab = (typeof PAGE_TABS)[number]
 
-const agentPrompts = [
-  "Where are we trending behind schedule?",
-  "Summarize project risks for tomorrow's QBR",
-  "What is the next milestone for RevenueOS expansion?",
-];
-
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-});
-
-const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-});
-
-function formatDate(value?: string | null) {
-  if (!value) return "—";
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return "—";
-  return dateFormatter.format(parsed);
+type ProjectsPageClientProps = {
+  clients: ClientRow[]
+  activeClients: ClientRow[]
+  overview: ClientOverview[]
+  owners: OwnerRow[]
+  projects: ProjectRecord[]
+  opportunities: OpportunityRecord[]
+  stages: string[]
+  healths: string[]
+  kpis: { label: string; value: string }[]
+  generatedAt: string
 }
 
-function formatDateTime(value: string) {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return dateTimeFormatter.format(parsed);
-}
+type OwnerOption = { id: string; label: string }
 
-function healthBadge(health: Project["health"]) {
-  switch (health) {
-    case "green":
-      return "bg-emerald-100 text-emerald-700";
-    case "yellow":
-      return "bg-amber-100 text-amber-700";
-    case "red":
-      return "bg-rose-100 text-rose-700";
-    default:
-      return "bg-gray-100 text-gray-700";
-  }
+type OpportunitySummary = {
+  clientId: string
+  nextStep: string | null
+  dueDate: string | null
+  stage: string | null
 }
 
 export default function ProjectsPageClient({
+  clients,
+  activeClients,
+  overview,
+  owners,
   projects,
-  stats,
-  activity,
-  forecast,
-}: {
-  projects: Project[];
-  stats: ProjectStats;
-  activity: ActivityData;
-  forecast: ForecastData;
-}) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const tabs = useMemo(() => resolveTabs(pathname), [pathname]);
-  const activeTab = useMemo(() => {
-    const current = searchParams.get("tab");
-    return current && tabs.includes(current) ? current : tabs[0];
-  }, [searchParams, tabs]);
+  opportunities,
+  stages,
+  healths,
+  kpis,
+  generatedAt,
+}: ProjectsPageClientProps) {
+  const { filters, setFilters } = useProjectsFilters()
+  const [activeTab, setActiveTab] = useState<Tab>("Overview")
 
-  const buildTabHref = useCallback(
-    (tab: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("tab", tab);
-      return `${pathname}?${params.toString()}`;
-    },
-    [pathname, searchParams],
-  );
+  const ownerOptions = useMemo<OwnerOption[]>(() => {
+    return owners
+      .map((owner) => ({
+        id: owner.id,
+        label: owner.full_name || owner.email || owner.id,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [owners])
 
-  const [prompt, setPrompt] = useState("");
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const opportunitySummaries = useMemo(() => buildOpportunitySummaries(opportunities), [opportunities])
 
-  const submitPrompt = useCallback(
-    (value: string) => {
-      if (!value.trim()) return;
-      startTransition(async () => {
-        const result = await actionSubmitProjectAgentPrompt({ prompt: value });
-        if (result.ok) {
-          setStatusMessage("Request sent to project agent. We'll notify you when the response is ready.");
-          setPrompt("");
-        } else {
-          setStatusMessage(result.error ?? "Unable to submit agent prompt. Please try again.");
-        }
-      });
-    },
-    [],
-  );
+  const timelineItems = useMemo<TimelineItem[]>(() => {
+    const clientNameMap = new Map(clients.map((client) => [client.id, client.name]))
+    return projects.map((project) => ({
+      id: project.id,
+      projectName: project.name,
+      clientName: clientNameMap.get(project.client_id) ?? null,
+      startDate: project.start_date,
+      endDate: project.end_date,
+    }))
+  }, [clients, projects])
+
+  const generatedLabel = useMemo(() => {
+    const parsed = new Date(generatedAt)
+    if (Number.isNaN(parsed.getTime())) return ""
+    return parsed.toLocaleString()
+  }, [generatedAt])
 
   return (
-    <div className="mx-auto max-w-7xl space-y-4 px-4 py-4">
-      <section className="space-y-4">
-        <header className="flex flex-col gap-2">
-          <h1 className="text-2xl font-semibold text-black">
-            Projects Control Center
-          </h1>
-          <p className="text-sm text-gray-600">
-            Coordinate delivery motions, surface risk, and keep stakeholders
-            aligned across TRS programs.
-          </p>
-        </header>
+    <PageTemplate
+      title="Projects"
+      description="Project Management Hub for live client delivery."
+      toolbar={
+        <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="w-full md:max-w-md">
+            <Input
+              placeholder="Search clients or next steps"
+              value={filters.q}
+              onChange={(event) =>
+                setFilters((current) => ({ ...current, q: event.target.value }))
+              }
+            />
+          </div>
+          {generatedLabel ? (
+            <span className="text-xs text-gray-500 md:text-sm">Updated {generatedLabel}</span>
+          ) : null}
+        </div>
+      }
+      stats={<KpiStrip items={kpis} />}
+      statsWrapperClassName="grid gap-3"
+      contentClassName="space-y-4"
+    >
+      <div className="space-y-4">
+        <PageTabs
+          tabs={[...PAGE_TABS]}
+          activeTab={activeTab}
+          onTabChange={(tab) => setActiveTab(tab as Tab)}
+        />
 
-        <PageTabs tabs={tabs} activeTab={activeTab} hrefForTab={buildTabHref} />
-
-        {activeTab === "Overview" && (
+        {activeTab === "Overview" ? (
           <div className="space-y-4">
-            <Card className={cn(TRS_CARD, "p-4")}>
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div>
-                  <div className="text-sm font-semibold text-black">
-                    Live Programs
-                  </div>
-                  <p className="text-xs text-gray-600">
-                    Snapshot of core initiatives and momentum.
-                  </p>
-                </div>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
-                  <div className={cn(TRS_CARD, "p-3")}>
-                    <div className={TRS_SUBTITLE}>Active Projects</div>
-                    <div className="mt-1 text-xl font-semibold text-black">
-                      {stats.active}
-                    </div>
-                    <div className="text-[11px] text-gray-600">
-                      Live delivery
-                    </div>
-                  </div>
-                  <div className={cn(TRS_CARD, "p-3")}>
-                    <div className={TRS_SUBTITLE}>On Track</div>
-                    <div className="mt-1 text-xl font-semibold text-black">
-                      {stats.onTrack}
-                    </div>
-                    <div className="text-[11px] text-gray-600">
-                      Healthy projects
-                    </div>
-                  </div>
-                  <div className={cn(TRS_CARD, "p-3")}>
-                    <div className={TRS_SUBTITLE}>At Risk</div>
-                    <div className="mt-1 text-xl font-semibold text-black">
-                      {stats.atRisk}
-                    </div>
-                    <div className="text-[11px] text-gray-600">
-                      Requires action
-                    </div>
-                  </div>
-                  <div className={cn(TRS_CARD, "p-3")}>
-                    <div className={TRS_SUBTITLE}>Budget Utilization</div>
-                    <div className="mt-1 text-xl font-semibold text-black">
-                      {stats.totalBudget > 0 ? `${stats.budgetUtilization}%` : "—"}
-                    </div>
-                    <div className="text-[11px] text-gray-600">
-                      {stats.totalBudget > 0 ? "Portfolio spend" : "No portfolio budget"}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
-                <table className="w-full text-sm">
-                  <thead className="bg-white text-left text-[12px] uppercase tracking-wide text-gray-500">
-                    <tr>
-                      <th className="px-3 py-2 font-medium">Project</th>
-                      <th className="px-3 py-2 font-medium">Client</th>
-                      <th className="px-3 py-2 font-medium">Phase</th>
-                      <th className="px-3 py-2 font-medium">Owner</th>
-                      <th className="px-3 py-2 font-medium">Health</th>
-                      <th className="px-3 py-2 font-medium">Progress</th>
-                      <th className="px-3 py-2 font-medium">Due</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200 bg-white">
-                    {projects.map((project) => (
-                      <tr key={project.id} className="hover:bg-gray-50">
-                        <td className="px-3 py-2 font-medium text-black">
-                          {project.name}
-                        </td>
-                        <td className="px-3 py-2">
-                          <Link
-                            href={`/clients/${project.clientId}?tab=Projects`}
-                            className="text-gray-700 hover:text-black hover:underline"
-                          >
-                            {project.clientName}
-                          </Link>
-                        </td>
-                        <td className="px-3 py-2 text-gray-700">
-                          {project.phase}
-                        </td>
-                        <td className="px-3 py-2 text-gray-700">
-                          {project.owner}
-                        </td>
-                        <td className="px-3 py-2">
-                          <span
-                            className={cn(
-                              "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold",
-                              healthBadge(project.health),
-                            )}
-                          >
-                            {project.health === "green"
-                              ? "On Track"
-                              : project.health === "yellow"
-                                ? "Watching"
-                                : "Critical"}
-                          </span>
-                        </td>
-                        <td className="px-3 py-2 text-gray-700">
-                          {project.progress}%
-                        </td>
-                        <td className="px-3 py-2 text-gray-700">
-                          {formatDate(project.dueDate)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
+            <FiltersBar
+              stagesAvailable={stages}
+              healthAvailable={healths}
+              owners={ownerOptions}
+              value={filters}
+              onChange={setFilters}
+              showSearch={false}
+            />
+            <ProjectsTable
+              rows={activeClients}
+              overview={overview}
+              owners={ownerOptions}
+              filters={filters}
+              opportunities={opportunitySummaries}
+            />
           </div>
-        )}
+        ) : null}
 
-        {activeTab === "Active" && (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            <Card className={cn(TRS_CARD, "p-4")}> 
-              <div className="flex items-center justify-between">
-                <div className="text-sm font-semibold text-black">Recent updates</div>
-                <span className="text-[11px] uppercase tracking-wide text-gray-500">
-                  {activity.updates.length} logged
-                </span>
-              </div>
-              <div className="mt-3 space-y-3">
-                {activity.updates.length === 0 && (
-                  <div className="rounded-lg border border-dashed border-gray-200 bg-white p-4 text-sm text-gray-600">
-                    Project updates will appear here as delivery owners post check-ins.
-                  </div>
-                )}
-                {activity.updates.slice(0, 6).map((update) => (
-                  <div key={update.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="text-sm font-semibold text-black">{update.projectName}</div>
-                        {update.summary && (
-                          <div className="mt-1 text-[12px] text-gray-600">{update.summary}</div>
-                        )}
-                        <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-500">
-                          {update.authorName} • {formatDateTime(update.createdAt)}
-                        </div>
-                      </div>
-                      {update.status && (
-                        <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-                          {update.status}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </Card>
+        {activeTab === "Board" ? <ProjectBoard rows={activeClients} /> : null}
 
-            <Card className={cn(TRS_CARD, "p-4")}>
-              <div className="flex items-center justify-between">
-                <div className="text-sm font-semibold text-black">Upcoming milestones</div>
-                <span className="text-[11px] uppercase tracking-wide text-gray-500">
-                  {activity.milestones.length} tracked
-                </span>
-              </div>
-              <div className="mt-3 space-y-3">
-                {activity.milestones.length === 0 && (
-                  <div className="rounded-lg border border-dashed border-gray-200 bg-white p-4 text-sm text-gray-600">
-                    Once milestones are defined, due dates and owners will populate here.
-                  </div>
-                )}
-                {activity.milestones.slice(0, 6).map((milestone) => (
-                  <div key={milestone.id} className="rounded-lg border border-gray-200 bg-white p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="text-sm font-semibold text-black">{milestone.title}</div>
-                        <div className="text-[12px] text-gray-600">
-                          {milestone.projectName}
-                        </div>
-                        <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-500">
-                          {milestone.ownerName ?? "Unassigned"} • Due {formatDate(milestone.dueDate)}
-                        </div>
-                      </div>
-                      <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-                        {milestone.status}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </Card>
-          </div>
-        )}
+        {activeTab === "Timeline" ? <ProjectTimeline items={timelineItems} /> : null}
 
-        {activeTab === "Forecast" && (
-          <div className="space-y-4">
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              {forecast.metrics.map((metric) => (
-                <Card key={metric.label} className={cn(TRS_CARD, "p-4")}>
-                  <div className={TRS_SUBTITLE}>{metric.label}</div>
-                  <div className="mt-2 text-2xl font-semibold text-black">
-                    {metric.value}
-                  </div>
-                  <div className="text-[12px] text-gray-600">
-                    {metric.context}
-                  </div>
-                </Card>
-              ))}
-            </div>
-            <Card className={cn(TRS_CARD, "p-4")}>
-              <div className="text-sm font-semibold text-black">Milestone outlook</div>
-              <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-4">
-                {forecast.timeline.length === 0 && (
-                  <div className="rounded-lg border border-dashed border-gray-200 bg-white p-4 text-sm text-gray-600">
-                    No upcoming milestones have been scheduled.
-                  </div>
-                )}
-                {forecast.timeline.map((point) => (
-                  <div key={point.period} className="rounded-lg border border-gray-200 bg-white p-3">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">{point.period}</div>
-                    <div className="mt-1 text-lg font-semibold text-black">{point.count} milestone{point.count === 1 ? "" : "s"}</div>
-                    <div className="text-[12px] text-gray-600">Next: {point.highlight}</div>
-                  </div>
-                ))}
-              </div>
-            </Card>
-          </div>
-        )}
+        {activeTab === "Agents" ? <AgentsPanel /> : null}
 
-        {activeTab === "Agent" && (
-          <Card className={cn(TRS_CARD, "p-4")}>
-            <div className="text-sm font-semibold text-black">
-              Project Intelligence Agent
-            </div>
-            <p className="mt-2 text-sm text-gray-600">
-              Ask the agent to analyze timelines, forecast budget impact, or
-              surface risk across delivery tracks.
+        {activeTab === "Reports" ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-4 text-sm text-gray-700">
+            <div className="text-sm font-medium text-black">Reports</div>
+            <p className="mt-1 text-xs text-gray-600">
+              Export project data for stakeholder reviews.
             </p>
-            <div className="mt-4 space-y-3">
-              <form
-                className="space-y-2"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  submitPrompt(prompt);
-                }}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-800 transition hover:bg-gray-100"
               >
-                <textarea
-                  value={prompt}
-                  onChange={(event) => setPrompt(event.target.value)}
-                  placeholder="Ask about delivery risks, timing, or budget scenarios..."
-                  className="h-28 w-full rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-700 shadow-sm focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
-                  disabled={isPending}
-                />
-                <div className="flex items-center justify-between">
-                  <div className="text-[12px] text-gray-500">
-                    Agent logs are stored in analytics events for auditing.
-                  </div>
-                  <button
-                    type="submit"
-                    disabled={isPending || !prompt.trim()}
-                    className={cn(
-                      "inline-flex items-center rounded-full border border-black px-4 py-1 text-[12px] font-semibold transition",
-                      isPending
-                        ? "cursor-wait bg-black text-white opacity-80"
-                        : "bg-black text-white hover:bg-white hover:text-black",
-                    )}
-                  >
-                    {isPending ? "Submitting..." : "Send to agent"}
-                  </button>
-                </div>
-              </form>
-              {statusMessage && (
-                <div className="rounded-lg border border-gray-200 bg-white p-3 text-[12px] text-gray-600">
-                  {statusMessage}
-                </div>
-              )}
-              <div>
-                <div className="text-[12px] uppercase tracking-wide text-gray-500">
-                  Quick prompts
-                </div>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {agentPrompts.map((prompt) => (
-                    <button
-                      key={prompt}
-                      className="rounded-full border border-gray-300 px-3 py-1 text-[12px] text-gray-700 transition hover:border-black hover:text-black"
-                      type="button"
-                      onClick={() => {
-                        setPrompt(prompt);
-                        setStatusMessage(null);
-                      }}
-                    >
-                      {prompt}
-                    </button>
-                  ))}
-                </div>
-              </div>
+                Export CSV
+              </button>
+              <button
+                type="button"
+                className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-800 transition hover:bg-gray-100"
+              >
+                Export ICS
+              </button>
             </div>
-          </Card>
-        )}
-      </section>
-    </div>
-  );
+          </div>
+        ) : null}
+      </div>
+    </PageTemplate>
+  )
+}
+
+function buildOpportunitySummaries(opportunities: OpportunityRecord[]): OpportunitySummary[] {
+  const byClient = new Map<string, OpportunitySummary>()
+
+  opportunities.forEach((opportunity) => {
+    if (!opportunity.client_id) {
+      return
+    }
+    const candidate: OpportunitySummary = {
+      clientId: opportunity.client_id,
+      nextStep: opportunity.next_step,
+      dueDate: opportunity.next_step_date ?? opportunity.close_date ?? null,
+      stage: normalizeOpportunityStage(opportunity.stage),
+    }
+    const existing = byClient.get(opportunity.client_id)
+    if (!existing) {
+      byClient.set(opportunity.client_id, candidate)
+      return
+    }
+    const chosen = chooseBetterOpportunity(existing, candidate)
+    byClient.set(opportunity.client_id, chosen)
+  })
+
+  return Array.from(byClient.values())
+}
+
+const OPPORTUNITY_STAGE_LABELS: Record<string, string> = {
+  Prospect: "Discovery",
+  Qualify: "Qualification",
+  Proposal: "Proposal",
+  Negotiation: "Negotiation",
+  ClosedWon: "Closed Won",
+  ClosedLost: "Closed Lost",
+}
+
+function normalizeOpportunityStage(stage: string | null) {
+  if (!stage) return null
+  return OPPORTUNITY_STAGE_LABELS[stage] ?? stage
+}
+
+function chooseBetterOpportunity(current: OpportunitySummary, candidate: OpportunitySummary): OpportunitySummary {
+  const currentDue = current.dueDate ? new Date(current.dueDate).getTime() : null
+  const candidateDue = candidate.dueDate ? new Date(candidate.dueDate).getTime() : null
+
+  if (candidateDue != null && currentDue != null) {
+    return candidateDue < currentDue ? candidate : current
+  }
+  if (candidateDue != null && currentDue == null) {
+    return candidate
+  }
+  if (candidateDue == null && currentDue != null) {
+    return current
+  }
+  if (!current.nextStep && candidate.nextStep) {
+    return candidate
+  }
+  return current
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,100 +1,105 @@
+import ProjectsPageClient from "./ProjectsPageClient"
+
 import {
-  actionGetProjectStats,
-  actionListProjectMilestones,
-  actionListProjectUpdates,
-  actionListProjects,
-} from "@/core/projects/actions";
-import ProjectsPageClient from "./ProjectsPageClient";
-import type { ProjectMilestone, ProjectStats } from "@/core/projects/types";
+  fetchClientsForProjects,
+  fetchOverviewJoin,
+  fetchOwners,
+  fetchProjects,
+  fetchOpportunities,
+  type ClientRow,
+} from "@/core/projects/queries"
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+export const dynamic = "force-dynamic"
 
-const percentFormatter = new Intl.NumberFormat("en-US", {
-  style: "percent",
-  maximumFractionDigits: 0,
-});
-
-const monthFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-});
-
-type ForecastMetric = { label: string; value: string; context?: string };
-type ForecastTimelinePoint = { period: string; count: number; highlight: string };
-type ForecastData = { metrics: ForecastMetric[]; timeline: ForecastTimelinePoint[] };
-
-function buildForecastMetrics(stats: ProjectStats): ForecastMetric[] {
-  const portfolioBudget = stats.totalBudget > 0 ? currencyFormatter.format(stats.totalBudget) : "—";
-  const totalSpend = stats.totalSpent > 0 ? currencyFormatter.format(stats.totalSpent) : "—";
-  const utilization = stats.totalBudget > 0 ? `${stats.budgetUtilization}% utilized` : "No budget captured";
-
-  return [
-    { label: "Portfolio Budget", value: portfolioBudget, context: utilization },
-    {
-      label: "Total Spend",
-      value: totalSpend,
-      context: stats.totalBudget > 0 ? `${percentFormatter.format(stats.totalSpent / stats.totalBudget)} of budget` : "—",
-    },
-    {
-      label: "Average Progress",
-      value: `${stats.avgProgress}%`,
-      context: `${stats.active} active projects`,
-    },
-  ];
-}
-
-function buildForecastTimeline(milestones: ProjectMilestone[]): ForecastTimelinePoint[] {
-  const buckets = new Map<string, { count: number; highlight: string }>();
-
-  milestones
-    .filter((milestone) => milestone.dueDate)
-    .forEach((milestone) => {
-      const due = new Date(milestone.dueDate!);
-      const key = `${due.getUTCFullYear()}-${due.getUTCMonth()}`;
-      const bucket = buckets.get(key) ?? { count: 0, highlight: milestone.title };
-      const highlight = bucket.highlight || milestone.title;
-      buckets.set(key, {
-        count: bucket.count + 1,
-        highlight,
-      });
-    });
-
-  return Array.from(buckets.entries())
-    .sort(([a], [b]) => (a < b ? -1 : 1))
-    .slice(0, 4)
-    .map(([key, value]) => {
-      const [year, month] = key.split("-").map((part) => Number(part));
-      const periodDate = new Date(Date.UTC(year, month, 1));
-      return {
-        period: `${monthFormatter.format(periodDate)} ${year}`,
-        count: value.count,
-        highlight: value.highlight,
-      };
-    });
-}
+const STAGE_ORDER = [
+  "Discovery",
+  "Data",
+  "Algorithm",
+  "Architecture",
+  "Deliverables",
+  "Finance",
+  "Onboarding",
+  "Closed",
+] as const
 
 export default async function ProjectsPage() {
-  const [projects, stats, updates, milestones] = await Promise.all([
-    actionListProjects(),
-    actionGetProjectStats(),
-    actionListProjectUpdates(),
-    actionListProjectMilestones(),
-  ]);
+  const [clients, overview, owners, projects, opportunities] = await Promise.all([
+    fetchClientsForProjects(),
+    fetchOverviewJoin(),
+    fetchOwners(),
+    fetchProjects(),
+    fetchOpportunities(),
+  ])
 
-  const forecast: ForecastData = {
-    metrics: buildForecastMetrics(stats),
-    timeline: buildForecastTimeline(milestones),
-  };
+  const activeClients = clients.filter((client) => (client.status ?? "").toLowerCase() === "active")
+
+  const stages = buildStageFilters(activeClients)
+  const healths = buildHealthFilters(activeClients)
+  const kpis = buildKpis(clients)
 
   return (
     <ProjectsPageClient
+      clients={clients}
+      activeClients={activeClients}
+      overview={overview}
+      owners={owners}
       projects={projects}
-      stats={stats}
-      activity={{ updates, milestones }}
-      forecast={forecast}
+      opportunities={opportunities}
+      stages={stages}
+      healths={healths}
+      kpis={kpis}
+      generatedAt={new Date().toISOString()}
     />
-  );
+  )
+}
+
+function buildStageFilters(clients: ClientRow[]) {
+  const stageSet = new Set<string>()
+  clients.forEach((client) => {
+    if (client.stage) {
+      stageSet.add(client.stage)
+    }
+  })
+  const preferred = STAGE_ORDER.filter((stage) => stageSet.has(stage))
+  const extras = Array.from(stageSet).filter((stage) => !STAGE_ORDER.includes(stage as typeof STAGE_ORDER[number]))
+  extras.sort((a, b) => a.localeCompare(b))
+  return [...preferred, ...extras]
+}
+
+function buildHealthFilters(clients: ClientRow[]) {
+  const healthSet = new Set<string>()
+  clients.forEach((client) => {
+    if (client.health) {
+      healthSet.add(client.health)
+    }
+  })
+  return Array.from(healthSet).sort((a, b) => a.localeCompare(b))
+}
+
+function buildKpis(clients: ClientRow[]) {
+  const activeClients = clients.filter((client) => (client.status ?? "").toLowerCase() === "active").length
+  const onboardingClients = clients.filter((client) => (client.phase ?? "").toLowerCase() === "onboarding").length
+
+  const stageCounts = STAGE_ORDER.map((stage) => ({
+    stage,
+    count: clients.filter((client) => (client.stage ?? "").toLowerCase() === stage.toLowerCase()).length,
+  }))
+
+  const arrTotal = clients.reduce((sum, client) => {
+    return sum + (typeof client.arr === "number" ? client.arr : 0)
+  }, 0)
+  const arrFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  })
+
+  const items = [
+    { label: "Active clients", value: String(activeClients) },
+    { label: "Onboarding", value: String(onboardingClients) },
+    ...stageCounts.map(({ stage, count }) => ({ label: stage, value: String(count) })),
+    { label: "ARR total", value: arrFormatter.format(arrTotal) },
+  ]
+
+  return items
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -12,6 +12,7 @@ import MobileBottomNav from '@/components/nav/MobileBottomNav'
 import SearchOverlay from '@/components/nav/SearchOverlay'
 import { MAIN_NAV, type NavItem } from '@/lib/navigation'
 import { cn, isActivePath } from '@/lib/utils'
+import { ToastViewport } from '@/ui/toast'
 
 const FULL_SHELL_EXCLUSIONS = new Set(['/login'])
 
@@ -89,6 +90,7 @@ export default function AppShell({ children }: AppShellProps) {
         </main>
       </div>
       <MobileBottomNav currentPath={pathname ?? ''} className="lg:hidden" />
+      <ToastViewport />
     </div>
   )
 }

--- a/components/projects/AgentsPanel.tsx
+++ b/components/projects/AgentsPanel.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useCallback, useState, useTransition } from "react"
+
+import { showToast } from "@/ui/toast"
+
+const BUTTON_CLASSES =
+  "h-9 px-3 rounded-md border border-gray-300 bg-white text-sm text-gray-800 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+
+type AgentKind = "risk_scan" | "collections_nudge" | "ops_check"
+
+type AgentResponse = {
+  ok: boolean
+  error?: string
+}
+
+export function AgentsPanel() {
+  const [status, setStatus] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const runAgent = useCallback((kind: AgentKind) => {
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/agents/run", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ kind, entityType: "projects", entityId: "projects_hub" }),
+        })
+
+        const payload: AgentResponse = await response
+          .json()
+          .catch(() => ({ ok: false, error: "Unknown response" }))
+
+        if (!response.ok || !payload.ok) {
+          const message = payload.error ?? "Agent run failed"
+          setStatus(message)
+          showToast({ title: "Agent run failed", description: message, variant: "destructive" })
+          return
+        }
+
+        const successMessage = `Agent run logged: ${kind}`
+        setStatus(successMessage)
+        showToast({ title: "Agent queued", description: successMessage, variant: "success" })
+      } catch (error) {
+        const message = "Unable to reach agent service"
+        setStatus(message)
+        showToast({ title: "Agent run failed", description: message, variant: "destructive" })
+      }
+    })
+  }, [])
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-sm font-medium text-black">Project Agents</div>
+      <p className="mt-1 text-xs text-gray-600">
+        Trigger playbooks and log activity for portfolio governance.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("risk_scan")}
+          disabled={isPending}
+        >
+          Run Risk Scan
+        </button>
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("collections_nudge")}
+          disabled={isPending}
+        >
+          Collections Nudge
+        </button>
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("ops_check")}
+          disabled={isPending}
+        >
+          Ops Check
+        </button>
+      </div>
+      {status ? <div className="mt-3 text-xs text-gray-600">{status}</div> : null}
+    </div>
+  )
+}

--- a/components/projects/Board.tsx
+++ b/components/projects/Board.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import Link from "next/link"
+
+import type { ClientRow } from "@/core/projects/queries"
+
+const DEFAULT_STAGES = ["Discovery", "Data", "Algorithm", "Architecture", "Closed"] as const
+
+export function ProjectBoard({ rows }: { rows: ClientRow[] }) {
+  const extraStages = Array.from(
+    new Set(
+      rows
+        .map((row) => row.stage)
+        .filter((stage): stage is string => Boolean(stage) && !DEFAULT_STAGES.includes(stage as (typeof DEFAULT_STAGES)[number])),
+    ),
+  ).sort((a, b) => a.localeCompare(b))
+
+  const stageOrder = [...DEFAULT_STAGES, ...extraStages]
+  const stageBuckets = new Map<string, ClientRow[]>()
+  stageOrder.forEach((stage) => {
+    stageBuckets.set(stage, [])
+  })
+
+  rows.forEach((row) => {
+    const stage = row.stage && stageBuckets.has(row.stage) ? row.stage : "Discovery"
+    stageBuckets.get(stage)!.push(row)
+  })
+
+  return (
+    <div className="grid gap-3 md:grid-cols-5">
+      {stageOrder.map((stage) => {
+        const bucket = stageBuckets.get(stage) ?? []
+        return (
+          <div key={stage} className="rounded-xl border border-gray-200 bg-white p-3">
+            <div className="text-xs font-medium text-gray-700">{stage}</div>
+            <div className="mt-2 space-y-2">
+              {bucket.map((row) => (
+                <Link
+                  key={row.id}
+                  href={`/clients/${row.id}`}
+                  className="block rounded-lg border border-gray-200 p-2 transition hover:bg-gray-50"
+                >
+                  <div className="text-sm font-medium text-black">{row.name}</div>
+                  <div className="text-[11px] text-gray-500">Health: {row.health ?? "-"}</div>
+                </Link>
+              ))}
+              {!bucket.length ? (
+                <div className="text-[12px] text-gray-500">No items</div>
+              ) : null}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/projects/Filters.tsx
+++ b/components/projects/Filters.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState } from "react"
+
+export type Filters = {
+  q: string
+  stages: string[]
+  health: string[]
+  ownerId: string | null
+}
+
+export function useProjectsFilters() {
+  const [filters, setFilters] = useState<Filters>({
+    q: "",
+    stages: [],
+    health: [],
+    ownerId: null,
+  })
+
+  return { filters, setFilters }
+}
+
+export function FiltersBar({
+  stagesAvailable,
+  healthAvailable,
+  owners,
+  value,
+  onChange,
+  showSearch = true,
+}: {
+  stagesAvailable: string[]
+  healthAvailable: string[]
+  owners: { id: string; label: string }[]
+  value: Filters
+  onChange: (filters: Filters) => void
+  showSearch?: boolean
+}) {
+  const update = (patch: Partial<Filters>) => {
+    onChange({ ...value, ...patch })
+  }
+
+  const toggle = (key: "stages" | "health", option: string) => {
+    const existing = new Set(value[key])
+    if (existing.has(option)) {
+      existing.delete(option)
+    } else {
+      existing.add(option)
+    }
+    onChange({ ...value, [key]: Array.from(existing) })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+      {showSearch ? (
+        <input
+          className="h-9 w-full rounded-md border border-gray-300 px-2 text-sm md:w-64"
+          placeholder="Search client or next step"
+          value={value.q}
+          onChange={(event) => update({ q: event.target.value })}
+        />
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <select
+          className="h-9 rounded-md border border-gray-300 px-2 text-sm"
+          value={value.ownerId ?? ""}
+          onChange={(event) => update({ ownerId: event.target.value || null })}
+          disabled={!owners.length}
+        >
+          <option value="">All owners</option>
+          {owners.map((owner) => (
+            <option key={owner.id} value={owner.id}>
+              {owner.label}
+            </option>
+          ))}
+        </select>
+        {stagesAvailable.length > 0 ? (
+          <MultiSelectChips
+            label="Stage"
+            values={stagesAvailable}
+            active={value.stages}
+            onToggle={(option) => toggle("stages", option)}
+          />
+        ) : null}
+        {healthAvailable.length > 0 ? (
+          <MultiSelectChips
+            label="Health"
+            values={healthAvailable}
+            active={value.health}
+            onToggle={(option) => toggle("health", option)}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+type MultiSelectChipsProps = {
+  label: string
+  values: string[]
+  active: string[]
+  onToggle: (value: string) => void
+}
+
+function MultiSelectChips({ label, values, active, onToggle }: MultiSelectChipsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-gray-500">{label}:</span>
+      {values.map((value) => {
+        const isActive = active.includes(value)
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onToggle(value)}
+            className={`h-7 rounded-md border px-2 text-xs ${
+              isActive
+                ? "border-black bg-black text-white"
+                : "border-gray-300 bg-white text-gray-700 transition hover:bg-gray-100"
+            }`}
+          >
+            {value}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/projects/KpiStrip.tsx
+++ b/components/projects/KpiStrip.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+type KPI = { label: string; value: string }
+
+export function KpiStrip({ items }: { items: KPI[] }) {
+  if (!items.length) {
+    return null
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">
+      {items.map((kpi, index) => (
+        <div
+          key={`${kpi.label}-${index}`}
+          className="rounded-xl border border-gray-200 bg-white p-3"
+        >
+          <div className="text-[11px] text-gray-500">{kpi.label}</div>
+          <div className="mt-1 text-xl font-semibold text-black">{kpi.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/projects/ProjectsTable.tsx
+++ b/components/projects/ProjectsTable.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useMemo } from "react"
+import { useRouter } from "next/navigation"
+
+import type { ClientOverview, ClientRow } from "@/core/projects/queries"
+
+import type { Filters } from "./Filters"
+
+type OpportunitySummary = {
+  clientId: string
+  nextStep: string | null
+  dueDate: string | null
+  stage: string | null
+}
+
+type OwnerOption = {
+  id: string
+  label: string
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+})
+
+export function ProjectsTable({
+  rows,
+  overview,
+  filters,
+  owners,
+  opportunities,
+}: {
+  rows: ClientRow[]
+  overview: ClientOverview[]
+  filters: Filters
+  owners: OwnerOption[]
+  opportunities: OpportunitySummary[]
+}) {
+  const router = useRouter()
+
+  const overviewMap = useMemo(() => {
+    return overview.reduce<Map<string, ClientOverview>>((map, entry) => {
+      map.set(entry.client_id, entry)
+      return map
+    }, new Map())
+  }, [overview])
+
+  const ownerMap = useMemo(() => {
+    return owners.reduce<Map<string, string>>((map, owner) => {
+      map.set(owner.id, owner.label)
+      return map
+    }, new Map())
+  }, [owners])
+
+  const opportunityMap = useMemo(() => {
+    return opportunities.reduce<Map<string, OpportunitySummary>>((map, summary) => {
+      map.set(summary.clientId, summary)
+      return map
+    }, new Map())
+  }, [opportunities])
+
+  const filteredRows = useMemo(() => {
+    return rows.filter((row) => {
+      if (filters.ownerId && row.owner_id !== filters.ownerId) {
+        return false
+      }
+      if (filters.stages.length && !filters.stages.includes(row.stage ?? "")) {
+        return false
+      }
+      if (filters.health.length && !filters.health.includes(row.health ?? "")) {
+        return false
+      }
+      if (filters.q) {
+        const search = filters.q.toLowerCase()
+        const opportunityEntry = opportunityMap.get(row.id)
+        const ownerName = ownerMap.get(row.owner_id ?? "") ?? ""
+        const haystack = `${row.name} ${row.stage ?? ""} ${
+          opportunityEntry?.nextStep ?? ""
+        } ${opportunityEntry?.stage ?? ""} ${ownerName}`.toLowerCase()
+        if (!haystack.includes(search)) {
+          return false
+        }
+      }
+      return true
+    })
+  }, [filters, opportunityMap, ownerMap, rows])
+
+  if (!rows.length) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+        No active clients found. Add active clients in Supabase to populate this view.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <table className="w-full text-sm">
+        <thead className="border-b border-gray-200">
+          <tr className="text-left text-[12px] text-gray-600">
+            <th className="px-3 py-2">Client</th>
+            <th className="px-3 py-2">Stage</th>
+            <th className="px-3 py-2">Health</th>
+            <th className="px-3 py-2">Owner</th>
+            <th className="px-3 py-2">ARR</th>
+            <th className="px-3 py-2">Weighted Pipeline</th>
+            <th className="px-3 py-2">Next Step</th>
+            <th className="px-3 py-2">Due</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {filteredRows.map((row) => {
+            const overviewEntry = overviewMap.get(row.id)
+            const opportunityEntry = opportunityMap.get(row.id)
+            const ownerLabel = row.owner_id ? ownerMap.get(row.owner_id) : null
+            const arrValue = row.arr ?? null
+            const weightedValue = overviewEntry?.weighted_value ?? null
+            const dueDate = opportunityEntry?.dueDate ?? null
+            const dueDateLabel = dueDate
+              ? (() => {
+                  const parsed = new Date(dueDate)
+                  return Number.isNaN(parsed.getTime())
+                    ? dueDate
+                    : dateFormatter.format(parsed)
+                })()
+              : "—"
+
+            return (
+              <tr
+                key={row.id}
+                className="cursor-pointer transition hover:bg-gray-50"
+                onClick={() => router.push(`/clients/${row.id}`)}
+              >
+                <td className="px-3 py-2 text-black">{row.name}</td>
+                <td className="px-3 py-2">{row.stage ?? "-"}</td>
+                <td className="px-3 py-2">{row.health ?? "-"}</td>
+                <td className="px-3 py-2">{ownerLabel ?? row.owner_id ?? "-"}</td>
+                <td className="px-3 py-2">
+                  {arrValue != null ? currencyFormatter.format(arrValue) : "-"}
+                </td>
+                <td className="px-3 py-2">
+                  {weightedValue != null ? currencyFormatter.format(weightedValue) : "-"}
+                </td>
+                <td className="px-3 py-2">
+                  {opportunityEntry?.nextStep ? opportunityEntry.nextStep : "—"}
+                </td>
+                <td className="px-3 py-2">{dueDateLabel}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {!filteredRows.length ? (
+        <div className="p-6 text-sm text-gray-600">No projects match current filters.</div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/projects/Timeline.tsx
+++ b/components/projects/Timeline.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useMemo } from "react"
+
+export type TimelineItem = {
+  id: string
+  projectName: string
+  clientName: string | null
+  startDate: string | null
+  endDate: string | null
+}
+
+type TimelinePoint = TimelineItem & {
+  startValue: number
+  endValue: number
+}
+
+export function ProjectTimeline({ items }: { items: TimelineItem[] }) {
+  const processed = useMemo(() => {
+    return items
+      .map<TimelinePoint | null>((item) => {
+        if (!item.startDate || !item.endDate) {
+          return null
+        }
+        const start = new Date(item.startDate)
+        const end = new Date(item.endDate)
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+          return null
+        }
+        return {
+          ...item,
+          startValue: start.getTime(),
+          endValue: end.getTime(),
+        }
+      })
+      .filter((entry): entry is TimelinePoint => Boolean(entry))
+  }, [items])
+
+  if (!processed.length) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-3 text-sm text-gray-600">
+        No project timelines recorded yet.
+      </div>
+    )
+  }
+
+  const minStart = Math.min(...processed.map((item) => item.startValue))
+  const maxEnd = Math.max(...processed.map((item) => item.endValue))
+  const span = Math.max(maxEnd - minStart, 1)
+  const labelWidth = 160
+  const barHeight = 18
+  const gap = 12
+  const chartWidth = 640
+  const viewWidth = labelWidth + chartWidth + 16
+  const viewHeight = processed.length * (barHeight + gap) + gap
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-sm font-medium text-black">Timeline</div>
+      <div className="mt-2 overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+          className="h-full w-full min-w-[320px]"
+          role="img"
+          aria-label="Project schedule overview"
+        >
+          {processed.map((item, index) => {
+            const y = gap / 2 + index * (barHeight + gap)
+            const offset = ((item.startValue - minStart) / span) * chartWidth
+            const width = Math.max(((item.endValue - item.startValue) / span) * chartWidth, 6)
+            return (
+              <g key={item.id}>
+                <text x={8} y={y + barHeight / 1.5} fill="#6b7280" fontSize="11">
+                  {item.projectName}
+                  {item.clientName ? ` • ${item.clientName}` : ""}
+                </text>
+                <rect
+                  x={labelWidth + offset}
+                  y={y}
+                  width={width}
+                  height={barHeight}
+                  rx={4}
+                  fill="#111827"
+                />
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/core/projects/queries.ts
+++ b/core/projects/queries.ts
@@ -1,0 +1,123 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type ClientRow = {
+  id: string
+  name: string
+  status: string | null
+  stage: string | null
+  health: string | null
+  owner_id: string | null
+  arr: number | null
+  created_at: string
+  phase: string | null
+  organization_id: string | null
+}
+
+export type ClientOverview = {
+  client_id: string
+  client_name: string
+  client_type: string | null
+  organization_id: string | null
+  owner_id: string | null
+  pipeline_id: string | null
+  pipeline_stage: string | null
+  pipeline_value: number | null
+  weighted_value: number | null
+  probability: number | null
+  finance_id: string | null
+  mrr: number | null
+  ar_outstanding: number | null
+  ar_collected: number | null
+}
+
+export type OwnerRow = {
+  id: string
+  email: string | null
+  full_name: string | null
+  role: string | null
+}
+
+export type ProjectRecord = {
+  id: string
+  client_id: string
+  name: string
+  status: string | null
+  health: string | null
+  start_date: string | null
+  end_date: string | null
+}
+
+export type OpportunityRecord = {
+  id: string
+  client_id: string
+  name: string | null
+  stage: string | null
+  amount: number | null
+  probability: number | null
+  next_step: string | null
+  next_step_date: string | null
+  close_date: string | null
+  owner_id: string | null
+}
+
+async function getClient() {
+  const supabase = await createClient()
+  return supabase
+}
+
+export async function fetchClientsForProjects() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("clients")
+    .select(
+      "id,name,status,stage,health,owner_id,arr,created_at,phase,organization_id",
+    )
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as ClientRow[]
+}
+
+export async function fetchOverviewJoin() {
+  const supabase = await getClient()
+  const { data, error } = await supabase.from("vw_client_overview").select("*")
+
+  if (error) throw error
+  return (data ?? []) as ClientOverview[]
+}
+
+export async function fetchOwners() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("users")
+    .select("id,email,full_name,role")
+    .order("email", { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as OwnerRow[]
+}
+
+export async function fetchProjects() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id,client_id,name,status,health,start_date,end_date")
+    .order("start_date", { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as ProjectRecord[]
+}
+
+export async function fetchOpportunities() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("opportunities")
+    .select(
+      "id,client_id,name,stage,amount,probability,next_step,next_step_date,close_date,owner_id",
+    )
+
+  if (error) throw error
+  return (data ?? []) as OpportunityRecord[]
+}


### PR DESCRIPTION
## Summary
- rebuild the Projects workspace around Supabase-backed overview, board, timeline, and agents tabs that fit the grayscale dashboard shell
- add reusable project filters, KPIs, timeline, and table components plus shared Supabase query helpers
- implement the agent run API, surface toast feedback globally, and tighten client discovery form typing

## Testing
- pnpm run typecheck
- NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=stub CI=1 pnpm run build
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb24db4578832481cd014ff69caad3