### PR TITLE
feat: automate governed agents and telemetry

### DIFF
--- a/app/dashboard/telemetry/TelemetryDashboardClient.tsx
+++ b/app/dashboard/telemetry/TelemetryDashboardClient.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import { StatCard } from '@/components/kit/StatCard'
+import type { TelemetrySnapshot } from '@/core/analytics/telemetry'
+import { cn } from '@/lib/utils'
+
+const LOOKBACK_OPTIONS = [7, 30, 90]
+
+type TelemetryDashboardClientProps = {
+  snapshot: TelemetrySnapshot
+}
+
+export default function TelemetryDashboardClient({ snapshot }: TelemetryDashboardClientProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const maxTimeline = useMemo(() => {
+    return snapshot.timeline.reduce((max, point) => Math.max(max, point.count), 0)
+  }, [snapshot.timeline])
+
+  const handleLookbackChange = (value: number) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('lookback', String(value))
+    router.replace(`/dashboard/telemetry?${params.toString()}`)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-black">Operational Telemetry</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Unified adoption, performance, and compliance signals across sales, delivery, and finance workflows.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {LOOKBACK_OPTIONS.map((option) => {
+            const active = snapshot.lookbackDays === option
+            return (
+              <button
+                key={option}
+                onClick={() => handleLookbackChange(option)}
+                className={cn(
+                  'rounded-full border px-3 py-1 text-xs font-medium transition',
+                  active
+                    ? 'border-gray-900 bg-gray-900 text-white shadow-sm'
+                    : 'border-gray-300 bg-white text-gray-700 hover:border-gray-400',
+                )}
+              >
+                Last {option}d
+              </button>
+            )
+          })}
+        </div>
+      </header>
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Adoption</h2>
+        <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label="Active users"
+            value={snapshot.adoption.activeUsers.toString()}
+            delta={`${snapshot.adoption.agentRuns} agent runs recorded`}
+            trend={snapshot.adoption.agentRuns > 0 ? 'up' : 'flat'}
+          />
+          <StatCard
+            label="Automation executions"
+            value={snapshot.adoption.automationExecutions.toString()}
+            delta={`${snapshot.adoption.activePlaybooks} active playbooks`}
+            trend={snapshot.adoption.automationExecutions > 0 ? 'up' : 'flat'}
+          />
+          <StatCard
+            label="Total events"
+            value={snapshot.adoption.totalEvents.toString()}
+            delta={`${snapshot.lookbackDays}-day window`}
+            trend={snapshot.adoption.totalEvents > 20 ? 'up' : 'flat'}
+          />
+          <StatCard
+            label="Throughput"
+            value={`${snapshot.performance.automationThroughput}`}
+            delta={`Automation signals emitted`}
+            trend={snapshot.performance.automationThroughput > snapshot.adoption.agentRuns ? 'up' : 'flat'}
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-5">
+        <div className="rounded-xl border border-gray-200 bg-white p-4 lg:col-span-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-base font-semibold text-gray-900">Event timeline</h3>
+              <p className="text-xs text-gray-500">Daily signal volume across the selected window.</p>
+            </div>
+            <span className="text-xs text-gray-500">Max {maxTimeline}</span>
+          </div>
+          <div className="mt-4 flex h-40 items-end gap-2">
+            {snapshot.timeline.length === 0 ? (
+              <div className="flex h-full w-full items-center justify-center text-xs text-gray-500">
+                No telemetry events in this window.
+              </div>
+            ) : (
+              snapshot.timeline.map((point) => {
+                const height = maxTimeline ? Math.max(4, Math.round((point.count / maxTimeline) * 100)) : 4
+                return (
+                  <div key={point.date} className="flex-1">
+                    <div
+                      className="mx-auto w-full rounded-t-md bg-gray-900"
+                      style={{ height: `${height}%`, minHeight: '0.75rem' }}
+                      title={`${point.count} events on ${point.date}`}
+                    />
+                    <div className="mt-2 text-center text-[10px] text-gray-500">{point.date.slice(5)}</div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 lg:col-span-2">
+          <h3 className="text-base font-semibold text-gray-900">Top workflows</h3>
+          <p className="text-xs text-gray-500">Most active automations and reviews.</p>
+          <ul className="mt-3 space-y-2">
+            {snapshot.topWorkflows.length === 0 ? (
+              <li className="rounded-lg border border-dashed border-gray-200 p-3 text-xs text-gray-500">
+                No workflow activity recorded.
+              </li>
+            ) : (
+              snapshot.topWorkflows.map((item) => (
+                <li key={item.workflow} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2">
+                  <div>
+                    <div className="text-sm font-medium text-gray-900">{item.workflow}</div>
+                    <div className="text-xs text-gray-500">Workflow signals</div>
+                  </div>
+                  <span className="text-sm font-semibold text-gray-900">{item.count}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <h3 className="text-base font-semibold text-gray-900">Automation performance</h3>
+          <p className="text-xs text-gray-500">Delivery speed and success of cross-workspace automations.</p>
+          <dl className="mt-3 space-y-2 text-sm text-gray-700">
+            <div className="flex items-center justify-between">
+              <dt>Success rate</dt>
+              <dd className="font-medium text-gray-900">{snapshot.performance.automationSuccessRate}%</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt>Average events / day</dt>
+              <dd className="font-medium text-gray-900">{snapshot.performance.avgEventsPerDay}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt>Automation throughput</dt>
+              <dd className="font-medium text-gray-900">{snapshot.performance.automationThroughput}</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 lg:col-span-2">
+          <h3 className="text-base font-semibold text-gray-900">Compliance & guardrails</h3>
+          <p className="text-xs text-gray-500">Track guardrail breaches and escalations triggered by agents.</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border border-gray-200 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-gray-500">Guardrail breaches</div>
+              <div className="mt-1 text-xl font-semibold text-gray-900">{snapshot.compliance.guardrailBreaches}</div>
+              <div className="text-[11px] text-gray-500">Agent runs requiring escalation</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-gray-500">Flagged runs</div>
+              <div className="mt-1 text-xl font-semibold text-gray-900">{snapshot.compliance.flaggedRuns}</div>
+              <div className="text-[11px] text-gray-500">Runs with policy annotations</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-gray-500">Compliance events</div>
+              <div className="mt-1 text-xl font-semibold text-gray-900">{snapshot.compliance.complianceEvents}</div>
+              <div className="text-[11px] text-gray-500">Audit + guardrail signals</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/dashboard/telemetry/page.tsx
+++ b/app/dashboard/telemetry/page.tsx
@@ -1,0 +1,19 @@
+import { getTelemetrySnapshot } from '@/core/analytics/telemetry'
+
+import TelemetryDashboardClient from './TelemetryDashboardClient'
+
+type TelemetryPageProps = {
+  searchParams?: { lookback?: string }
+}
+
+export default async function TelemetryPage({ searchParams }: TelemetryPageProps) {
+  const requestedLookback = Number(searchParams?.lookback ?? '30')
+  const lookbackDays = Number.isFinite(requestedLookback) && requestedLookback > 0 ? requestedLookback : 30
+  const snapshot = await getTelemetrySnapshot(lookbackDays)
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-6">
+      <TelemetryDashboardClient snapshot={snapshot} />
+    </div>
+  )
+}

--- a/app/ops/playbooks/PlaybookBuilderClient.tsx
+++ b/app/ops/playbooks/PlaybookBuilderClient.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+import { upsertAutomationPlaybook, updateAutomationPlaybookStatus, runAutomationPlaybook } from '@/core/automations/actions'
+import type { AutomationPlaybook } from '@/core/automations/types'
+import { cn } from '@/lib/utils'
+
+const CLOSED_WON_TEMPLATE = {
+  name: 'Closed Won → Delivery & Finance',
+  description: 'Kick off delivery and schedule invoices automatically when a deal closes won.',
+  triggerEvent: 'pipeline.closed_won',
+  status: 'active' as const,
+  configuration: { sla_hours: 4 },
+  steps: [
+    {
+      sortOrder: 1,
+      workspace: 'sales' as const,
+      action: 'log_closed_won_context',
+      config: { summaryField: 'win_notes' },
+    },
+    {
+      sortOrder: 2,
+      workspace: 'delivery' as const,
+      action: 'create_project_kickoff',
+      config: { phase: 'Data' },
+    },
+    {
+      sortOrder: 3,
+      workspace: 'finance' as const,
+      action: 'schedule_invoice_plan',
+      config: { cadence: 'monthly', installments: 3 },
+    },
+  ],
+}
+
+type PlaybookBuilderClientProps = {
+  playbooks: AutomationPlaybook[]
+}
+
+export default function PlaybookBuilderClient({ playbooks }: PlaybookBuilderClientProps) {
+  const [pending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+
+  const handleCreateTemplate = () => {
+    startTransition(async () => {
+      try {
+        await upsertAutomationPlaybook(CLOSED_WON_TEMPLATE)
+        setMessage('Closed-won automation template deployed.')
+      } catch (error) {
+        console.error('playbooks:create-template', error)
+        setMessage('Unable to create automation template.')
+      }
+    })
+  }
+
+  const handleStatusChange = (id: string, status: 'draft' | 'active' | 'archived') => {
+    startTransition(async () => {
+      try {
+        await updateAutomationPlaybookStatus(id, status)
+        setMessage(`Playbook status updated to ${status}.`)
+      } catch (error) {
+        console.error('playbooks:update-status', error)
+        setMessage('Unable to update playbook status.')
+      }
+    })
+  }
+
+  const handleRun = (id: string) => {
+    startTransition(async () => {
+      try {
+        const result = await runAutomationPlaybook(id, {
+          opportunityId: 'demo-opportunity',
+          clientId: 'demo-client',
+          amount: 45000,
+          name: 'Demo Opportunity',
+        })
+        setMessage(`Automation run ${result.runId} ${result.status}.`)
+      } catch (error) {
+        console.error('playbooks:run', error)
+        setMessage('Unable to execute automation.')
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-black">Automation Playbooks</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Orchestrate cross-workspace workflows that connect sales wins to delivery kickoffs and finance schedules.
+          </p>
+        </div>
+        <button
+          onClick={handleCreateTemplate}
+          disabled={pending}
+          className="inline-flex items-center rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-black disabled:cursor-not-allowed disabled:bg-gray-600"
+        >
+          Deploy closed-won playbook
+        </button>
+      </header>
+
+      {message ? (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900">{message}</div>
+      ) : null}
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {playbooks.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 bg-white p-6 text-sm text-gray-600">
+            No automation playbooks configured yet. Deploy the closed-won template to get started.
+          </div>
+        ) : (
+          playbooks.map((playbook) => (
+            <article key={playbook.id} className="flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900">{playbook.name}</h2>
+                  <p className="mt-1 text-sm text-gray-600">{playbook.description ?? 'No description provided.'}</p>
+                </div>
+                <span
+                  className={cn(
+                    'rounded-full px-3 py-1 text-xs font-semibold uppercase',
+                    playbook.status === 'active'
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : playbook.status === 'draft'
+                      ? 'bg-amber-100 text-amber-700'
+                      : 'bg-gray-200 text-gray-700',
+                  )}
+                >
+                  {playbook.status}
+                </span>
+              </div>
+
+              <dl className="mt-4 space-y-2 text-xs text-gray-600">
+                <div className="flex items-center justify-between">
+                  <dt>Trigger event</dt>
+                  <dd className="font-medium text-gray-900">{playbook.triggerEvent}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <dt>Steps</dt>
+                  <dd className="flex-1 space-y-2 text-gray-700">
+                    {playbook.steps.length === 0 ? (
+                      <div className="rounded border border-dashed border-gray-200 p-2 text-xs text-gray-500">
+                        No steps defined.
+                      </div>
+                    ) : (
+                      playbook.steps.map((step) => (
+                        <div key={step.id} className="rounded border border-gray-200 p-2">
+                          <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-500">
+                            <span>{step.workspace}</span>
+                            <span>#{step.sortOrder}</span>
+                          </div>
+                          <div className="text-sm font-medium text-gray-900">{step.action}</div>
+                          {Object.keys(step.config).length ? (
+                            <pre className="mt-1 rounded bg-gray-50 p-2 text-[11px] text-gray-600">
+                              {JSON.stringify(step.config, null, 2)}
+                            </pre>
+                          ) : null}
+                        </div>
+                      ))
+                    )}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  onClick={() => handleRun(playbook.id)}
+                  disabled={pending}
+                  className="rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:border-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Run test
+                </button>
+                <button
+                  onClick={() => handleStatusChange(playbook.id, playbook.status === 'active' ? 'archived' : 'active')}
+                  disabled={pending}
+                  className="rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:border-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {playbook.status === 'active' ? 'Archive playbook' : 'Activate playbook'}
+                </button>
+                {playbook.status !== 'draft' ? (
+                  <button
+                    onClick={() => handleStatusChange(playbook.id, 'draft')}
+                    disabled={pending}
+                    className="rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:border-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Move to draft
+                  </button>
+                ) : null}
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/ops/playbooks/page.tsx
+++ b/app/ops/playbooks/page.tsx
@@ -1,0 +1,13 @@
+import { listAutomationPlaybooks } from '@/core/automations/actions'
+
+import PlaybookBuilderClient from './PlaybookBuilderClient'
+
+export default async function PlaybooksPage() {
+  const playbooks = await listAutomationPlaybooks()
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-6">
+      <PlaybookBuilderClient playbooks={playbooks} />
+    </div>
+  )
+}

--- a/core/agents/bus.ts
+++ b/core/agents/bus.ts
@@ -3,11 +3,26 @@ import { Agent, AgentKey, AgentRunInput, AgentRunOutput } from './types'
 const REGISTRY = new Map<AgentKey, Agent>()
 type Log = { ts: string; key: AgentKey; input: AgentRunInput; output: AgentRunOutput }
 const LOGS: Log[] = []
-const STATUS = new Map<AgentKey, { enabled: boolean; lastRun?: string; lastSummary?: string; impact$?: number }>()
+const STATUS = new Map<
+  AgentKey,
+  {
+    enabled: boolean
+    lastRun?: string
+    lastSummary?: string
+    impact$?: number
+    lifecycle?: string
+    autoRunnable?: boolean
+  }
+>()
 
 export function register(agent: Agent) {
   REGISTRY.set(agent.meta.key, agent)
-  if (!STATUS.has(agent.meta.key)) STATUS.set(agent.meta.key, { enabled: true })
+  if (!STATUS.has(agent.meta.key))
+    STATUS.set(agent.meta.key, {
+      enabled: true,
+      autoRunnable: agent.meta.autoRunnable ?? false,
+      lifecycle: 'active',
+    })
 }
 
 export function listAgents() {
@@ -43,6 +58,7 @@ export function logsFor(key: AgentKey, limit = 50) {
 export function setEnabled(key: AgentKey, enabled: boolean) {
   const s = STATUS.get(key) ?? { enabled: true }
   s.enabled = enabled
+  s.lifecycle = enabled ? 'active' : 'disabled'
   STATUS.set(key, s)
   return s
 }

--- a/core/agents/governance.ts
+++ b/core/agents/governance.ts
@@ -1,0 +1,111 @@
+'use server'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type AgentGovernanceRecord = {
+  agentKey: string
+  definitionId: string
+  lifecycleStatus: string
+  autoRunnable: boolean
+  displayName?: string | null
+  description?: string | null
+  definition?: Record<string, unknown> | null
+  prompts: {
+    id: string
+    name: string
+    role: string
+    content: string
+    lifecycleStatus: string
+  }[]
+  guardrails: {
+    id: string
+    rule: string
+    severity: string
+    remediation?: string | null
+    lifecycleStatus: string
+  }[]
+}
+
+export async function loadAgentGovernance(
+  supabase: SupabaseClient,
+  organizationId: string,
+  agentKeys: string[],
+): Promise<Map<string, AgentGovernanceRecord>> {
+  if (!agentKeys.length) return new Map()
+
+  const { data, error } = await supabase
+    .from('agent_definitions')
+    .select(
+      `id, agent_key, lifecycle_status, auto_runnable, display_name, description, definition,
+       prompts:agent_prompts(id, name, role, content, lifecycle_status),
+       guardrails:agent_guardrails(id, rule, severity, remediation, lifecycle_status)`,
+    )
+    .eq('organization_id', organizationId)
+    .in('agent_key', agentKeys)
+    .order('version', { ascending: false })
+
+  if (error) {
+    console.error('agents:load-governance-failed', error)
+    return new Map()
+  }
+
+  const records = new Map<string, AgentGovernanceRecord>()
+
+  for (const row of data ?? []) {
+    const key = row.agent_key as string
+    if (!records.has(key)) {
+      records.set(key, {
+        agentKey: key,
+        definitionId: row.id as string,
+        lifecycleStatus: (row.lifecycle_status as string) ?? 'active',
+        autoRunnable: Boolean(row.auto_runnable),
+        displayName: row.display_name as string | null,
+        description: row.description as string | null,
+        definition: (row.definition as Record<string, unknown> | null) ?? null,
+        prompts: ((row.prompts as any[]) ?? []).map((prompt) => ({
+          id: prompt.id as string,
+          name: prompt.name as string,
+          role: prompt.role as string,
+          content: prompt.content as string,
+          lifecycleStatus: (prompt.lifecycle_status as string) ?? 'active',
+        })),
+        guardrails: ((row.guardrails as any[]) ?? []).map((rule) => ({
+          id: rule.id as string,
+          rule: rule.rule as string,
+          severity: (rule.severity as string) ?? 'medium',
+          remediation: rule.remediation as string | null,
+          lifecycleStatus: (rule.lifecycle_status as string) ?? 'active',
+        })),
+      })
+    }
+  }
+
+  return records
+}
+
+export async function persistAgentRunRecord(
+  supabase: SupabaseClient,
+  input: {
+    agentKey: string
+    organizationId: string
+    userId: string
+    runInput?: Record<string, unknown>
+    runOutput?: Record<string, unknown>
+    summary?: string
+    guardrailViolations?: string[]
+  },
+) {
+  const { error } = await supabase.from('agent_runs').insert({
+    agent_key: input.agentKey,
+    organization_id: input.organizationId,
+    user_id: input.userId,
+    input: input.runInput ?? {},
+    output: input.runOutput ?? {},
+    summary: input.summary ?? null,
+    guardrail_violations: input.guardrailViolations ?? [],
+  })
+
+  if (error) {
+    console.error('agents:persist-run-failed', error)
+  }
+}

--- a/core/analytics/actions.ts
+++ b/core/analytics/actions.ts
@@ -7,6 +7,8 @@ type LogEventInput = {
   payload?: Record<string, unknown>
   organizationId?: string | null
   userId?: string | null
+  entity?: string
+  entityId?: string
 }
 
 export async function logAnalyticsEvent({
@@ -14,6 +16,8 @@ export async function logAnalyticsEvent({
   payload = {},
   organizationId,
   userId,
+  entity,
+  entityId,
 }: LogEventInput) {
   if (!eventKey) {
     return { ok: false, error: 'missing-event-key' }
@@ -33,6 +37,8 @@ export async function logAnalyticsEvent({
       organization_id: resolvedOrgId,
       user_id: resolvedUserId,
       event_key: eventKey,
+      entity: entity ?? undefined,
+      entity_id: entityId ?? undefined,
       payload: {
         ...payload,
         emitted_at: new Date().toISOString(),

--- a/core/analytics/telemetry.ts
+++ b/core/analytics/telemetry.ts
@@ -1,0 +1,146 @@
+'use server'
+
+import { requireAuth } from '@/lib/server/auth'
+
+export type TelemetrySnapshot = {
+  lookbackDays: number
+  adoption: {
+    activeUsers: number
+    agentRuns: number
+    automationExecutions: number
+    totalEvents: number
+    activePlaybooks: number
+  }
+  performance: {
+    automationSuccessRate: number
+    avgEventsPerDay: number
+    automationThroughput: number
+  }
+  compliance: {
+    guardrailBreaches: number
+    flaggedRuns: number
+    complianceEvents: number
+  }
+  timeline: { date: string; count: number }[]
+  topWorkflows: { workflow: string; count: number }[]
+}
+
+export async function getTelemetrySnapshot(lookbackDays = 30): Promise<TelemetrySnapshot> {
+  const { supabase, organizationId } = await requireAuth({ redirectTo: '/login?next=/dashboard/telemetry' })
+
+  if (!organizationId) {
+    return {
+      lookbackDays,
+      adoption: { activeUsers: 0, agentRuns: 0, automationExecutions: 0, totalEvents: 0, activePlaybooks: 0 },
+      performance: { automationSuccessRate: 0, avgEventsPerDay: 0, automationThroughput: 0 },
+      compliance: { guardrailBreaches: 0, flaggedRuns: 0, complianceEvents: 0 },
+      timeline: [],
+      topWorkflows: [],
+    }
+  }
+
+  const since = new Date()
+  since.setDate(since.getDate() - lookbackDays)
+  const sinceIso = since.toISOString()
+
+  const [eventsRes, agentRunsRes, automationRunsRes, playbooksRes] = await Promise.all([
+    supabase
+      .from('analytics_events')
+      .select('event_key, occurred_at, user_id, workflow, payload')
+      .eq('organization_id', organizationId)
+      .gte('occurred_at', sinceIso),
+    supabase
+      .from('agent_runs')
+      .select('id, guardrail_violations, created_at, agent_key')
+      .eq('organization_id', organizationId)
+      .gte('created_at', sinceIso),
+    supabase
+      .from('automation_runs')
+      .select('id, status, created_at')
+      .eq('organization_id', organizationId)
+      .gte('created_at', sinceIso),
+    supabase.from('automation_playbooks').select('id, status').eq('organization_id', organizationId),
+  ])
+
+  if (eventsRes.error) console.error('telemetry:events-error', eventsRes.error)
+  if (agentRunsRes.error) console.error('telemetry:agent-runs-error', agentRunsRes.error)
+  if (automationRunsRes.error) console.error('telemetry:automation-runs-error', automationRunsRes.error)
+  if (playbooksRes.error) console.error('telemetry:playbooks-error', playbooksRes.error)
+
+  const events = eventsRes.data ?? []
+  const agentRuns = agentRunsRes.data ?? []
+  const automationRuns = automationRunsRes.data ?? []
+  const playbooks = playbooksRes.data ?? []
+
+  const adoptionUsers = new Set<string>()
+  const timelineMap = new Map<string, number>()
+  const workflowMap = new Map<string, number>()
+
+  for (const event of events) {
+    const userId = event.user_id as string | null
+    if (userId) adoptionUsers.add(userId)
+
+    const day = typeof event.occurred_at === 'string' ? event.occurred_at.slice(0, 10) : null
+    if (day) {
+      timelineMap.set(day, (timelineMap.get(day) ?? 0) + 1)
+    }
+
+    const workflow = (event.workflow as string | null) ??
+      (typeof event.event_key === 'string' ? event.event_key.split('.').slice(0, 2).join('.') : 'other')
+    workflowMap.set(workflow, (workflowMap.get(workflow) ?? 0) + 1)
+  }
+
+  const agentRunEvents = events.filter((event) => typeof event.event_key === 'string' && event.event_key.startsWith('agent.'))
+  const automationEvents = events.filter((event) => typeof event.event_key === 'string' && event.event_key.startsWith('automation.'))
+  const complianceEvents = events.filter((event) => {
+    if (typeof event.event_key !== 'string') return false
+    return event.event_key.includes('guardrail') || event.event_key.includes('compliance')
+  })
+
+  const automationExecutions = automationRuns.length
+  const automationCompleted = automationRuns.filter((run) => run.status === 'completed').length
+  const automationSuccessRate = automationExecutions
+    ? Math.round((automationCompleted / automationExecutions) * 100)
+    : 0
+
+  const guardrailBreaches = agentRuns.filter((run) => (run.guardrail_violations as string[] | null)?.length).length
+
+  const timeline = Array.from(timelineMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, count]) => ({ date, count }))
+
+  const topWorkflows = Array.from(workflowMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([workflow, count]) => ({ workflow, count }))
+
+  const avgEventsPerDay = timeline.length
+    ? Number((events.length / timeline.length).toFixed(2))
+    : 0
+
+  const flaggedRuns = guardrailBreaches
+  const activePlaybooks = playbooks.filter((playbook) => playbook.status === 'active').length
+
+  return {
+    lookbackDays,
+    adoption: {
+      activeUsers: adoptionUsers.size,
+      agentRuns: agentRunEvents.length,
+      automationExecutions,
+      totalEvents: events.length,
+      activePlaybooks,
+    },
+    performance: {
+      automationSuccessRate,
+      avgEventsPerDay,
+      automationThroughput: automationEvents.length,
+    },
+    compliance: {
+      guardrailBreaches,
+      flaggedRuns,
+      complianceEvents: complianceEvents.length,
+    },
+    timeline,
+    topWorkflows,
+  }
+}

--- a/core/automations/actions.ts
+++ b/core/automations/actions.ts
@@ -1,0 +1,233 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { logAnalyticsEvent } from '@/core/analytics/actions'
+import { requireAuth } from '@/lib/server/auth'
+
+import {
+  executeAutomationPlaybook,
+  loadAutomationPlaybook,
+  loadAutomationPlaybooksForEvent,
+} from './engine'
+import type { AutomationPlaybook } from './types'
+
+type PlaybookInput = {
+  id?: string
+  name: string
+  description?: string
+  triggerEvent: string
+  status?: 'draft' | 'active' | 'archived'
+  configuration?: Record<string, unknown>
+  steps: {
+    id?: string
+    sortOrder: number
+    workspace: 'sales' | 'delivery' | 'finance' | 'ops'
+    action: string
+    config?: Record<string, unknown>
+  }[]
+}
+
+export async function listAutomationPlaybooks(): Promise<AutomationPlaybook[]> {
+  const { supabase, organizationId } = await requireAuth({ redirectTo: '/login?next=/ops/playbooks' })
+
+  if (!organizationId) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('automation_playbooks')
+    .select('id, name, description, trigger_event, status, configuration, created_at, updated_at, steps:automation_steps(*)')
+    .eq('organization_id', organizationId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('automation:list-playbooks', error)
+    return []
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    name: row.name as string,
+    description: (row.description as string) ?? null,
+    triggerEvent: row.trigger_event as string,
+    status: (row.status as AutomationPlaybook['status']) ?? 'draft',
+    configuration: (row.configuration as Record<string, unknown>) ?? {},
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string | null,
+    steps: Array.isArray(row.steps)
+      ? (row.steps as any[]).map((step) => ({
+          id: step.id as string,
+          sortOrder: Number(step.sort_order ?? 0),
+          workspace: (step.workspace as 'sales' | 'delivery' | 'finance' | 'ops') ?? 'ops',
+          action: step.action as string,
+          config: (step.config as Record<string, unknown>) ?? {},
+        }))
+      : [],
+  }))
+}
+
+export async function upsertAutomationPlaybook(input: PlaybookInput) {
+  const { supabase, organizationId, user } = await requireAuth({ redirectTo: '/login?next=/ops/playbooks' })
+
+  if (!organizationId) {
+    throw new Error('Organization context required')
+  }
+
+  const base = {
+    name: input.name,
+    description: input.description ?? null,
+    trigger_event: input.triggerEvent,
+    status: input.status ?? 'draft',
+    configuration: input.configuration ?? {},
+    organization_id: organizationId,
+    created_by: user.id,
+  }
+
+  if (input.id) {
+    const { error } = await supabase
+      .from('automation_playbooks')
+      .update({ ...base, updated_at: new Date().toISOString() })
+      .eq('id', input.id)
+
+    if (error) {
+      throw error
+    }
+
+    await supabase.from('automation_steps').delete().eq('playbook_id', input.id)
+    const records = input.steps.map((step) => ({
+      ...(step.id ? { id: step.id } : {}),
+      playbook_id: input.id,
+      sort_order: step.sortOrder,
+      workspace: step.workspace,
+      action: step.action,
+      config: step.config ?? {},
+    }))
+
+    if (records.length) {
+      await supabase.from('automation_steps').insert(records)
+    }
+  } else {
+    const { data, error } = await supabase
+      .from('automation_playbooks')
+      .insert(base)
+      .select('id')
+      .single()
+
+    if (error || !data) {
+      throw error ?? new Error('Failed to create playbook')
+    }
+
+    if (input.steps.length) {
+      const records = input.steps.map((step) => ({
+        ...(step.id ? { id: step.id } : {}),
+        playbook_id: data.id,
+        sort_order: step.sortOrder,
+        workspace: step.workspace,
+        action: step.action,
+        config: step.config ?? {},
+      }))
+
+      await supabase.from('automation_steps').insert(records)
+    }
+
+    input.id = data.id as string
+  }
+
+  await logAnalyticsEvent({
+    eventKey: 'automation.playbook.upserted',
+    payload: { playbookId: input.id ?? 'new', triggerEvent: input.triggerEvent, status: input.status ?? 'draft' },
+  })
+
+  revalidatePath('/ops/playbooks')
+}
+
+export async function updateAutomationPlaybookStatus(id: string, status: 'draft' | 'active' | 'archived') {
+  const { supabase, organizationId } = await requireAuth({ redirectTo: '/login?next=/ops/playbooks' })
+
+  if (!organizationId) {
+    throw new Error('Organization context required')
+  }
+
+  const { error } = await supabase
+    .from('automation_playbooks')
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('organization_id', organizationId)
+
+  if (error) {
+    throw error
+  }
+
+  await logAnalyticsEvent({ eventKey: 'automation.playbook.status_changed', payload: { playbookId: id, status } })
+  revalidatePath('/ops/playbooks')
+}
+
+export async function runAutomationPlaybook(playbookId: string, context: Record<string, unknown>) {
+  const { supabase, user, organizationId } = await requireAuth({ redirectTo: '/login?next=/ops/playbooks' })
+
+  if (!organizationId) {
+    throw new Error('Organization context required')
+  }
+
+  const playbook = await loadAutomationPlaybook(supabase, organizationId, playbookId)
+
+  if (!playbook) {
+    throw new Error('playbook-not-found')
+  }
+
+  const result = await executeAutomationPlaybook({
+    supabase,
+    playbook,
+    organizationId,
+    userId: user.id,
+    context,
+  })
+
+  await logAnalyticsEvent({
+    eventKey: 'automation.run.completed',
+    payload: { playbookId, runId: result.runId, status: result.status },
+  })
+
+  revalidatePath('/ops/playbooks')
+  return result
+}
+
+export async function triggerClosedWonAutomation(
+  params: { opportunityId: string; clientId?: string; amount?: number; name?: string },
+) {
+  const { supabase, user, organizationId } = await requireAuth({ redirectTo: '/login?next=/pipeline' })
+
+  if (!organizationId) {
+    return { ok: false, error: 'missing-organization' } as const
+  }
+
+  const playbooks = await loadAutomationPlaybooksForEvent(supabase, organizationId, 'pipeline.closed_won')
+  const executions = []
+
+  for (const playbook of playbooks) {
+    const result = await executeAutomationPlaybook({
+      supabase,
+      playbook,
+      organizationId,
+      userId: user.id,
+      context: {
+        opportunityId: params.opportunityId,
+        clientId: params.clientId,
+        amount: params.amount,
+        opportunityName: params.name,
+      },
+    })
+
+    executions.push({ playbookId: playbook.id, runId: result.runId, status: result.status })
+  }
+
+  if (executions.length) {
+    await logAnalyticsEvent({
+      eventKey: 'automation.closed_won.triggered',
+      payload: { opportunityId: params.opportunityId, runs: executions },
+    })
+  }
+
+  return { ok: true, runs: executions } as const
+}

--- a/core/automations/engine.ts
+++ b/core/automations/engine.ts
@@ -1,0 +1,296 @@
+'use server'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { AutomationPlaybook, AutomationRunResult, AutomationStep } from './types'
+
+function normalizeSteps(steps: any[] | null | undefined): AutomationStep[] {
+  return (steps ?? [])
+    .map((step) => ({
+      id: step.id as string,
+      sortOrder: Number(step.sort_order ?? step.sortOrder ?? 0),
+      workspace: (step.workspace as AutomationStep['workspace']) ?? 'ops',
+      action: step.action as string,
+      config: (step.config as Record<string, any>) ?? {},
+    }))
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+}
+
+export async function loadAutomationPlaybooksForEvent(
+  supabase: SupabaseClient,
+  organizationId: string,
+  triggerEvent: string,
+): Promise<AutomationPlaybook[]> {
+  const { data, error } = await supabase
+    .from('automation_playbooks')
+    .select('id, name, description, trigger_event, status, configuration, created_at, updated_at, steps:automation_steps(*)')
+    .eq('organization_id', organizationId)
+    .eq('trigger_event', triggerEvent)
+    .neq('status', 'archived')
+
+  if (error) {
+    console.error('automation:load-for-event', error)
+    return []
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    name: row.name as string,
+    description: (row.description as string) ?? null,
+    triggerEvent: row.trigger_event as string,
+    status: (row.status as AutomationPlaybook['status']) ?? 'draft',
+    configuration: (row.configuration as Record<string, unknown>) ?? {},
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string | null,
+    steps: normalizeSteps(row.steps as any[]),
+  }))
+}
+
+export async function loadAutomationPlaybook(
+  supabase: SupabaseClient,
+  organizationId: string,
+  playbookId: string,
+): Promise<AutomationPlaybook | null> {
+  const { data, error } = await supabase
+    .from('automation_playbooks')
+    .select('id, name, description, trigger_event, status, configuration, created_at, updated_at, steps:automation_steps(*)')
+    .eq('organization_id', organizationId)
+    .eq('id', playbookId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('automation:load-playbook', error)
+    return null
+  }
+
+  if (!data) return null
+
+  return {
+    id: data.id as string,
+    name: data.name as string,
+    description: (data.description as string) ?? null,
+    triggerEvent: data.trigger_event as string,
+    status: (data.status as AutomationPlaybook['status']) ?? 'draft',
+    configuration: (data.configuration as Record<string, unknown>) ?? {},
+    createdAt: data.created_at as string,
+    updatedAt: data.updated_at as string | null,
+    steps: normalizeSteps(data.steps as any[]),
+  }
+}
+
+type ExecuteParams = {
+  supabase: SupabaseClient
+  playbook: AutomationPlaybook
+  organizationId: string
+  userId: string
+  context: Record<string, unknown>
+}
+
+type StepExecutionResult = {
+  status: 'completed' | 'skipped' | 'failed'
+  output?: Record<string, unknown>
+}
+
+export async function executeAutomationPlaybook({
+  supabase,
+  playbook,
+  organizationId,
+  userId,
+  context,
+}: ExecuteParams): Promise<AutomationRunResult> {
+  const { data: run, error: runError } = await supabase
+    .from('automation_runs')
+    .insert({
+      playbook_id: playbook.id,
+      organization_id: organizationId,
+      triggered_by: userId,
+      context,
+      status: 'processing',
+    })
+    .select('id')
+    .single()
+
+  if (runError || !run) {
+    console.error('automation:create-run-failed', runError)
+    throw runError ?? new Error('create-run-failed')
+  }
+
+  const stepResults: AutomationRunResult['stepResults'] = []
+
+  for (const step of playbook.steps) {
+    try {
+      const result = await performStep(supabase, organizationId, userId, step, context)
+
+      await supabase
+        .from('automation_run_steps')
+        .insert({
+          run_id: run.id,
+          step_id: step.id,
+          workspace: step.workspace,
+          action: step.action,
+          status: result.status,
+          output: result.output ?? {},
+          completed_at: new Date().toISOString(),
+        })
+
+      stepResults.push({ stepId: step.id, status: result.status, output: result.output })
+
+      if (result.status === 'failed') {
+        await supabase
+          .from('automation_runs')
+          .update({ status: 'failed', completed_at: new Date().toISOString() })
+          .eq('id', run.id)
+        return { runId: run.id, status: 'failed', stepResults }
+      }
+    } catch (error) {
+      console.error('automation:step-error', step.action, error)
+      await supabase
+        .from('automation_run_steps')
+        .insert({
+          run_id: run.id,
+          step_id: step.id,
+          workspace: step.workspace,
+          action: step.action,
+          status: 'failed',
+          output: { error: error instanceof Error ? error.message : String(error) },
+          completed_at: new Date().toISOString(),
+        })
+
+      stepResults.push({
+        stepId: step.id,
+        status: 'failed',
+        output: { error: error instanceof Error ? error.message : String(error) },
+      })
+
+      await supabase
+        .from('automation_runs')
+        .update({ status: 'failed', completed_at: new Date().toISOString() })
+        .eq('id', run.id)
+
+      return { runId: run.id, status: 'failed', stepResults }
+    }
+  }
+
+  await supabase
+    .from('automation_runs')
+    .update({ status: 'completed', completed_at: new Date().toISOString() })
+    .eq('id', run.id)
+
+  return { runId: run.id, status: 'completed', stepResults }
+}
+
+async function performStep(
+  supabase: SupabaseClient,
+  organizationId: string,
+  userId: string,
+  step: AutomationStep,
+  context: Record<string, unknown>,
+): Promise<StepExecutionResult> {
+  switch (step.action) {
+    case 'log_closed_won_context': {
+      const payload = {
+        organization_id: organizationId,
+        user_id: userId,
+        event_key: 'automation.closed_won.context',
+        payload: { context },
+      }
+
+      const { error } = await supabase.functions.invoke('analytics-events', { body: payload })
+      if (error) {
+        throw error
+      }
+
+      return { status: 'completed', output: { analyticsEvent: 'automation.closed_won.context' } }
+    }
+    case 'create_project_kickoff': {
+      const clientId = (context.clientId as string | undefined) ?? null
+      const name = (context.projectName as string | undefined) ??
+        (context.name as string | undefined) ??
+        `Implementation for ${(context.opportunityName as string | undefined) ?? 'new win'}`
+      const phase = (step.config.phase as string | undefined) ?? 'Discovery'
+      const ownerId = (context.ownerId as string | undefined) ?? userId
+
+      const today = new Date().toISOString().slice(0, 10)
+
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .insert({
+          client_id: clientId,
+          name,
+          status: 'Active',
+          phase,
+          health: 'Green',
+          start_date: today,
+          owner_id: ownerId,
+          progress: 0,
+        })
+        .select('id')
+        .single()
+
+      if (projectError || !project) {
+        throw projectError ?? new Error('project-create-failed')
+      }
+
+      const kickoffAgenda = {
+        source: 'automation',
+        trigger: step.action,
+        checklist: [
+          'Confirm project owner + roles',
+          'Align on timeline + billing milestones',
+        ],
+        ...(step.config.agendaOverrides as Record<string, unknown> | undefined),
+      }
+
+      const { error: kickoffError } = await supabase.from('project_kickoffs').insert({
+        project_id: project.id,
+        client_id: clientId,
+        owner_id: ownerId,
+        kickoff_date: today,
+        agenda: kickoffAgenda,
+      })
+
+      if (kickoffError) {
+        throw kickoffError
+      }
+
+      return { status: 'completed', output: { projectId: project.id } }
+    }
+    case 'schedule_invoice_plan': {
+      const clientId = (context.clientId as string | undefined) ?? null
+      const projectId = (context.projectId as string | undefined) ?? null
+      const amount = Number(context.amount ?? 0)
+      const installments = Math.max(1, Number(step.config.installments ?? 3))
+      const cadence = (step.config.cadence as string | undefined) ?? 'monthly'
+
+      if (!clientId) {
+        return { status: 'skipped', output: { reason: 'missing-client-id' } }
+      }
+
+      const entries = Array.from({ length: installments }).map((_, index) => {
+        const dueDate = new Date()
+        if (cadence === 'monthly') {
+          dueDate.setMonth(dueDate.getMonth() + index)
+        } else if (cadence === 'weekly') {
+          dueDate.setDate(dueDate.getDate() + index * 7)
+        }
+
+        return {
+          client_id: clientId,
+          project_id: projectId,
+          amount: installments > 0 ? Math.round((amount / installments) * 100) / 100 : amount,
+          due_date: dueDate.toISOString().slice(0, 10),
+          status: 'scheduled',
+        }
+      })
+
+      const { error: invoiceError } = await supabase.from('invoice_schedules').insert(entries)
+      if (invoiceError) {
+        throw invoiceError
+      }
+
+      return { status: 'completed', output: { invoicesScheduled: entries.length } }
+    }
+    default:
+      return { status: 'skipped', output: { action: step.action } }
+  }
+}

--- a/core/automations/types.ts
+++ b/core/automations/types.ts
@@ -1,0 +1,31 @@
+export type AutomationStepConfig = Record<string, any>
+
+export type AutomationStep = {
+  id: string
+  sortOrder: number
+  workspace: 'sales' | 'delivery' | 'finance' | 'ops'
+  action: string
+  config: AutomationStepConfig
+}
+
+export type AutomationPlaybook = {
+  id: string
+  name: string
+  description: string | null
+  triggerEvent: string
+  status: 'draft' | 'active' | 'archived'
+  configuration: Record<string, unknown>
+  createdAt: string
+  updatedAt: string | null
+  steps: AutomationStep[]
+}
+
+export type AutomationRunResult = {
+  runId: string
+  status: 'completed' | 'failed'
+  stepResults: {
+    stepId: string
+    status: 'completed' | 'skipped' | 'failed'
+    output?: Record<string, unknown>
+  }[]
+}

--- a/core/memory/trsos.ts
+++ b/core/memory/trsos.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type MemoryResult = {
+  id: string
+  agentKey: string
+  title: string | null
+  content: string
+  metadata: Record<string, unknown> | null
+  salienceScore: number
+  createdAt: string
+}
+
+export async function searchAgentMemories(
+  supabase: SupabaseClient,
+  params: {
+    query: string
+    organizationId: string
+    agentKey?: string
+    limit?: number
+  },
+): Promise<MemoryResult[]> {
+  if (!params.organizationId) return []
+
+  const { data, error } = await supabase.rpc('match_agent_memories', {
+    p_query: params.query,
+    p_agent_key: params.agentKey ?? null,
+    p_organization: params.organizationId,
+    p_limit: params.limit ?? 5,
+  })
+
+  if (error) {
+    console.error('trsos:memory-search-failed', error)
+    return []
+  }
+
+  return (data ?? []).map((row: any) => ({
+    id: row.id as string,
+    agentKey: (row.agent_key as string) ?? params.agentKey ?? 'unknown',
+    title: (row.title as string) ?? null,
+    content: (row.content as string) ?? '',
+    metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+    salienceScore: typeof row.salience_score === 'number' ? row.salience_score : Number(row.salience_score ?? 0),
+    createdAt: row.created_at as string,
+  }))
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -26,6 +26,12 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
   },
   {
+    label: 'Telemetry',
+    href: '/dashboard/telemetry',
+    icon: 'Activity',
+    roles: ['SuperAdmin', 'Admin', 'Director'],
+  },
+  {
     label: 'Pipeline',
     href: '/pipeline',
     icon: 'TrendingUp',
@@ -60,6 +66,12 @@ export const MAIN_NAV: NavItem[] = [
     href: '/agents',
     icon: 'Bot',
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member'],
+  },
+  {
+    label: 'Playbooks',
+    href: '/ops/playbooks',
+    icon: 'ListChecks',
+    roles: ['SuperAdmin', 'Admin', 'Director'],
   },
   {
     label: 'Finance',

--- a/supabase/functions/analytics-events/index.ts
+++ b/supabase/functions/analytics-events/index.ts
@@ -5,6 +5,8 @@ type AnalyticsPayload = {
   user_id: string | null;
   event_key: string;
   payload?: Record<string, unknown>;
+  entity?: string;
+  entity_id?: string;
 };
 
 const JSON_HEADERS = {
@@ -75,12 +77,21 @@ Deno.serve(async (req) => {
   const supabase = createSupabaseClient();
   const timestamp = new Date().toISOString();
 
+  const segments = payload.event_key.split(".");
+  const category = segments[0] ?? null;
+  const workflow = segments.length > 1 ? segments.slice(0, 2).join(".") : null;
+
   const { data, error } = await supabase
     .from("analytics_events")
     .insert({
       organization_id: payload.organization_id,
       user_id: payload.user_id,
       event_key: payload.event_key,
+      event_type: payload.event_key,
+      category,
+      workflow,
+      entity: payload.entity ?? null,
+      entity_id: payload.entity_id ?? null,
       payload: {
         ...payload.payload,
         received_at: timestamp,


### PR DESCRIPTION
## Summary
- persist agent governance, memory retrieval, and analytics logging through Supabase-backed Rosie API and agent actions
- add operational automation engine, closed-won playbook workflows, and ops playbook builder UI
- deliver telemetry snapshot aggregation with executive dashboard routes and expand Supabase schema, seeds, and analytics edge function

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ef034b595483248b015be0c0e8d683