### PR TITLE
Fix content creation form typing to satisfy content models

### DIFF
--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -75,12 +75,18 @@ export default function ContentStudioPage() {
   const [showNewContentModal, setShowNewContentModal] = useState(false);
   const [showIdeaModal, setShowIdeaModal] = useState(false);
 
-  const [newContentForm, setNewContentForm] = useState({
+  const [newContentForm, setNewContentForm] = useState<{
+    audience: string;
+    goal: string;
+    deliverable: ContentPiece["format"];
+    purpose: ContentPiece["purpose"];
+    channel: ContentPiece["channel"];
+  }>({
     audience: "",
     goal: "",
     deliverable: "Post",
-    purpose: "Inspire" as const,
-    channel: "LinkedIn" as const,
+    purpose: "Inspire",
+    channel: "LinkedIn",
   });
   const [generatedSummary, setGeneratedSummary] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
@@ -1084,7 +1090,12 @@ export default function ContentStudioPage() {
                     </label>
                     <select
                       value={newContentForm.deliverable}
-                      onChange={(e) => setNewContentForm((prev) => ({ ...prev, deliverable: e.target.value }))}
+                      onChange={(e) =>
+                        setNewContentForm((prev) => ({
+                          ...prev,
+                          deliverable: e.target.value as ContentPiece["format"],
+                        }))
+                      }
                       className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
                     >
                       {DELIVERABLE_OPTIONS.map((option) => (

--- a/core/content/api.ts
+++ b/core/content/api.ts
@@ -95,7 +95,7 @@ const fallbackContentPieces: ContentPiece[] = [
     id: "mkt-1",
     title: "AI RevOps Playbook",
     contentType: "Prospect",
-    format: "Guide",
+    format: "White Paper",
     status: "Scheduled",
     purpose: "Sell",
     channel: "LinkedIn",


### PR DESCRIPTION
## Summary
- align the new content modal state with ContentPiece types instead of literal "const" values
- ensure the deliverable select writes a typed ContentFormat value
- update the fallback marketing piece to use an allowed format value

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ec6b0335b88324974846229cc42a84