### PR TITLE
Guard client activity fetch against missing Supabase credentials

### DIFF
--- a/core/clients/actions.ts
+++ b/core/clients/actions.ts
@@ -684,6 +684,10 @@ export async function saveFinanceTerms(input: {
 }
 
 export async function getActivity(clientId: string): Promise<ActivityItem[]> {
+  if (!hasSupabaseCredentials()) {
+    return []
+  }
+
   const supabase = await createClient();
 
   const [analytics, emails, calendar, notes] = await Promise.all([


### PR DESCRIPTION
## Summary
- return an empty activity timeline when Supabase credentials are not configured so the client profile can render

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eb3b0b3874832497faf50f1d2f99d7