### PR TITLE
Fix clients page fallback when Supabase is unavailable

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,7 +1,87 @@
 import Link from "next/link";
 
+import { listClients } from "@/core/clients/store";
+import type { Client } from "@/core/clients/types";
 import { createServerClient } from "@/lib/supabase/server";
 import { ClientsSearch } from "./ClientsSearch";
+
+type ClientRow = {
+  id: string;
+  name: string;
+  status: string | null;
+  phase: string | null;
+  owner_id: string | null;
+  arr: number | null;
+  health: number | null;
+  created_at: string | null;
+  owner: { name: string | null } | { name: string | null }[] | null;
+};
+
+const hasSupabaseCredentials = Boolean(
+  process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+const stageOrder: Record<string, number> = {
+  New: 1,
+  Qualify: 2,
+  Proposal: 3,
+  Negotiation: 4,
+  ClosedWon: 5,
+  ClosedLost: 0,
+};
+
+const defaultProbabilities: Partial<Record<string, number>> = {
+  New: 0.2,
+  Qualify: 0.35,
+  Proposal: 0.55,
+  Negotiation: 0.7,
+  ClosedWon: 1,
+  ClosedLost: 0,
+};
+
+function mapStoreClient(client: Client): ClientRow {
+  return {
+    id: client.id,
+    name: client.name,
+    status: client.status ?? "active",
+    phase: client.phase,
+    owner_id: client.owner,
+    arr: client.arr ?? 0,
+    health: client.health ?? null,
+    created_at: client.qbrDate ?? null,
+    owner: [{ name: client.owner }],
+  };
+}
+
+function computeFallbackOverview(client: Client) {
+  const openOpps = client.opportunities.filter(
+    (opp) => opp.stage !== "ClosedLost" && opp.stage !== "ClosedWon"
+  );
+  const pipelineValue = openOpps.reduce((sum, opp) => sum + (opp.amount ?? 0), 0);
+  const weightedValue = openOpps.reduce((sum, opp) => {
+    const probability = opp.probability ?? defaultProbabilities[opp.stage] ?? 0;
+    return sum + probability * (opp.amount ?? 0);
+  }, 0);
+  const pipelineStage = openOpps.reduce((best, opp) => {
+    if (!best) return opp.stage;
+    return stageOrder[opp.stage] > stageOrder[best] ? opp.stage : best;
+  }, "" as string);
+  const invoicesDue = client.invoices.filter(
+    (invoice) => invoice.status === "Overdue" || invoice.status === "Sent"
+  );
+  const arOutstanding = invoicesDue.reduce((sum, invoice) => sum + (invoice.amount ?? 0), 0);
+  const mrr = client.arr ? Math.round(client.arr / 12) : 0;
+
+  return {
+    pipeline_stage: pipelineStage || null,
+    pipeline_value: pipelineValue,
+    weighted_value: Math.round(weightedValue),
+    probability:
+      pipelineValue > 0 ? Math.min(1, weightedValue / pipelineValue) : null,
+    mrr,
+    ar_outstanding: arOutstanding,
+  };
+}
 
 function SummaryCard({ label, value }: { label: string; value: string }) {
   return (
@@ -17,29 +97,70 @@ export default async function ClientsPage({
 }: {
   searchParams?: { q?: string; phase?: string };
 }) {
-  const supabase = createServerClient();
   const search = searchParams?.q?.trim() ?? "";
   const phaseFilter = (searchParams?.phase ?? "all").toLowerCase();
 
-  let query = supabase
-    .from("clients")
-    .select(
-      "id, name, status, phase, owner_id, arr, health, created_at, owner:users!clients_owner_id_fkey(name)"
-    )
-    .order("created_at", { ascending: false })
-    .limit(200);
+  const overviewMap = new Map<string, any>();
+  let clientsData: ClientRow[] = [];
+  let usingFallback = !hasSupabaseCredentials;
 
-  if (search) {
-    const pattern = `%${search.replace(/%/g, "\\%")}%`;
-    query = query.or(
-      `name.ilike.${pattern},industry.ilike.${pattern},region.ilike.${pattern}`
-    );
+  if (!usingFallback) {
+    try {
+      const supabase = createServerClient();
+      let query = supabase
+        .from("clients")
+        .select(
+          "id, name, status, phase, owner_id, arr, health, created_at, owner:users!clients_owner_id_fkey(name)"
+        )
+        .order("created_at", { ascending: false })
+        .limit(200);
+
+      if (search) {
+        const pattern = `%${search.replace(/%/g, "\\%")}%`;
+        query = query.or(
+          `name.ilike.${pattern},industry.ilike.${pattern},region.ilike.${pattern}`
+        );
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        throw error;
+      }
+
+      clientsData = data ?? [];
+
+      const ids = clientsData.map((c) => c.id);
+
+      if (ids.length) {
+        const { data: overviewRows, error: overviewError } = await supabase
+          .from("vw_client_overview")
+          .select(
+            "client_id, pipeline_stage, pipeline_value, weighted_value, probability, mrr, ar_outstanding"
+          )
+          .in("client_id", ids);
+
+        if (overviewError) {
+          throw overviewError;
+        }
+
+        overviewRows?.forEach((row) => {
+          overviewMap.set(row.client_id, row);
+        });
+      }
+    } catch (error) {
+      console.error("Failed to load clients from Supabase", error);
+      usingFallback = true;
+      clientsData = [];
+    }
   }
 
-  const { data: clientsData, error } = await query;
-
-  if (error) {
-    throw error;
+  if (usingFallback) {
+    const fallbackClients = listClients();
+    clientsData = fallbackClients.map(mapStoreClient);
+    fallbackClients.forEach((client) => {
+      overviewMap.set(client.id, computeFallbackOverview(client));
+    });
   }
 
   const clients = (clientsData ?? []).filter((client) => {
@@ -54,20 +175,6 @@ export default async function ClientsPage({
     }
     return true;
   });
-
-  const ids = clients.map((c) => c.id);
-  const overviewMap = new Map<string, any>();
-
-  if (ids.length) {
-    const { data: overviewRows } = await supabase
-      .from("vw_client_overview")
-      .select("client_id, pipeline_stage, pipeline_value, weighted_value, probability, mrr, ar_outstanding")
-      .in("client_id", ids);
-
-    overviewRows?.forEach((row) => {
-      overviewMap.set(row.client_id, row);
-    });
-  }
 
   const totalArr = clients.reduce((sum, client) => sum + (client.arr ?? 0), 0);
   const avgHealth = clients.length
@@ -87,6 +194,13 @@ export default async function ClientsPage({
             Production view of customers and onboarding progress powered by Supabase.
           </p>
         </header>
+
+        {usingFallback && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+            Live Supabase data isn&rsquo;t available right now, so this view is showing
+            seeded portfolio data instead.
+          </div>
+        )}
 
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm">


### PR DESCRIPTION
## Summary
- guard the clients index page against missing Supabase credentials or query errors and fall back to seeded store data
- derive pipeline metrics from the seeded portfolio so summary cards and table rows still render when offline
- surface a banner to let users know when the seeded portfolio data is being shown

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eb372e4d7483248e364917969d8309