### PR TITLE
fix(PR#80): restore projects shell and onboarding flows

### DIFF
--- a/app/api/agents/run/route.ts
+++ b/app/api/agents/run/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(request: Request) {
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    payload = null
+  }
+
+  const body = (payload && typeof payload === 'object' ? payload : {}) as {
+    kind?: string
+    entityType?: 'projects' | 'clients' | 'content'
+    entityId?: string
+    metadata?: Record<string, unknown>
+  }
+
+  const kind = typeof body.kind === 'string' && body.kind.trim() ? body.kind.trim() : 'unknown'
+  const entityType = body.entityType ?? 'projects'
+  const entityId =
+    body.entityId ??
+    (entityType === 'clients'
+      ? 'client_workspace'
+      : entityType === 'content'
+        ? 'content_studio'
+        : 'projects_hub')
+
+  try {
+    const supabase = await createClient()
+    const { error } = await supabase.from('analytics_events').insert({
+      event_type: 'agent_run',
+      entity_type: entityType,
+      entity_id: entityId,
+      metadata: { kind, ...(body.metadata ?? {}) },
+    })
+
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 500 })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error'
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/clients/[id]/ClientWorkspace.tsx
+++ b/app/clients/[id]/ClientWorkspace.tsx
@@ -24,6 +24,7 @@ import ArchitectureTab from './tabs/ArchitectureTab'
 import DeliverablesTab from './tabs/DeliverablesTab'
 import FinanceTab from './tabs/FinanceTab'
 import ActivityTab from './tabs/ActivityTab'
+import OnboardingTab from './tabs/OnboardingTab'
 
 const TAB_ITEMS: { key: TabKey; label: string }[] = [
   { key: 'discovery', label: 'Discovery' },
@@ -33,6 +34,7 @@ const TAB_ITEMS: { key: TabKey; label: string }[] = [
   { key: 'deliverables', label: 'Deliverables' },
   { key: 'finance', label: 'Finance' },
   { key: 'activity', label: 'Activity' },
+  { key: 'onboarding', label: 'Onboarding' },
 ]
 
 export type TabKey =
@@ -43,6 +45,7 @@ export type TabKey =
   | 'deliverables'
   | 'finance'
   | 'activity'
+  | 'onboarding'
 
 export type ClientWorkspaceClient = {
   id: string
@@ -203,6 +206,9 @@ export default function ClientWorkspace({
         </TabsContent>
         <TabsContent value="activity" className="border border-dashed border-[color:var(--color-outline)]">
           <ActivityTab items={activity} />
+        </TabsContent>
+        <TabsContent value="onboarding" className="border border-dashed border-[color:var(--color-outline)]">
+          <OnboardingTab clientId={client.id} phase={client.phase} status={client.status} />
         </TabsContent>
       </Tabs>
     </div>

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -5,7 +5,16 @@ import type { ActivityItem, ClientDeliverable, ClientStrategy, DataRequirement, 
 import ClientWorkspace, { ClientFinance, ClientWorkspaceClient, TabKey } from './ClientWorkspace'
 import { createServerClient } from '@/lib/supabase/server'
 
-const TAB_KEYS: TabKey[] = ['discovery', 'data', 'algorithm', 'architecture', 'deliverables', 'finance', 'activity']
+const TAB_KEYS: TabKey[] = [
+  'discovery',
+  'data',
+  'algorithm',
+  'architecture',
+  'deliverables',
+  'finance',
+  'activity',
+  'onboarding',
+]
 
 export default async function ClientPage({
   params,
@@ -76,8 +85,8 @@ export default async function ClientPage({
   if (deliverableRows.error) throw deliverableRows.error
 
   const ownerRecord = Array.isArray(clientRow.owner)
-    ? clientRow.owner[0] ?? null
-    : (clientRow.owner ?? null)
+    ? clientRow.owner[0]
+    : clientRow.owner
 
   const client: ClientWorkspaceClient = {
     id: clientRow.id,

--- a/app/clients/[id]/tabs/OnboardingTab.tsx
+++ b/app/clients/[id]/tabs/OnboardingTab.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useTransition } from 'react'
+
+import { ensureOnboarding, setClientPhase } from '../actions'
+import { Badge } from '@/ui/badge'
+import { Button } from '@/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
+import { showToast } from '@/ui/toast'
+
+type OnboardingTabProps = {
+  clientId: string
+  phase: string | null
+  status: string | null
+}
+
+const PHASE_LABELS: Record<string, string> = {
+  onboarding: 'Onboarding',
+  active: 'Active',
+  paused: 'Paused',
+}
+
+const STATUS_HINTS: Record<string, string> = {
+  onboarding: 'Working through kickoff tasks and data collection.',
+  active: 'Engagement is live with recurring delivery.',
+  paused: 'Engagement paused — confirm restart plan.',
+}
+
+export default function OnboardingTab({ clientId, phase, status }: OnboardingTabProps) {
+  const [isPending, startTransition] = useTransition()
+
+  const normalizedPhase = (phase ?? 'onboarding').toLowerCase()
+  const normalizedStatus = (status ?? 'Active').toLowerCase()
+
+  const handleEnsure = () => {
+    startTransition(async () => {
+      try {
+        await ensureOnboarding(clientId)
+        showToast({
+          title: 'Onboarding initialized',
+          description: 'Kickoff checklist generated from Supabase workflow.',
+          variant: 'success',
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to initialize onboarding'
+        showToast({ title: 'Onboarding failed', description: message, variant: 'destructive' })
+      }
+    })
+  }
+
+  const handlePhaseChange = (nextPhase: 'Onboarding' | 'Active') => {
+    startTransition(async () => {
+      try {
+        await setClientPhase(clientId, nextPhase)
+        showToast({
+          title: 'Client phase updated',
+          description: `Client marked as ${nextPhase.toLowerCase()}.`,
+          variant: 'success',
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to update phase'
+        showToast({ title: 'Phase update failed', description: message, variant: 'destructive' })
+      }
+    })
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card className="border border-[color:var(--color-outline)] bg-white">
+        <CardHeader>
+          <CardTitle>Current State</CardTitle>
+          <CardDescription>Track onboarding milestones and shift the client into delivery.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-[color:var(--color-text-muted)]">
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">Phase</span>
+            <Badge variant="outline">{PHASE_LABELS[normalizedPhase] ?? phase ?? 'Onboarding'}</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">Status</span>
+            <Badge variant="outline">{status ?? 'Active'}</Badge>
+          </div>
+          <p className="text-xs leading-relaxed">
+            {STATUS_HINTS[normalizedStatus] ?? 'Use the actions on the right to update onboarding progress.'}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-[color:var(--color-outline)] bg-white">
+        <CardHeader>
+          <CardTitle>Actions</CardTitle>
+          <CardDescription>Log kickoff in Supabase and switch the client into an active phase.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full justify-start"
+            onClick={handleEnsure}
+            disabled={isPending}
+          >
+            Generate onboarding checklist
+          </Button>
+          <Button
+            type="button"
+            className="w-full justify-start"
+            onClick={() => handlePhaseChange('Onboarding')}
+            disabled={isPending || normalizedPhase === 'onboarding'}
+          >
+            Mark as onboarding
+          </Button>
+          <Button
+            type="button"
+            className="w-full justify-start"
+            onClick={() => handlePhaseChange('Active')}
+            disabled={isPending || normalizedPhase === 'active'}
+          >
+            Mark as active delivery
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,100 +1,105 @@
+import ProjectsPageClient from "./ProjectsPageClient"
+
 import {
-  actionGetProjectStats,
-  actionListProjectMilestones,
-  actionListProjectUpdates,
-  actionListProjects,
-} from "@/core/projects/actions";
-import ProjectsPageClient from "./ProjectsPageClient";
-import type { ProjectMilestone, ProjectStats } from "@/core/projects/types";
+  fetchClientsForProjects,
+  fetchOverviewJoin,
+  fetchOwners,
+  fetchProjects,
+  fetchOpportunities,
+  type ClientRow,
+} from "@/core/projects/queries"
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+export const dynamic = "force-dynamic"
 
-const percentFormatter = new Intl.NumberFormat("en-US", {
-  style: "percent",
-  maximumFractionDigits: 0,
-});
-
-const monthFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-});
-
-type ForecastMetric = { label: string; value: string; context?: string };
-type ForecastTimelinePoint = { period: string; count: number; highlight: string };
-type ForecastData = { metrics: ForecastMetric[]; timeline: ForecastTimelinePoint[] };
-
-function buildForecastMetrics(stats: ProjectStats): ForecastMetric[] {
-  const portfolioBudget = stats.totalBudget > 0 ? currencyFormatter.format(stats.totalBudget) : "—";
-  const totalSpend = stats.totalSpent > 0 ? currencyFormatter.format(stats.totalSpent) : "—";
-  const utilization = stats.totalBudget > 0 ? `${stats.budgetUtilization}% utilized` : "No budget captured";
-
-  return [
-    { label: "Portfolio Budget", value: portfolioBudget, context: utilization },
-    {
-      label: "Total Spend",
-      value: totalSpend,
-      context: stats.totalBudget > 0 ? `${percentFormatter.format(stats.totalSpent / stats.totalBudget)} of budget` : "—",
-    },
-    {
-      label: "Average Progress",
-      value: `${stats.avgProgress}%`,
-      context: `${stats.active} active projects`,
-    },
-  ];
-}
-
-function buildForecastTimeline(milestones: ProjectMilestone[]): ForecastTimelinePoint[] {
-  const buckets = new Map<string, { count: number; highlight: string }>();
-
-  milestones
-    .filter((milestone) => milestone.dueDate)
-    .forEach((milestone) => {
-      const due = new Date(milestone.dueDate!);
-      const key = `${due.getUTCFullYear()}-${due.getUTCMonth()}`;
-      const bucket = buckets.get(key) ?? { count: 0, highlight: milestone.title };
-      const highlight = bucket.highlight || milestone.title;
-      buckets.set(key, {
-        count: bucket.count + 1,
-        highlight,
-      });
-    });
-
-  return Array.from(buckets.entries())
-    .sort(([a], [b]) => (a < b ? -1 : 1))
-    .slice(0, 4)
-    .map(([key, value]) => {
-      const [year, month] = key.split("-").map((part) => Number(part));
-      const periodDate = new Date(Date.UTC(year, month, 1));
-      return {
-        period: `${monthFormatter.format(periodDate)} ${year}`,
-        count: value.count,
-        highlight: value.highlight,
-      };
-    });
-}
+const STAGE_ORDER = [
+  "Discovery",
+  "Data",
+  "Algorithm",
+  "Architecture",
+  "Deliverables",
+  "Finance",
+  "Onboarding",
+  "Closed",
+] as const
 
 export default async function ProjectsPage() {
-  const [projects, stats, updates, milestones] = await Promise.all([
-    actionListProjects(),
-    actionGetProjectStats(),
-    actionListProjectUpdates(),
-    actionListProjectMilestones(),
-  ]);
+  const [clients, overview, owners, projects, opportunities] = await Promise.all([
+    fetchClientsForProjects(),
+    fetchOverviewJoin(),
+    fetchOwners(),
+    fetchProjects(),
+    fetchOpportunities(),
+  ])
 
-  const forecast: ForecastData = {
-    metrics: buildForecastMetrics(stats),
-    timeline: buildForecastTimeline(milestones),
-  };
+  const activeClients = clients.filter((client) => (client.status ?? "").toLowerCase() === "active")
+
+  const stages = buildStageFilters(activeClients)
+  const healths = buildHealthFilters(activeClients)
+  const kpis = buildKpis(clients)
 
   return (
     <ProjectsPageClient
+      clients={clients}
+      activeClients={activeClients}
+      overview={overview}
+      owners={owners}
       projects={projects}
-      stats={stats}
-      activity={{ updates, milestones }}
-      forecast={forecast}
+      opportunities={opportunities}
+      stages={stages}
+      healths={healths}
+      kpis={kpis}
+      generatedAt={new Date().toISOString()}
     />
-  );
+  )
+}
+
+function buildStageFilters(clients: ClientRow[]) {
+  const stageSet = new Set<string>()
+  clients.forEach((client) => {
+    if (client.stage) {
+      stageSet.add(client.stage)
+    }
+  })
+  const preferred = STAGE_ORDER.filter((stage) => stageSet.has(stage))
+  const extras = Array.from(stageSet).filter((stage) => !STAGE_ORDER.includes(stage as typeof STAGE_ORDER[number]))
+  extras.sort((a, b) => a.localeCompare(b))
+  return [...preferred, ...extras]
+}
+
+function buildHealthFilters(clients: ClientRow[]) {
+  const healthSet = new Set<string>()
+  clients.forEach((client) => {
+    if (client.health) {
+      healthSet.add(client.health)
+    }
+  })
+  return Array.from(healthSet).sort((a, b) => a.localeCompare(b))
+}
+
+function buildKpis(clients: ClientRow[]) {
+  const activeClients = clients.filter((client) => (client.status ?? "").toLowerCase() === "active").length
+  const onboardingClients = clients.filter((client) => (client.phase ?? "").toLowerCase() === "onboarding").length
+
+  const stageCounts = STAGE_ORDER.map((stage) => ({
+    stage,
+    count: clients.filter((client) => (client.stage ?? "").toLowerCase() === stage.toLowerCase()).length,
+  }))
+
+  const arrTotal = clients.reduce((sum, client) => {
+    return sum + (typeof client.arr === "number" ? client.arr : 0)
+  }, 0)
+  const arrFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  })
+
+  const items = [
+    { label: "Active clients", value: String(activeClients) },
+    { label: "Onboarding", value: String(onboardingClients) },
+    ...stageCounts.map(({ stage, count }) => ({ label: stage, value: String(count) })),
+    { label: "ARR total", value: arrFormatter.format(arrTotal) },
+  ]
+
+  return items
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -12,6 +12,7 @@ import MobileBottomNav from '@/components/nav/MobileBottomNav'
 import SearchOverlay from '@/components/nav/SearchOverlay'
 import { MAIN_NAV, type NavItem } from '@/lib/navigation'
 import { cn, isActivePath } from '@/lib/utils'
+import { ToastViewport } from '@/ui/toast'
 
 const FULL_SHELL_EXCLUSIONS = new Set(['/login'])
 
@@ -89,6 +90,7 @@ export default function AppShell({ children }: AppShellProps) {
         </main>
       </div>
       <MobileBottomNav currentPath={pathname ?? ''} className="lg:hidden" />
+      <ToastViewport />
     </div>
   )
 }

--- a/components/projects/AgentsPanel.tsx
+++ b/components/projects/AgentsPanel.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useCallback, useState, useTransition } from "react"
+
+import { showToast } from "@/ui/toast"
+
+const BUTTON_CLASSES =
+  "h-9 px-3 rounded-md border border-gray-300 bg-white text-sm text-gray-800 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+
+type AgentKind = "risk_scan" | "collections_nudge" | "ops_check"
+
+type AgentResponse = {
+  ok: boolean
+  error?: string
+}
+
+export function AgentsPanel() {
+  const [status, setStatus] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const runAgent = useCallback((kind: AgentKind) => {
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/agents/run", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ kind, entityType: "projects", entityId: "projects_hub" }),
+        })
+
+        const payload: AgentResponse = await response
+          .json()
+          .catch(() => ({ ok: false, error: "Unknown response" }))
+
+        if (!response.ok || !payload.ok) {
+          const message = payload.error ?? "Agent run failed"
+          setStatus(message)
+          showToast({ title: "Agent run failed", description: message, variant: "destructive" })
+          return
+        }
+
+        const successMessage = `Agent run logged: ${kind}`
+        setStatus(successMessage)
+        showToast({ title: "Agent queued", description: successMessage, variant: "success" })
+      } catch (error) {
+        const message = "Unable to reach agent service"
+        setStatus(message)
+        showToast({ title: "Agent run failed", description: message, variant: "destructive" })
+      }
+    })
+  }, [])
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-sm font-medium text-black">Project Agents</div>
+      <p className="mt-1 text-xs text-gray-600">
+        Trigger playbooks and log activity for portfolio governance.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("risk_scan")}
+          disabled={isPending}
+        >
+          Run Risk Scan
+        </button>
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("collections_nudge")}
+          disabled={isPending}
+        >
+          Collections Nudge
+        </button>
+        <button
+          type="button"
+          className={BUTTON_CLASSES}
+          onClick={() => runAgent("ops_check")}
+          disabled={isPending}
+        >
+          Ops Check
+        </button>
+      </div>
+      {status ? <div className="mt-3 text-xs text-gray-600">{status}</div> : null}
+    </div>
+  )
+}

--- a/components/projects/Board.tsx
+++ b/components/projects/Board.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import Link from "next/link"
+
+import type { ClientRow } from "@/core/projects/queries"
+
+const DEFAULT_STAGES = ["Discovery", "Data", "Algorithm", "Architecture", "Closed"] as const
+
+export function ProjectBoard({ rows }: { rows: ClientRow[] }) {
+  const extraStages = Array.from(
+    new Set(
+      rows
+        .map((row) => row.stage)
+        .filter((stage): stage is string => Boolean(stage) && !DEFAULT_STAGES.includes(stage as (typeof DEFAULT_STAGES)[number])),
+    ),
+  ).sort((a, b) => a.localeCompare(b))
+
+  const stageOrder = [...DEFAULT_STAGES, ...extraStages]
+  const stageBuckets = new Map<string, ClientRow[]>()
+  stageOrder.forEach((stage) => {
+    stageBuckets.set(stage, [])
+  })
+
+  rows.forEach((row) => {
+    const stage = row.stage && stageBuckets.has(row.stage) ? row.stage : "Discovery"
+    stageBuckets.get(stage)!.push(row)
+  })
+
+  return (
+    <div className="grid gap-3 md:grid-cols-5">
+      {stageOrder.map((stage) => {
+        const bucket = stageBuckets.get(stage) ?? []
+        return (
+          <div key={stage} className="rounded-xl border border-gray-200 bg-white p-3">
+            <div className="text-xs font-medium text-gray-700">{stage}</div>
+            <div className="mt-2 space-y-2">
+              {bucket.map((row) => (
+                <Link
+                  key={row.id}
+                  href={`/clients/${row.id}`}
+                  className="block rounded-lg border border-gray-200 p-2 transition hover:bg-gray-50"
+                >
+                  <div className="text-sm font-medium text-black">{row.name}</div>
+                  <div className="text-[11px] text-gray-500">Health: {row.health ?? "-"}</div>
+                </Link>
+              ))}
+              {!bucket.length ? (
+                <div className="text-[12px] text-gray-500">No items</div>
+              ) : null}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/projects/Filters.tsx
+++ b/components/projects/Filters.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState } from "react"
+
+export type Filters = {
+  q: string
+  stages: string[]
+  health: string[]
+  ownerId: string | null
+}
+
+export function useProjectsFilters() {
+  const [filters, setFilters] = useState<Filters>({
+    q: "",
+    stages: [],
+    health: [],
+    ownerId: null,
+  })
+
+  return { filters, setFilters }
+}
+
+export function FiltersBar({
+  stagesAvailable,
+  healthAvailable,
+  owners,
+  value,
+  onChange,
+  showSearch = true,
+}: {
+  stagesAvailable: string[]
+  healthAvailable: string[]
+  owners: { id: string; label: string }[]
+  value: Filters
+  onChange: (filters: Filters) => void
+  showSearch?: boolean
+}) {
+  const update = (patch: Partial<Filters>) => {
+    onChange({ ...value, ...patch })
+  }
+
+  const toggle = (key: "stages" | "health", option: string) => {
+    const existing = new Set(value[key])
+    if (existing.has(option)) {
+      existing.delete(option)
+    } else {
+      existing.add(option)
+    }
+    onChange({ ...value, [key]: Array.from(existing) })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+      {showSearch ? (
+        <input
+          className="h-9 w-full rounded-md border border-gray-300 px-2 text-sm md:w-64"
+          placeholder="Search client or next step"
+          value={value.q}
+          onChange={(event) => update({ q: event.target.value })}
+        />
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <select
+          className="h-9 rounded-md border border-gray-300 px-2 text-sm"
+          value={value.ownerId ?? ""}
+          onChange={(event) => update({ ownerId: event.target.value || null })}
+          disabled={!owners.length}
+        >
+          <option value="">All owners</option>
+          {owners.map((owner) => (
+            <option key={owner.id} value={owner.id}>
+              {owner.label}
+            </option>
+          ))}
+        </select>
+        {stagesAvailable.length > 0 ? (
+          <MultiSelectChips
+            label="Stage"
+            values={stagesAvailable}
+            active={value.stages}
+            onToggle={(option) => toggle("stages", option)}
+          />
+        ) : null}
+        {healthAvailable.length > 0 ? (
+          <MultiSelectChips
+            label="Health"
+            values={healthAvailable}
+            active={value.health}
+            onToggle={(option) => toggle("health", option)}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+type MultiSelectChipsProps = {
+  label: string
+  values: string[]
+  active: string[]
+  onToggle: (value: string) => void
+}
+
+function MultiSelectChips({ label, values, active, onToggle }: MultiSelectChipsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-gray-500">{label}:</span>
+      {values.map((value) => {
+        const isActive = active.includes(value)
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onToggle(value)}
+            className={`h-7 rounded-md border px-2 text-xs ${
+              isActive
+                ? "border-black bg-black text-white"
+                : "border-gray-300 bg-white text-gray-700 transition hover:bg-gray-100"
+            }`}
+          >
+            {value}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/projects/KpiStrip.tsx
+++ b/components/projects/KpiStrip.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+type KPI = { label: string; value: string }
+
+export function KpiStrip({ items }: { items: KPI[] }) {
+  if (!items.length) {
+    return null
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">
+      {items.map((kpi, index) => (
+        <div
+          key={`${kpi.label}-${index}`}
+          className="rounded-xl border border-gray-200 bg-white p-3"
+        >
+          <div className="text-[11px] text-gray-500">{kpi.label}</div>
+          <div className="mt-1 text-xl font-semibold text-black">{kpi.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/projects/ProjectsTable.tsx
+++ b/components/projects/ProjectsTable.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useMemo } from "react"
+import { useRouter } from "next/navigation"
+
+import type { ClientOverview, ClientRow } from "@/core/projects/queries"
+
+import type { Filters } from "./Filters"
+
+type OpportunitySummary = {
+  clientId: string
+  nextStep: string | null
+  dueDate: string | null
+  stage: string | null
+}
+
+type OwnerOption = {
+  id: string
+  label: string
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+})
+
+export function ProjectsTable({
+  rows,
+  overview,
+  filters,
+  owners,
+  opportunities,
+}: {
+  rows: ClientRow[]
+  overview: ClientOverview[]
+  filters: Filters
+  owners: OwnerOption[]
+  opportunities: OpportunitySummary[]
+}) {
+  const router = useRouter()
+
+  const overviewMap = useMemo(() => {
+    return overview.reduce<Map<string, ClientOverview>>((map, entry) => {
+      map.set(entry.client_id, entry)
+      return map
+    }, new Map())
+  }, [overview])
+
+  const ownerMap = useMemo(() => {
+    return owners.reduce<Map<string, string>>((map, owner) => {
+      map.set(owner.id, owner.label)
+      return map
+    }, new Map())
+  }, [owners])
+
+  const opportunityMap = useMemo(() => {
+    return opportunities.reduce<Map<string, OpportunitySummary>>((map, summary) => {
+      map.set(summary.clientId, summary)
+      return map
+    }, new Map())
+  }, [opportunities])
+
+  const filteredRows = useMemo(() => {
+    return rows.filter((row) => {
+      if (filters.ownerId && row.owner_id !== filters.ownerId) {
+        return false
+      }
+      if (filters.stages.length && !filters.stages.includes(row.stage ?? "")) {
+        return false
+      }
+      if (filters.health.length && !filters.health.includes(row.health ?? "")) {
+        return false
+      }
+      if (filters.q) {
+        const search = filters.q.toLowerCase()
+        const opportunityEntry = opportunityMap.get(row.id)
+        const ownerName = ownerMap.get(row.owner_id ?? "") ?? ""
+        const haystack = `${row.name} ${row.stage ?? ""} ${
+          opportunityEntry?.nextStep ?? ""
+        } ${opportunityEntry?.stage ?? ""} ${ownerName}`.toLowerCase()
+        if (!haystack.includes(search)) {
+          return false
+        }
+      }
+      return true
+    })
+  }, [filters, opportunityMap, ownerMap, rows])
+
+  if (!rows.length) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+        No active clients found. Add active clients in Supabase to populate this view.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <table className="w-full text-sm">
+        <thead className="border-b border-gray-200">
+          <tr className="text-left text-[12px] text-gray-600">
+            <th className="px-3 py-2">Client</th>
+            <th className="px-3 py-2">Stage</th>
+            <th className="px-3 py-2">Health</th>
+            <th className="px-3 py-2">Owner</th>
+            <th className="px-3 py-2">ARR</th>
+            <th className="px-3 py-2">Weighted Pipeline</th>
+            <th className="px-3 py-2">Next Step</th>
+            <th className="px-3 py-2">Due</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {filteredRows.map((row) => {
+            const overviewEntry = overviewMap.get(row.id)
+            const opportunityEntry = opportunityMap.get(row.id)
+            const ownerLabel = row.owner_id ? ownerMap.get(row.owner_id) : null
+            const arrValue = row.arr ?? null
+            const weightedValue = overviewEntry?.weighted_value ?? null
+            const dueDate = opportunityEntry?.dueDate ?? null
+            const dueDateLabel = dueDate
+              ? (() => {
+                  const parsed = new Date(dueDate)
+                  return Number.isNaN(parsed.getTime())
+                    ? dueDate
+                    : dateFormatter.format(parsed)
+                })()
+              : "—"
+
+            return (
+              <tr
+                key={row.id}
+                className="cursor-pointer transition hover:bg-gray-50"
+                onClick={() => router.push(`/clients/${row.id}`)}
+              >
+                <td className="px-3 py-2 text-black">{row.name}</td>
+                <td className="px-3 py-2">{row.stage ?? "-"}</td>
+                <td className="px-3 py-2">{row.health ?? "-"}</td>
+                <td className="px-3 py-2">{ownerLabel ?? row.owner_id ?? "-"}</td>
+                <td className="px-3 py-2">
+                  {arrValue != null ? currencyFormatter.format(arrValue) : "-"}
+                </td>
+                <td className="px-3 py-2">
+                  {weightedValue != null ? currencyFormatter.format(weightedValue) : "-"}
+                </td>
+                <td className="px-3 py-2">
+                  {opportunityEntry?.nextStep ? opportunityEntry.nextStep : "—"}
+                </td>
+                <td className="px-3 py-2">{dueDateLabel}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {!filteredRows.length ? (
+        <div className="p-6 text-sm text-gray-600">No projects match current filters.</div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/projects/Timeline.tsx
+++ b/components/projects/Timeline.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useMemo } from "react"
+
+export type TimelineItem = {
+  id: string
+  projectName: string
+  clientName: string | null
+  startDate: string | null
+  endDate: string | null
+}
+
+type TimelinePoint = TimelineItem & {
+  startValue: number
+  endValue: number
+}
+
+export function ProjectTimeline({ items }: { items: TimelineItem[] }) {
+  const processed = useMemo(() => {
+    return items
+      .map<TimelinePoint | null>((item) => {
+        if (!item.startDate || !item.endDate) {
+          return null
+        }
+        const start = new Date(item.startDate)
+        const end = new Date(item.endDate)
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+          return null
+        }
+        return {
+          ...item,
+          startValue: start.getTime(),
+          endValue: end.getTime(),
+        }
+      })
+      .filter((entry): entry is TimelinePoint => Boolean(entry))
+  }, [items])
+
+  if (!processed.length) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-3 text-sm text-gray-600">
+        No project timelines recorded yet.
+      </div>
+    )
+  }
+
+  const minStart = Math.min(...processed.map((item) => item.startValue))
+  const maxEnd = Math.max(...processed.map((item) => item.endValue))
+  const span = Math.max(maxEnd - minStart, 1)
+  const labelWidth = 160
+  const barHeight = 18
+  const gap = 12
+  const chartWidth = 640
+  const viewWidth = labelWidth + chartWidth + 16
+  const viewHeight = processed.length * (barHeight + gap) + gap
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-sm font-medium text-black">Timeline</div>
+      <div className="mt-2 overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+          className="h-full w-full min-w-[320px]"
+          role="img"
+          aria-label="Project schedule overview"
+        >
+          {processed.map((item, index) => {
+            const y = gap / 2 + index * (barHeight + gap)
+            const offset = ((item.startValue - minStart) / span) * chartWidth
+            const width = Math.max(((item.endValue - item.startValue) / span) * chartWidth, 6)
+            return (
+              <g key={item.id}>
+                <text x={8} y={y + barHeight / 1.5} fill="#6b7280" fontSize="11">
+                  {item.projectName}
+                  {item.clientName ? ` • ${item.clientName}` : ""}
+                </text>
+                <rect
+                  x={labelWidth + offset}
+                  y={y}
+                  width={width}
+                  height={barHeight}
+                  rx={4}
+                  fill="#111827"
+                />
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/core/projects/queries.ts
+++ b/core/projects/queries.ts
@@ -1,0 +1,123 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type ClientRow = {
+  id: string
+  name: string
+  status: string | null
+  stage: string | null
+  health: string | null
+  owner_id: string | null
+  arr: number | null
+  created_at: string
+  phase: string | null
+  organization_id: string | null
+}
+
+export type ClientOverview = {
+  client_id: string
+  client_name: string
+  client_type: string | null
+  organization_id: string | null
+  owner_id: string | null
+  pipeline_id: string | null
+  pipeline_stage: string | null
+  pipeline_value: number | null
+  weighted_value: number | null
+  probability: number | null
+  finance_id: string | null
+  mrr: number | null
+  ar_outstanding: number | null
+  ar_collected: number | null
+}
+
+export type OwnerRow = {
+  id: string
+  email: string | null
+  full_name: string | null
+  role: string | null
+}
+
+export type ProjectRecord = {
+  id: string
+  client_id: string
+  name: string
+  status: string | null
+  health: string | null
+  start_date: string | null
+  end_date: string | null
+}
+
+export type OpportunityRecord = {
+  id: string
+  client_id: string
+  name: string | null
+  stage: string | null
+  amount: number | null
+  probability: number | null
+  next_step: string | null
+  next_step_date: string | null
+  close_date: string | null
+  owner_id: string | null
+}
+
+async function getClient() {
+  const supabase = await createClient()
+  return supabase
+}
+
+export async function fetchClientsForProjects() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("clients")
+    .select(
+      "id,name,status,stage,health,owner_id,arr,created_at,phase,organization_id",
+    )
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as ClientRow[]
+}
+
+export async function fetchOverviewJoin() {
+  const supabase = await getClient()
+  const { data, error } = await supabase.from("vw_client_overview").select("*")
+
+  if (error) throw error
+  return (data ?? []) as ClientOverview[]
+}
+
+export async function fetchOwners() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("users")
+    .select("id,email,full_name,role")
+    .order("email", { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as OwnerRow[]
+}
+
+export async function fetchProjects() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id,client_id,name,status,health,start_date,end_date")
+    .order("start_date", { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as ProjectRecord[]
+}
+
+export async function fetchOpportunities() {
+  const supabase = await getClient()
+  const { data, error } = await supabase
+    .from("opportunities")
+    .select(
+      "id,client_id,name,stage,amount,probability,next_step,next_step_date,close_date,owner_id",
+    )
+
+  if (error) throw error
+  return (data ?? []) as OpportunityRecord[]
+}


### PR DESCRIPTION
## Summary
- add an onboarding workspace tab with supabase-backed phase controls and toast feedback
- keep the projects hub within the shared shell, wiring tab state to URL params and retaining supabase data joins
- extend the agents run API to record content runs while keeping analytics wiring intact

## Testing
- pnpm run typecheck
- pnpm run lint
- CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=stub SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=stub pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb2fc7b280832492c9f12d8a82ccef