### PR TITLE
Fix resources tab merge conflict handling

### DIFF
--- a/components/layout/PageTabs.tsx
+++ b/components/layout/PageTabs.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 export type PageTabsProps = {
-  tabs: string[];
+  tabs: readonly string[];
   activeTab: string;
   onTabChange?: (tab: string) => void;
   hrefForTab?: (tab: string) => string;

--- a/lib/tabs.ts
+++ b/lib/tabs.ts
@@ -1,3 +1,17 @@
+export const RESOURCE_TABS = [
+  "Pricing",
+  "Revenue",
+  "Revenue Clear",
+  "Financial Plan",
+  "Profit",
+  "Board Scenarios",
+  "Forms",
+] as const;
+
+function resourceTabs(): string[] {
+  return [...RESOURCE_TABS];
+}
+
 export const PAGE_TABS: Record<string, string[]> = {
   "/": ["Today", "This Week", "Focus Blocks", "Risks", "Morning Brief"],
   "/dashboard": ["Overview", "Analytics", "Reports", "Notifications"],
@@ -8,33 +22,9 @@ export const PAGE_TABS: Record<string, string[]> = {
   "/content": ["Overview", "Pipeline", "Ideas", "Scheduled", "Performance", "Create", "Advertising"],
   "/agents": ["All", "Projects", "Content", "Clients", "GPT Agents"],
   "/mail-calendar": ["Inbox", "Calendar", "Integrations"],
-  "/resources": [
-    "Pricing",
-    "Revenue",
-    "Revenue Clear",
-    "Financial Plan",
-    "Profit",
-    "Board Scenarios",
-    "Forms",
-  ],
-  "/resources/forms": [
-    "Pricing",
-    "Revenue",
-    "Revenue Clear",
-    "Financial Plan",
-    "Profit",
-    "Board Scenarios",
-    "Forms",
-  ],
-  "/resources/forms/[formId]": [
-    "Pricing",
-    "Revenue",
-    "Revenue Clear",
-    "Financial Plan",
-    "Profit",
-    "Board Scenarios",
-    "Forms",
-  ],
+  "/resources": resourceTabs(),
+  "/resources/forms": resourceTabs(),
+  "/resources/forms/[formId]": resourceTabs(),
   "/settings": ["Agents", "Appearance", "Integrations", "Feature Flags", "Behavior"],
   "/clients": ["Overview", "Accounts", "Engagement", "Renewals", "Signals"],
   "/clients/[id]": [


### PR DESCRIPTION
## Summary
- centralize the Resources tab order into a shared constant used across every route
- widen the PageTabs component typing so it can consume the readonly list without mutation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ed511fc96c8324841181910a6147b2