### PR TITLE
feat: restore resources nav entry

### DIFF
--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -68,6 +68,12 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
+    label: 'Resources',
+    href: '/resources',
+    icon: 'BookOpen',
+    roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
+  },
+  {
     label: 'Settings',
     href: '/settings',
     icon: 'Settings',


### PR DESCRIPTION
## Summary
- restore the Resources link in the primary navigation between Finance and Settings so it shows up in the sidebar again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed26d25e4c8324b01011cffcc45407