### PR TITLE
feat: deliver pipeline forecasting and review workflows

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { FormEvent } from "react";
 import { useCallback, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -12,8 +13,30 @@ import ScopeBar from "@/components/exec/ScopeBar";
 import { SmallSpark } from "@/components/exec/SmallSpark";
 import { Card } from "@/components/kit/Card";
 import { AreaChart, BarChart } from "@/components/kit/Charts";
+import { Button } from "@/ui/button";
+import { Badge } from "@/ui/badge";
+import { Select } from "@/ui/select";
+import { Textarea } from "@/ui/textarea";
+import { Input } from "@/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/table";
 import type { ExecDashboard } from "@/core/exec/types";
 import { refreshDashboardSnapshot } from "@/core/exec/actions";
+import {
+  recordForecastApproval,
+  submitForecastComment,
+} from "@/core/exec/review";
+import type {
+  ForecastReviewApproval,
+  ForecastReviewState,
+  ForecastScenarioKey,
+} from "@/core/exec/review";
 import { TRS_CARD } from "@/lib/style";
 import { resolveTabs } from "@/lib/tabs";
 import { cn } from "@/lib/utils";
@@ -21,11 +44,13 @@ import { cn } from "@/lib/utils";
 type DashboardClientProps = {
   data: ExecDashboard;
   exportAction: () => Promise<void>;
+  review: ForecastReviewState;
 };
 
 export default function DashboardClient({
   data,
   exportAction,
+  review,
 }: DashboardClientProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -36,6 +61,20 @@ export default function DashboardClient({
   }, [searchParams, tabs]);
   const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
   const [refreshPending, startRefresh] = useTransition();
+  const [reviewState, setReviewState] = useState<ForecastReviewState>(review);
+  const [commentScenario, setCommentScenario] =
+    useState<ForecastScenarioKey>("commit");
+  const [commentText, setCommentText] = useState("");
+  const [focusArea, setFocusArea] = useState("");
+  const [commentError, setCommentError] = useState<string | null>(null);
+  const [approvalScenario, setApprovalScenario] =
+    useState<ForecastScenarioKey>("commit");
+  const [approvalDecision, setApprovalDecision] = useState<
+    "approved" | "changes_requested"
+  >("approved");
+  const [approvalNote, setApprovalNote] = useState("");
+  const [approvalFeedback, setApprovalFeedback] = useState<string | null>(null);
+  const [reviewPending, startReviewAction] = useTransition();
 
   const handleRefresh = () => {
     startRefresh(async () => {
@@ -61,6 +100,103 @@ export default function DashboardClient({
   const exportErrored = searchParams.get("export") === "failed";
 
   const d = data;
+  const scenarioOptions: ForecastScenarioKey[] = ["commit", "upside", "best"];
+  const scenarioLabels: Record<ForecastScenarioKey, string> = {
+    commit: "Commit",
+    upside: "Upside",
+    best: "Best Case",
+  };
+  const dateTimeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    [],
+  );
+
+  const approvalsByScenario = useMemo(() => {
+    const map = new Map<ForecastScenarioKey, ForecastReviewApproval>();
+    reviewState.approvals.forEach((approval) => {
+      if (!map.has(approval.scenario)) {
+        map.set(approval.scenario, approval);
+      }
+    });
+    return map;
+  }, [reviewState.approvals]);
+
+  const handleSubmitComment = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!commentText.trim()) {
+        setCommentError("Add guidance before submitting.");
+        return;
+      }
+      setCommentError(null);
+
+      startReviewAction(async () => {
+        const result = await submitForecastComment({
+          scope: data.scope,
+          scenario: commentScenario,
+          comment: commentText,
+          focusArea,
+        });
+
+        if (!result.ok || !result.comment) {
+          setCommentError("Unable to submit comment right now.");
+          return;
+        }
+
+        setReviewState((prev) => ({
+          ...prev,
+          comments: [result.comment, ...prev.comments].slice(0, 50),
+        }));
+        setCommentText("");
+        setFocusArea("");
+      });
+    },
+    [commentScenario, commentText, data.scope, focusArea, startReviewAction],
+  );
+
+  const handleSubmitApproval = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setApprovalFeedback(null);
+
+      startReviewAction(async () => {
+        const result = await recordForecastApproval({
+          scope: data.scope,
+          scenario: approvalScenario,
+          status: approvalDecision,
+          note: approvalNote,
+        });
+
+        if (!result.ok || !result.approval) {
+          setApprovalFeedback("Failed to record decision. Try again shortly.");
+          return;
+        }
+
+        setReviewState((prev) => ({
+          ...prev,
+          approvals: [
+            result.approval,
+            ...prev.approvals.filter(
+              (item) =>
+                !(
+                  item.approverId === result.approval.approverId &&
+                  item.scenario === result.approval.scenario
+                ),
+            ),
+          ],
+        }));
+        setApprovalFeedback("Decision logged for finance & exec review.");
+        setApprovalNote("");
+      });
+    },
+    [approvalDecision, approvalNote, approvalScenario, data.scope, startReviewAction],
+  );
 
   const kpiGrid = (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
@@ -324,6 +460,234 @@ export default function DashboardClient({
               </div>
             </Card>
           </div>
+
+          <Card className={cn(TRS_CARD)}>
+            <div className="grid gap-4 p-4 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <div className="text-sm font-semibold text-black">Forecast Review Comments</div>
+                  <p className="text-xs text-gray-500">
+                    Capture finance and revenue leader guidance on the live forecast.
+                  </p>
+                </div>
+                <form onSubmit={handleSubmitComment} className="space-y-2">
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <Select
+                      value={commentScenario}
+                      onChange={(event) =>
+                        setCommentScenario(event.target.value as ForecastScenarioKey)
+                      }
+                    >
+                      {scenarioOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {scenarioLabels[option]}
+                        </option>
+                      ))}
+                    </Select>
+                    <Input
+                      value={focusArea}
+                      onChange={(event) => setFocusArea(event.target.value)}
+                      placeholder="Focus area (optional)"
+                    />
+                  </div>
+                  <Textarea
+                    rows={3}
+                    value={commentText}
+                    onChange={(event) => setCommentText(event.target.value)}
+                    placeholder="Call out risks, upside drivers, or asks for finance..."
+                  />
+                  {commentError ? (
+                    <div className="text-xs text-rose-600">{commentError}</div>
+                  ) : null}
+                  <div className="flex justify-end">
+                    <Button type="submit" size="sm" disabled={reviewPending}>
+                      {reviewPending ? "Submitting…" : "Add comment"}
+                    </Button>
+                  </div>
+                </form>
+                <div className="space-y-3">
+                  {reviewState.comments.slice(0, 4).map((comment) => (
+                    <div
+                      key={comment.id}
+                      className="rounded-md border border-gray-200 bg-white p-3 text-sm shadow-sm"
+                    >
+                      <div className="flex items-center justify-between text-xs text-gray-500">
+                        <span className="font-medium text-gray-700">{comment.authorName}</span>
+                        <Badge variant="outline">{scenarioLabels[comment.scenario]}</Badge>
+                      </div>
+                      <p className="mt-2 text-sm text-gray-700">{comment.comment}</p>
+                      {comment.focusArea ? (
+                        <div className="mt-1 text-xs text-gray-500">Focus: {comment.focusArea}</div>
+                      ) : null}
+                      <div className="mt-1 text-[11px] text-gray-400">
+                        {dateTimeFormatter.format(new Date(comment.createdAt))}
+                      </div>
+                    </div>
+                  ))}
+                  {!reviewState.comments.length && (
+                    <p className="text-sm text-gray-500">
+                      No comments yet. Start the commit review to align stakeholders.
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <div className="text-sm font-semibold text-black">Approvals & Decisions</div>
+                  <p className="text-xs text-gray-500">
+                    Record commit sign-off or request adjustments before locking guidance.
+                  </p>
+                </div>
+                <form onSubmit={handleSubmitApproval} className="space-y-2">
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <Select
+                      value={approvalScenario}
+                      onChange={(event) =>
+                        setApprovalScenario(event.target.value as ForecastScenarioKey)
+                      }
+                    >
+                      {scenarioOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {scenarioLabels[option]}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      value={approvalDecision}
+                      onChange={(event) =>
+                        setApprovalDecision(
+                          event.target.value as "approved" | "changes_requested",
+                        )
+                      }
+                    >
+                      <option value="approved">Approve commit</option>
+                      <option value="changes_requested">Request changes</option>
+                    </Select>
+                  </div>
+                  <Textarea
+                    rows={3}
+                    value={approvalNote}
+                    onChange={(event) => setApprovalNote(event.target.value)}
+                    placeholder="Note optional context for finance or GTM leaders"
+                  />
+                  {approvalFeedback ? (
+                    <div
+                      className={cn(
+                        "text-xs",
+                        approvalFeedback.startsWith("Failed")
+                          ? "text-rose-600"
+                          : "text-emerald-600",
+                      )}
+                    >
+                      {approvalFeedback}
+                    </div>
+                  ) : null}
+                  <div className="flex justify-end">
+                    <Button type="submit" size="sm" disabled={reviewPending}>
+                      {reviewPending ? "Recording…" : "Record decision"}
+                    </Button>
+                  </div>
+                </form>
+                <div className="space-y-2">
+                  {scenarioOptions.map((option) => {
+                    const approval = approvalsByScenario.get(option);
+                    const variant = approval
+                      ? approval.status === "approved"
+                        ? "success"
+                        : "warning"
+                      : "outline";
+                    return (
+                      <div
+                        key={option}
+                        className="rounded-md border border-gray-200 bg-white p-3 text-sm shadow-sm"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="font-medium text-gray-800">
+                            {scenarioLabels[option]}
+                          </div>
+                          <Badge variant={variant}>
+                            {approval
+                              ? approval.status === "approved"
+                                ? "Approved"
+                                : "Changes requested"
+                              : "Pending"}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          {approval
+                            ? `${approval.approverName} • ${dateTimeFormatter.format(
+                                new Date(approval.createdAt),
+                              )}`
+                            : "Awaiting reviewer"}
+                        </div>
+                        {approval?.note ? (
+                          <div className="mt-1 text-xs text-gray-600">{approval.note}</div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <Card className={cn(TRS_CARD)}>
+            <div className="space-y-4 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-semibold text-black">Finance Export History</div>
+                  <p className="text-xs text-gray-500">
+                    Track every forecast package sent to finance with download links.
+                  </p>
+                </div>
+                <Badge variant="outline">{reviewState.versions.length} versions</Badge>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Scenario</TableHead>
+                    <TableHead>Coverage</TableHead>
+                    <TableHead>Risk</TableHead>
+                    <TableHead>Owner</TableHead>
+                    <TableHead>Download</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {reviewState.versions.slice(0, 6).map((version) => (
+                    <TableRow key={version.id}>
+                      <TableCell>v{version.version}</TableCell>
+                      <TableCell>{scenarioLabels[version.scenario]}</TableCell>
+                      <TableCell>{version.coverage.toFixed(1)}x</TableCell>
+                      <TableCell>{version.riskIndex.toFixed(1)}%</TableCell>
+                      <TableCell>
+                        <div className="text-sm text-gray-800">{version.authorName}</div>
+                        <div className="text-[11px] text-gray-500">
+                          {dateTimeFormatter.format(new Date(version.createdAt))}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <a
+                          href={version.downloadUrl}
+                          download={`forecast-v${version.version}.csv`}
+                          className="text-xs font-medium text-blue-600 hover:underline"
+                        >
+                          Download CSV
+                        </a>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {!reviewState.versions.length && (
+                    <TableRow>
+                      <TableCell colSpan={6} className="py-4 text-center text-sm text-gray-500">
+                        Export a forecast to finance to build the version history.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </Card>
         </div>
       )}
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,113 +1,38 @@
-// app/dashboard/page.tsx
-import { listClientOverview, getPipelineForecast } from "@/lib/queries";
+import { redirect } from "next/navigation";
 
-function Kpi({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-3">
-      <div className="text-[11px] text-gray-500">{label}</div>
-      <div className="text-2xl font-semibold text-black">{value}</div>
-    </div>
-  );
-}
-
-const Th = ({ children }: { children: React.ReactNode }) => (
-  <th className="px-3 py-2 text-left text-gray-600 text-[12px]">{children}</th>
-);
-const Td = ({ children }: { children: React.ReactNode }) => (
-  <td className="px-3 py-2">{children}</td>
-);
+import DashboardClient from "./DashboardClient";
+import { getExecDashboard } from "@/core/exec/actions";
+import { exportForecastSnapshot, getForecastReviewState } from "@/core/exec/review";
 
 export default async function DashboardPage() {
-  const [clients, forecast] = await Promise.all([
-    listClientOverview(),
-    getPipelineForecast(),
-  ]);
+  const data = await getExecDashboard();
+  const review = await getForecastReviewState(data.scope);
 
-  const totalMRR = clients.reduce((s, c) => s + (c.mrr ?? 0), 0);
-  const totalAR = clients.reduce((s, c) => s + (c.ar_outstanding ?? 0), 0);
-  const weighted = forecast.length ? (forecast[0].all_weighted_value ?? 0) : 0;
+  const commitTrajectory = data.forecast.p50;
+  const bestTrajectory = data.forecast.p90;
+  const upsideTrajectory = data.forecast.p50.map((point, index) => ({
+    ts: point.ts,
+    value: Math.round(
+      ((point.value ?? 0) + (data.forecast.p90[index]?.value ?? point.value ?? 0)) / 2,
+    ),
+  }));
 
-  return (
-    <div className="w-full min-h-screen bg-white text-black">
-      {/* Top masthead is assumed to be part of your layout; keep page content simple */}
-      <div className="p-4">
-        {/* KPI Row */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <Kpi label="Total MRR" value={`$${totalMRR.toLocaleString()}`} />
-          <Kpi label="A/R Outstanding" value={`$${totalAR.toLocaleString()}`} />
-          <Kpi label="Weighted Pipeline" value={`$${weighted.toLocaleString()}`} />
-        </div>
+  async function handleExport() {
+    "use server";
 
-        {/* Clients table */}
-        <div className="mt-6 rounded-xl border border-gray-200 overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50">
-              <tr>
-                <Th>Client</Th>
-                <Th>Type</Th>
-                <Th>Stage</Th>
-                <Th>MRR</Th>
-                <Th>AR</Th>
-                <Th>Weighted</Th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {(clients.length ? clients : []).map((c) => (
-                <tr key={c.client_id} className="hover:bg-gray-50">
-                  <Td>{c.client_name}</Td>
-                  <Td>{c.client_type ?? "-"}</Td>
-                  <Td>{c.pipeline_stage ?? "-"}</Td>
-                  <Td>${(c.mrr ?? 0).toLocaleString()}</Td>
-                  <Td>${(c.ar_outstanding ?? 0).toLocaleString()}</Td>
-                  <Td>${(c.weighted_value ?? 0).toLocaleString()}</Td>
-                </tr>
-              ))}
-              {!clients.length && (
-                <tr>
-                  <td className="p-6 text-center text-gray-500" colSpan={6}>
-                    No data yet. Add clients or pipeline to see live metrics.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+    await exportForecastSnapshot(data.scope, {
+      scenario: "commit",
+      commitTrajectory,
+      upsideTrajectory,
+      bestTrajectory,
+      metadata: {
+        coverage: data.sales.pipelineCoverageX,
+        riskIndex: data.ribbon.riskIndexPct,
+      },
+    });
 
-        {/* Pipeline summary (optional read-out) */}
-        <div className="mt-6 rounded-xl border border-gray-200 bg-white p-3">
-          <div className="text-sm font-medium mb-2">Pipeline by Stage</div>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50">
-                <tr>
-                  <Th>Stage</Th>
-                  <Th>Deals</Th>
-                  <Th>Total</Th>
-                  <Th>Weighted</Th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {(forecast.length ? forecast : []).map((r) => (
-                  <tr key={r.stage}>
-                    <Td>{r.stage}</Td>
-                    <Td>{r.deals}</Td>
-                    <Td>${(r.total_value ?? 0).toLocaleString()}</Td>
-                    <Td>${(r.weighted_value ?? 0).toLocaleString()}</Td>
-                  </tr>
-                ))}
-                {!forecast.length && (
-                  <tr>
-                    <td className="p-6 text-center text-gray-500" colSpan={4}>
-                      No pipeline yet. Add opportunities to populate this view.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
+    redirect("/dashboard?tab=Overview&export=success");
+  }
 
-      </div>
-    </div>
-  );
+  return <DashboardClient data={data} review={review} exportAction={handleExport} />;
 }

--- a/app/pipeline/page.tsx
+++ b/app/pipeline/page.tsx
@@ -1,4 +1,8 @@
-import { getOpportunities, getPipelineMetrics } from "@/core/pipeline/actions";
+import {
+  getOpportunities,
+  getPipelineAutomationState,
+  getPipelineMetrics,
+} from "@/core/pipeline/actions";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import PipelineClient from "./PipelineClient";
@@ -13,10 +17,18 @@ export default async function PipelinePage() {
     redirect("/login");
   }
 
-  const [opportunities, metrics] = await Promise.all([
+  const [opportunities, metrics, automation] = await Promise.all([
     getOpportunities(),
     getPipelineMetrics(),
+    getPipelineAutomationState(),
   ]);
 
-  return <PipelineClient opportunities={opportunities} metrics={metrics} userId={user.id} />;
+  return (
+    <PipelineClient
+      opportunities={opportunities}
+      metrics={metrics}
+      automation={automation}
+      userId={user.id}
+    />
+  );
 }

--- a/core/exec/review.ts
+++ b/core/exec/review.ts
@@ -1,0 +1,236 @@
+"use server";
+
+import { randomUUID } from "crypto";
+
+import { logAnalyticsEvent } from "@/core/analytics/actions";
+import { revalidatePath } from "next/cache";
+
+import type { ExecDashboard, MetricPoint } from "./types";
+import { requireAuth } from "@/lib/server/auth";
+
+export type ForecastScenarioKey = "commit" | "upside" | "best";
+
+export type ForecastReviewComment = {
+  id: string;
+  scenario: ForecastScenarioKey;
+  comment: string;
+  focusArea?: string;
+  authorId: string;
+  authorName: string;
+  createdAt: string;
+};
+
+export type ForecastReviewApproval = {
+  id: string;
+  scenario: ForecastScenarioKey;
+  status: "approved" | "changes_requested";
+  note?: string;
+  approverId: string;
+  approverName: string;
+  createdAt: string;
+};
+
+export type ForecastExportVersion = {
+  id: string;
+  version: number;
+  scenario: ForecastScenarioKey;
+  createdAt: string;
+  authorId: string;
+  authorName: string;
+  coverage: number;
+  riskIndex: number;
+  downloadUrl: string;
+};
+
+export type ForecastReviewState = {
+  comments: ForecastReviewComment[];
+  approvals: ForecastReviewApproval[];
+  versions: ForecastExportVersion[];
+};
+
+type ExportPayload = {
+  scenario: ForecastScenarioKey;
+  commitTrajectory: MetricPoint[];
+  upsideTrajectory: MetricPoint[];
+  bestTrajectory: MetricPoint[];
+  metadata: {
+    coverage: number;
+    riskIndex: number;
+  };
+};
+
+const REVIEW_STATE = new Map<string, ForecastReviewState>();
+
+function scopeKey(scope: ExecDashboard["scope"]) {
+  const segment = scope.segment || {};
+  return [
+    scope.time,
+    segment.businessLine ?? "*",
+    segment.icp ?? "*",
+    segment.channel ?? "*",
+    segment.region ?? "*",
+  ].join("|");
+}
+
+function cloneState(state: ForecastReviewState): ForecastReviewState {
+  return {
+    comments: [...state.comments],
+    approvals: [...state.approvals],
+    versions: [...state.versions],
+  };
+}
+
+function getDisplayName(user: { email?: string | null; user_metadata?: Record<string, any> }) {
+  return (
+    (user.user_metadata?.full_name as string | undefined) ||
+    (user.user_metadata?.name as string | undefined) ||
+    user.email ||
+    "Revenue Operator"
+  );
+}
+
+function getState(scope: ExecDashboard["scope"]) {
+  const key = scopeKey(scope);
+  if (!REVIEW_STATE.has(key)) {
+    REVIEW_STATE.set(key, { comments: [], approvals: [], versions: [] });
+  }
+  return REVIEW_STATE.get(key)!;
+}
+
+export async function getForecastReviewState(scope: ExecDashboard["scope"]) {
+  const state = getState(scope);
+  return cloneState(state);
+}
+
+export async function submitForecastComment(input: {
+  scope: ExecDashboard["scope"];
+  scenario: ForecastScenarioKey;
+  comment: string;
+  focusArea?: string;
+}) {
+  if (!input.comment?.trim()) {
+    return { ok: false, error: "missing-comment" } as const;
+  }
+
+  const context = await requireAuth({ redirectTo: "/login?next=/dashboard" });
+  const state = getState(input.scope);
+  const now = new Date().toISOString();
+  const comment: ForecastReviewComment = {
+    id: randomUUID(),
+    scenario: input.scenario,
+    comment: input.comment.trim(),
+    focusArea: input.focusArea?.trim() || undefined,
+    authorId: context.user.id,
+    authorName: getDisplayName(context.user),
+    createdAt: now,
+  };
+
+  state.comments = [comment, ...state.comments].slice(0, 50);
+
+  await logAnalyticsEvent({
+    eventKey: "forecast.review.comment",
+    payload: {
+      scenario: input.scenario,
+      focusArea: comment.focusArea ?? null,
+    },
+  });
+
+  revalidatePath("/dashboard");
+  return { ok: true, comment } as const;
+}
+
+export async function recordForecastApproval(input: {
+  scope: ExecDashboard["scope"];
+  scenario: ForecastScenarioKey;
+  status: "approved" | "changes_requested";
+  note?: string;
+}) {
+  const context = await requireAuth({ redirectTo: "/login?next=/dashboard" });
+  const state = getState(input.scope);
+  const now = new Date().toISOString();
+
+  const approval: ForecastReviewApproval = {
+    id: randomUUID(),
+    scenario: input.scenario,
+    status: input.status,
+    note: input.note?.trim() || undefined,
+    approverId: context.user.id,
+    approverName: getDisplayName(context.user),
+    createdAt: now,
+  };
+
+  state.approvals = state.approvals.filter(
+    (existing) => !(existing.approverId === approval.approverId && existing.scenario === approval.scenario),
+  );
+  state.approvals.unshift(approval);
+  state.approvals = state.approvals.slice(0, 30);
+
+  await logAnalyticsEvent({
+    eventKey: "forecast.review.approval",
+    payload: {
+      scenario: input.scenario,
+      status: input.status,
+    },
+  });
+
+  revalidatePath("/dashboard");
+  return { ok: true, approval } as const;
+}
+
+export async function exportForecastSnapshot(scope: ExecDashboard["scope"], payload: ExportPayload) {
+  const context = await requireAuth({ redirectTo: "/login?next=/dashboard" });
+  const state = getState(scope);
+  const versionNumber = (state.versions[0]?.version ?? 0) + 1;
+
+  const rows: string[] = ["Week,Commit,Upside,Best",];
+  const horizon = Math.max(
+    payload.commitTrajectory.length,
+    payload.upsideTrajectory.length,
+    payload.bestTrajectory.length,
+  );
+
+  for (let i = 0; i < horizon; i += 1) {
+    const commitPoint = payload.commitTrajectory[i];
+    const upsidePoint = payload.upsideTrajectory[i];
+    const bestPoint = payload.bestTrajectory[i];
+    const timestamp = commitPoint?.ts || upsidePoint?.ts || bestPoint?.ts || `Week ${i + 1}`;
+    rows.push([
+      timestamp,
+      commitPoint?.value ?? "",
+      upsidePoint?.value ?? "",
+      bestPoint?.value ?? "",
+    ].join(","));
+  }
+
+  rows.push("", `Coverage,${payload.metadata.coverage.toFixed(2)}`, `Risk Index %,${payload.metadata.riskIndex.toFixed(1)}`);
+
+  const csv = rows.join("\n");
+  const downloadUrl = `data:text/csv;charset=utf-8;base64,${Buffer.from(csv, "utf-8").toString("base64")}`;
+
+  const version: ForecastExportVersion = {
+    id: randomUUID(),
+    version: versionNumber,
+    scenario: payload.scenario,
+    createdAt: new Date().toISOString(),
+    authorId: context.user.id,
+    authorName: getDisplayName(context.user),
+    coverage: payload.metadata.coverage,
+    riskIndex: payload.metadata.riskIndex,
+    downloadUrl,
+  };
+
+  state.versions = [version, ...state.versions].slice(0, 20);
+
+  await logAnalyticsEvent({
+    eventKey: "forecast.export.finance",
+    payload: {
+      scenario: payload.scenario,
+      version: version.version,
+      coverage: payload.metadata.coverage,
+      riskIndex: payload.metadata.riskIndex,
+    },
+  });
+
+  revalidatePath("/dashboard");
+  return { ok: true, version } as const;
+}

--- a/core/pipeline/analytics.ts
+++ b/core/pipeline/analytics.ts
@@ -1,0 +1,404 @@
+import type { OpportunityWithNotes } from "./actions";
+
+export type PipelineStageSummary = {
+  stage: string;
+  deals: number;
+  totalValue: number;
+  weightedValue: number;
+  averageProbability: number;
+  historicalWinRate: number;
+};
+
+export type ScenarioProjection = {
+  key: "commit" | "upside" | "best";
+  label: string;
+  value: number;
+  coverage: number;
+  variance: number;
+  description: string;
+};
+
+export type OpportunityScoreCard = {
+  id: string;
+  name: string;
+  clientName: string | null;
+  ownerName: string | null;
+  stage: string;
+  amount: number;
+  score: number;
+  riskLevel: "low" | "medium" | "high";
+  signals: string[];
+  nextStep?: string | null;
+  closeDate?: string | null;
+};
+
+export type PipelineAlertCandidate = {
+  id: string;
+  type: "coverage" | "stalled" | "expiring" | "variance";
+  severity: "info" | "warning" | "critical";
+  summary: string;
+  detail?: string;
+  opportunityId?: string;
+  stage?: string;
+  amount?: number;
+  dueDate?: string;
+};
+
+export type PipelineAnalytics = {
+  target: number;
+  stageSummary: PipelineStageSummary[];
+  weightedTotal: number;
+  pipelineTotal: number;
+  coverageX: number;
+  scenarios: Record<"commit" | "upside" | "best", ScenarioProjection>;
+  ownerWinRates: Record<string, number>;
+  historicalStageWinRates: Record<string, number>;
+  opportunityScores: OpportunityScoreCard[];
+  alerts: PipelineAlertCandidate[];
+};
+
+const STAGE_ORDER: Array<
+  "Prospect" | "Qualify" | "Proposal" | "Negotiation" | "ClosedWon" | "ClosedLost"
+> = ["Prospect", "Qualify", "Proposal", "Negotiation", "ClosedWon", "ClosedLost"];
+
+const STAGE_WEIGHTS: Record<string, number> = {
+  Prospect: 0.15,
+  Qualify: 0.3,
+  Proposal: 0.55,
+  Negotiation: 0.8,
+  ClosedWon: 1,
+  ClosedLost: 0,
+};
+
+const SCENARIO_METADATA: Record<
+  "commit" | "upside" | "best",
+  { label: string; description: string }
+> = {
+  commit: {
+    label: "Commit",
+    description: "Deals in late stage with >70% confidence and executive coverage.",
+  },
+  upside: {
+    label: "Upside",
+    description: "Pipeline that can be pulled in with acceleration plays and exec focus.",
+  },
+  best: {
+    label: "Best Case",
+    description: "All open pipeline excluding losses, assuming cycle time holds.",
+  },
+};
+
+function daysBetween(a: string | null, b: string | null) {
+  if (!a || !b) return 0;
+  const start = new Date(a).getTime();
+  const end = new Date(b).getTime();
+  return Math.max(0, Math.round((end - start) / (1000 * 60 * 60 * 24)));
+}
+
+function computeHistoricalStageWinRates(opportunities: OpportunityWithNotes[]) {
+  const closed = opportunities.filter((opp) => opp.close_date);
+  const buckets = STAGE_ORDER.reduce<Record<string, { won: number; total: number }>>(
+    (acc, stage) => {
+      acc[stage] = { won: 0, total: 0 };
+      return acc;
+    },
+    {},
+  );
+
+  closed.forEach((opp) => {
+    const cycle = daysBetween(opp.created_at, opp.close_date);
+    let inferredStage: (typeof STAGE_ORDER)[number] = "Prospect";
+
+    if (cycle <= 14) {
+      inferredStage = "Negotiation";
+    } else if (cycle <= 28) {
+      inferredStage = "Proposal";
+    } else if (cycle <= 45) {
+      inferredStage = "Qualify";
+    }
+
+    buckets[inferredStage].total += 1;
+    if (opp.stage === "ClosedWon") {
+      buckets[inferredStage].won += 1;
+    }
+  });
+
+  const results = STAGE_ORDER.reduce<Record<string, number>>((acc, stage) => {
+    if (stage === "ClosedLost") {
+      acc[stage] = 0;
+      return acc;
+    }
+
+    const data = buckets[stage];
+    const base = STAGE_WEIGHTS[stage] ?? 0.3;
+    if (!data.total) {
+      acc[stage] = base;
+      return acc;
+    }
+
+    acc[stage] = Math.min(1, Math.max(0.05, data.won / data.total));
+    return acc;
+  }, {} as Record<string, number>);
+
+  return results;
+}
+
+function computeOwnerWinRates(opportunities: OpportunityWithNotes[]) {
+  const closed = opportunities.filter((opp) => opp.stage === "ClosedWon" || opp.stage === "ClosedLost");
+  const stats = new Map<string, { won: number; total: number }>();
+
+  closed.forEach((opp) => {
+    const key = opp.owner_id || "unknown";
+    const entry = stats.get(key) ?? { won: 0, total: 0 };
+    entry.total += 1;
+    if (opp.stage === "ClosedWon") {
+      entry.won += 1;
+    }
+    stats.set(key, entry);
+  });
+
+  const overall = closed.length
+    ? closed.filter((opp) => opp.stage === "ClosedWon").length / closed.length
+    : 0.35;
+
+  const map: Record<string, number> = {};
+  stats.forEach((value, key) => {
+    map[key] = value.total ? value.won / value.total : overall;
+  });
+
+  return { ownerWinRates: map, overallWinRate: overall };
+}
+
+function classifyAlerts(
+  opportunities: OpportunityWithNotes[],
+  target: number,
+  scenarios: Record<"commit" | "upside" | "best", ScenarioProjection>,
+  coverageX: number,
+): PipelineAlertCandidate[] {
+  const alerts: PipelineAlertCandidate[] = [];
+  const now = Date.now();
+
+  if (coverageX < 1.8) {
+    alerts.push({
+      id: `coverage-${coverageX.toFixed(2)}`,
+      type: "coverage",
+      severity: coverageX < 1.2 ? "critical" : "warning",
+      summary: `Pipeline coverage ${coverageX.toFixed(1)}x vs ${(
+        target / 1_000_000
+      ).toFixed(1)}M quarterly target`,
+      detail: "Add late-stage opps or expand existing deals to protect commit.",
+    });
+  }
+
+  if (scenarios.commit.variance < 0) {
+    alerts.push({
+      id: `variance-commit-${Math.abs(scenarios.commit.variance)}`,
+      type: "variance",
+      severity: Math.abs(scenarios.commit.variance) > target * 0.2 ? "critical" : "warning",
+      summary: `Commit shortfall ${formatCurrency(Math.abs(scenarios.commit.variance))}`,
+      detail: "Execute pull-forward plays or adjust forecast guidance.",
+    });
+  }
+
+  const staleThreshold = 30;
+  opportunities
+    .filter((opp) => !["ClosedWon", "ClosedLost"].includes(opp.stage))
+    .forEach((opp) => {
+      const lastUpdated = new Date(opp.updated_at).getTime();
+      const daysStale = Math.round((now - lastUpdated) / (1000 * 60 * 60 * 24));
+      if (daysStale >= staleThreshold) {
+        alerts.push({
+          id: `stalled-${opp.id}`,
+          type: "stalled",
+          severity: daysStale > 45 ? "critical" : "warning",
+          summary: `${opp.name} stalled ${daysStale}d in ${opp.stage}`,
+          detail: opp.next_step ?? "Add exec sponsor touch to re-engage.",
+          opportunityId: opp.id,
+          stage: opp.stage,
+          amount: opp.amount,
+        });
+      }
+    });
+
+  opportunities
+    .filter((opp) => !["ClosedWon", "ClosedLost"].includes(opp.stage))
+    .forEach((opp) => {
+      if (!opp.close_date) return;
+      const daysToClose = daysBetween(new Date().toISOString(), opp.close_date);
+      if (daysToClose <= 14) {
+        alerts.push({
+          id: `expiring-${opp.id}`,
+          type: "expiring",
+          severity: daysToClose <= 7 ? "critical" : "warning",
+          summary: `${opp.name} quote expires in ${Math.max(0, daysToClose)}d`,
+          detail: opp.next_step ?? "Send final pricing + exec alignment.",
+          opportunityId: opp.id,
+          stage: opp.stage,
+          amount: opp.amount,
+          dueDate: opp.close_date ?? undefined,
+        });
+      }
+    });
+
+  return alerts;
+}
+
+function formatCurrency(value: number) {
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+export function buildPipelineAnalytics(
+  opportunities: OpportunityWithNotes[],
+  options: { target: number },
+): PipelineAnalytics {
+  const target = options.target;
+
+  const historicalStageWinRates = computeHistoricalStageWinRates(opportunities);
+  const { ownerWinRates, overallWinRate } = computeOwnerWinRates(opportunities);
+
+  const stageSummary: PipelineStageSummary[] = STAGE_ORDER.map((stage) => {
+    const deals = opportunities.filter((opp) => opp.stage === stage);
+    const totalValue = deals.reduce((sum, opp) => sum + (opp.amount || 0), 0);
+    const weight = STAGE_WEIGHTS[stage] ?? (deals[0]?.probability ?? 50) / 100;
+    const weightedValue = deals.reduce(
+      (sum, opp) => sum + (opp.amount || 0) * (STAGE_WEIGHTS[stage] ?? (opp.probability || 0) / 100),
+      0,
+    );
+    const averageProbability =
+      deals.length > 0
+        ? deals.reduce((sum, opp) => sum + (opp.probability || weight * 100), 0) / deals.length
+        : weight * 100;
+
+    return {
+      stage,
+      deals: deals.length,
+      totalValue,
+      weightedValue,
+      averageProbability,
+      historicalWinRate: historicalStageWinRates[stage] ?? weight,
+    };
+  });
+
+  const weightedTotal = stageSummary.reduce((sum, stage) => sum + stage.weightedValue, 0);
+  const pipelineTotal = stageSummary.reduce((sum, stage) => sum + stage.totalValue, 0);
+  const coverageX = target > 0 ? pipelineTotal / target : 0;
+
+  const commitDeals = opportunities.filter(
+    (opp) =>
+      ["Negotiation", "ClosedWon"].includes(opp.stage) || (opp.probability ?? 0) >= 70,
+  );
+  const upsideDeals = opportunities.filter(
+    (opp) =>
+      ["Proposal", "Negotiation", "ClosedWon"].includes(opp.stage) ||
+      (opp.probability ?? 0) >= 50,
+  );
+  const bestDeals = opportunities.filter((opp) => opp.stage !== "ClosedLost");
+
+  const scenarioValues = {
+    commit: commitDeals.reduce((sum, opp) => sum + (opp.amount || 0), 0),
+    upside: upsideDeals.reduce((sum, opp) => sum + (opp.amount || 0), 0),
+    best: bestDeals.reduce((sum, opp) => sum + (opp.amount || 0), 0),
+  } as const;
+
+  const scenarios: Record<"commit" | "upside" | "best", ScenarioProjection> = {
+    commit: {
+      key: "commit",
+      label: SCENARIO_METADATA.commit.label,
+      description: SCENARIO_METADATA.commit.description,
+      value: scenarioValues.commit,
+      coverage: target > 0 ? scenarioValues.commit / target : 0,
+      variance: scenarioValues.commit - target,
+    },
+    upside: {
+      key: "upside",
+      label: SCENARIO_METADATA.upside.label,
+      description: SCENARIO_METADATA.upside.description,
+      value: scenarioValues.upside,
+      coverage: target > 0 ? scenarioValues.upside / target : 0,
+      variance: scenarioValues.upside - target,
+    },
+    best: {
+      key: "best",
+      label: SCENARIO_METADATA.best.label,
+      description: SCENARIO_METADATA.best.description,
+      value: scenarioValues.best,
+      coverage: target > 0 ? scenarioValues.best / target : 0,
+      variance: scenarioValues.best - target,
+    },
+  };
+
+  const alerts = classifyAlerts(opportunities, target, scenarios, coverageX);
+
+  const now = Date.now();
+  const scored: OpportunityScoreCard[] = opportunities
+    .filter((opp) => !["ClosedWon", "ClosedLost"].includes(opp.stage))
+    .map((opp) => {
+      const stageWeight = STAGE_WEIGHTS[opp.stage] ?? (opp.probability ?? 0) / 100;
+      const historical = historicalStageWinRates[opp.stage] ?? stageWeight;
+      const ownerRate = ownerWinRates[opp.owner_id ?? "unknown"] ?? overallWinRate;
+      const updated = new Date(opp.updated_at).getTime();
+      const daysSinceUpdate = Math.round((now - updated) / (1000 * 60 * 60 * 24));
+      const freshness = Math.max(0, 1 - Math.min(daysSinceUpdate / 45, 1));
+      const agentKeywords = ["rosie", "agent", "playbook", "automation", "ai"];
+      const agentTouches = (opp.notes || []).filter((note) =>
+        agentKeywords.some((keyword) => note.body?.toLowerCase().includes(keyword)),
+      ).length;
+      const agentSignal = agentTouches > 0 ? Math.min(1, 0.6 + agentTouches * 0.1) : opp.notes?.length ? 0.4 : 0.25;
+      const baseProbability = (opp.probability ?? stageWeight * 100) / 100;
+
+      const rawScore =
+        baseProbability * 35 +
+        historical * 25 +
+        ownerRate * 20 +
+        agentSignal * 10 +
+        freshness * 10;
+
+      const score = Math.max(0, Math.min(100, Math.round(rawScore)));
+      const riskLevel: "low" | "medium" | "high" = score >= 70 ? "low" : score >= 45 ? "medium" : "high";
+
+      const signals: string[] = [
+        `Stage weight ${(stageWeight * 100).toFixed(0)}%`,
+        `Owner win rate ${(ownerRate * 100).toFixed(0)}%`,
+      ];
+
+      if (agentTouches > 0) {
+        signals.push(`${agentTouches} agent insight${agentTouches > 1 ? "s" : ""}`);
+      } else if (opp.notes?.length) {
+        signals.push("Manual notes logged");
+      } else {
+        signals.push("Needs agent activation");
+      }
+
+      if (daysSinceUpdate > 21) {
+        signals.push(`Stale ${daysSinceUpdate}d`);
+      }
+
+      return {
+        id: opp.id,
+        name: opp.name,
+        clientName: opp.client?.name ?? null,
+        ownerName: opp.owner?.name ?? null,
+        stage: opp.stage,
+        amount: opp.amount,
+        score,
+        riskLevel,
+        signals,
+        nextStep: opp.next_step,
+        closeDate: opp.close_date,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  return {
+    target,
+    stageSummary,
+    weightedTotal,
+    pipelineTotal,
+    coverageX,
+    scenarios,
+    ownerWinRates,
+    historicalStageWinRates,
+    opportunityScores: scored,
+    alerts,
+  };
+}


### PR DESCRIPTION
## Summary
- add pipeline analytics helpers for stage-weighted forecasts, scenario projections, scoring, and alerts
- surface scenario planning, automation scheduling, and risk alert workflows in the pipeline UI
- introduce collaborative forecast review actions and UI with finance export history on the executive dashboard

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68eeac8e97b083248aff20894bb2418e