### PR TITLE
fix: surface newly won clients

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -43,14 +43,17 @@ export default async function ClientsPage({
   }
 
   const clients = (clientsData ?? []).filter((client) => {
+    const normalizedPhase = (client.phase ?? "").toLowerCase();
+    const normalizedStatus = (client.status ?? "").toLowerCase();
+
     if (phaseFilter === "onboarding") {
-      return client.phase === "Onboarding";
+      return normalizedPhase === "onboarding";
     }
     if (phaseFilter === "active") {
-      return client.status === "active";
+      return normalizedStatus === "active";
     }
     if (phaseFilter === "churned") {
-      return client.status === "churned";
+      return normalizedStatus === "churned";
     }
     return true;
   });
@@ -76,7 +79,9 @@ export default async function ClientsPage({
           clients.length,
       )
     : 0;
-  const onboardingCount = clients.filter((client) => client.phase === "Onboarding").length;
+  const onboardingCount = clients.filter(
+    (client) => (client.phase ?? "").toLowerCase() === "onboarding",
+  ).length;
 
   return (
     <div className="min-h-screen bg-white text-black">

--- a/app/pipeline/actions.ts
+++ b/app/pipeline/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { createServerClient } from "@/lib/supabase/server";
@@ -19,6 +20,11 @@ export async function markClosedWon({
 
   if (error) {
     throw error
+  }
+
+  if (data) {
+    revalidatePath("/clients")
+    revalidatePath(`/clients/${data}`)
   }
 
   redirect(`/clients/${data}`)


### PR DESCRIPTION
## Summary
- normalize phase and status filters on the Clients listing so onboarding deals always appear
- revalidate the Clients views after converting a pipeline deal to a client

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eb38880944832499b116bf0cca6787