### PR TITLE
feat: add revenue clear workflow module

### DIFF
--- a/app/clients/[id]/revenue-clear/page.tsx
+++ b/app/clients/[id]/revenue-clear/page.tsx
@@ -1,0 +1,8 @@
+import RevenueClearShell from '@/modules/revenue-clear/components/RevenueClearShell'
+import { getRevenueClearSnapshot } from '@/modules/revenue-clear/lib/queries'
+
+export default async function RevenueClearPage({ params }: { params: { id: string } }) {
+  const snapshot = await getRevenueClearSnapshot(params.id)
+
+  return <RevenueClearShell snapshot={snapshot} />
+}

--- a/modules/revenue-clear/components/ProgressStepper.tsx
+++ b/modules/revenue-clear/components/ProgressStepper.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+import { RevenueClearStageKey, StageStatus } from '../lib/types'
+
+const STATUS_COLORS: Record<StageStatus, string> = {
+  idle: 'bg-[color:var(--color-surface-muted)] text-[color:var(--color-text-muted)] border-[color:var(--color-outline)]',
+  saving: 'bg-amber-500/20 text-amber-200 border-amber-400/60',
+  saved: 'bg-emerald-500/20 text-emerald-200 border-emerald-400/60',
+  running: 'bg-sky-500/20 text-sky-200 border-sky-400/60',
+  error: 'bg-rose-500/20 text-rose-200 border-rose-400/60',
+}
+
+type StepperItem = {
+  key: RevenueClearStageKey
+  label: string
+  description: string
+  status: StageStatus
+}
+
+type ProgressStepperProps = {
+  items: StepperItem[]
+  active: RevenueClearStageKey
+  onSelect?: (key: RevenueClearStageKey) => void
+}
+
+export function ProgressStepper({ items, active, onSelect }: ProgressStepperProps) {
+  return (
+    <nav className="sticky top-0 z-10 -mx-6 mb-6 flex flex-col gap-3 border-b border-[color:var(--color-outline)] bg-[color:var(--color-surface)]/90 px-6 py-4 backdrop-blur">
+      <h2 className="text-sm font-medium uppercase tracking-[0.2em] text-[color:var(--color-text-muted)]">
+        Revenue Clear Workflow
+      </h2>
+      <div className="grid gap-3 md:grid-cols-7">
+        {items.map((item) => {
+          const isActive = item.key === active
+          return (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => onSelect?.(item.key)}
+              className={cn(
+                'flex flex-col items-start gap-1 rounded-xl border px-3 py-2 text-left transition',
+                STATUS_COLORS[item.status],
+                isActive ? 'ring-2 ring-[color:var(--color-accent)] ring-offset-2 ring-offset-[color:var(--color-surface)]' : '',
+              )}
+            >
+              <span className="text-xs font-semibold uppercase tracking-wide">{item.label}</span>
+              <span className="line-clamp-2 text-[11px] text-white/80">{item.description}</span>
+            </button>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/modules/revenue-clear/components/RevenueClearShell.tsx
+++ b/modules/revenue-clear/components/RevenueClearShell.tsx
@@ -1,0 +1,745 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs'
+
+import { useAutosave } from '../hooks/useAutosave'
+import {
+  AuditLeak,
+  BlueprintIntervention,
+  ExecutionTask,
+  ExecutionWeeklySummary,
+  NextStepPlan,
+  RevenueClearIntake,
+  RevenueClearResult,
+  RevenueClearSnapshot,
+  RevboardMetric,
+  StageStatus,
+  RevenueClearStageKey,
+} from '../lib/types'
+import {
+  runAdvisorSummary,
+  runBlueprintGeneration,
+  runIntakeSummary,
+  runLeakScan,
+  runProposal,
+  runResultsReport,
+} from '../lib/automations'
+import { ProgressStepper } from './ProgressStepper'
+import IntakeTab from './tabs/IntakeTab'
+import AuditTab from './tabs/AuditTab'
+import BlueprintTab from './tabs/BlueprintTab'
+import RevboardTab from './tabs/RevboardTab'
+import ExecutionTab from './tabs/ExecutionTab'
+import ResultsTab from './tabs/ResultsTab'
+import NextStepsTab from './tabs/NextStepsTab'
+import { createClient } from '@/lib/supabase/client'
+
+const TAB_CONFIG: { key: RevenueClearStageKey; label: string; description: string }[] = [
+  { key: 'intake', label: 'Intake', description: 'Baseline data, goals, and financial posture.' },
+  { key: 'audit', label: 'Audit', description: 'Leak severity across pricing, demand, retention, forecasting.' },
+  { key: 'blueprint', label: 'Blueprint', description: 'Prioritized interventions and projected ROI.' },
+  { key: 'revboard', label: 'RevBoard', description: 'KPI tracking and TRS score telemetry.' },
+  { key: 'execution', label: 'Execution', description: 'Tasks, owners, and weekly advisor recaps.' },
+  { key: 'results', label: 'Results', description: 'Before/after impact and ROI payback.' },
+  { key: 'nextSteps', label: 'Next Steps', description: 'Proposal packaging and client-ready plan.' },
+]
+
+const DEFAULT_INTAKE: RevenueClearIntake = {
+  companyProfile: {
+    name: '',
+    industry: '',
+    revenueModel: '',
+  },
+  financials: {
+    monthlyRevenue: 0,
+    profitMargin: 0,
+    targetGrowth: 0,
+  },
+  goals: {
+    primaryGoal: '',
+    secondaryGoal: '',
+    notes: '',
+  },
+}
+
+const DEFAULT_RESULT: RevenueClearResult = {
+  beforeMRR: 0,
+  afterMRR: 0,
+  beforeProfit: 0,
+  afterProfit: 0,
+  totalGain: 0,
+  paybackPeriod: 0,
+}
+
+const DEFAULT_NEXT_STEPS: NextStepPlan = {
+  nextOffer: 'Advisory',
+  rationale: '',
+  projectedOutcome: 0,
+  proposalDoc: '',
+}
+
+function computeTrsScore(audits: AuditLeak[]): number {
+  const weights: Record<AuditLeak['pillar'], number> = {
+    pricing: 0.3,
+    demand: 0.25,
+    retention: 0.25,
+    forecasting: 0.2,
+  }
+
+  const weightedLoss = audits.reduce((acc, audit) => {
+    const severity = Math.max(0, Math.min(10, Number(audit.leakSeverity ?? 0)))
+    const normalized = severity / 10
+    return acc + normalized * (weights[audit.pillar] ?? 0) * 100
+  }, 0)
+
+  return Math.max(0, Math.round(100 - weightedLoss))
+}
+
+type RevenueClearShellProps = {
+  snapshot: RevenueClearSnapshot
+}
+
+export default function RevenueClearShell({ snapshot }: RevenueClearShellProps) {
+  const supabase = useMemo(() => createClient(), [])
+  const [activeTab, setActiveTab] = useState<RevenueClearStageKey>('intake')
+
+  const [intake, setIntake] = useState<RevenueClearIntake>(snapshot.intake ?? DEFAULT_INTAKE)
+  const [audits, setAudits] = useState<AuditLeak[]>(
+    snapshot.audits.length
+      ? snapshot.audits
+      : ([
+          'pricing',
+          'demand',
+          'retention',
+          'forecasting',
+        ] as AuditLeak['pillar'][]).map((pillar) => ({
+          pillar,
+          leakSeverity: 0,
+          leakDescription: '',
+          estimatedLoss: 0,
+          score: 0,
+        })),
+  )
+  const [interventions, setInterventions] = useState<BlueprintIntervention[]>(snapshot.interventions.slice(0, 3))
+  const [metrics, setMetrics] = useState<RevboardMetric[]>(snapshot.metrics)
+  const [tasks, setTasks] = useState<ExecutionTask[]>(snapshot.tasks)
+  const [weeklySummary, setWeeklySummary] = useState<ExecutionWeeklySummary | null>(snapshot.weeklySummary)
+  const [results, setResults] = useState<RevenueClearResult>(snapshot.results ?? DEFAULT_RESULT)
+  const [nextStep, setNextStep] = useState<NextStepPlan>(snapshot.nextStep ?? DEFAULT_NEXT_STEPS)
+
+  const {
+    scheduleSave: scheduleIntakeSave,
+    saveImmediately: saveIntakeNow,
+    status: intakeStatus,
+    setStatus: setIntakeStatus,
+  } = useAutosave<RevenueClearIntake>(
+    async (value) => {
+      const { data, error } = await supabase
+        .from('intakes')
+        .upsert(
+          {
+            id: value.id,
+            client_id: snapshot.client.id,
+            company_profile: value.companyProfile,
+            financials: value.financials,
+            goals: value.goals,
+            clarity_summary_url: value.claritySummaryUrl ?? null,
+          },
+          { onConflict: 'client_id' },
+        )
+        .select()
+        .maybeSingle()
+
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setIntake((current) => ({
+          ...current,
+          id: data.id,
+          claritySummaryUrl: data.clarity_summary_url ?? current.claritySummaryUrl ?? null,
+        }))
+      }
+    },
+  )
+
+  const {
+    scheduleSave: scheduleAuditSave,
+    saveImmediately: saveAuditNow,
+    status: auditStatus,
+    setStatus: setAuditStatus,
+  } = useAutosave<AuditLeak[]>(
+    async (value) => {
+      const payload = value.map((audit) => ({
+        id: audit.id,
+        client_id: snapshot.client.id,
+        pillar: audit.pillar,
+        leak_severity: audit.leakSeverity,
+        leak_description: audit.leakDescription,
+        estimated_loss: audit.estimatedLoss,
+        score: audit.score,
+        leak_map_url: audit.leakMapUrl ?? null,
+      }))
+
+      const { data, error } = await supabase.from('audits').upsert(payload, { onConflict: 'client_id,pillar' }).select()
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setAudits((current) =>
+          current.map((audit) => {
+            const updated = data.find((row) => row.pillar === audit.pillar)
+            if (!updated) return audit
+            return {
+              ...audit,
+              id: updated.id,
+              leakMapUrl: updated.leak_map_url ?? audit.leakMapUrl ?? null,
+            }
+          }),
+        )
+      }
+    },
+  )
+
+  const {
+    scheduleSave: scheduleBlueprintSave,
+    saveImmediately: saveBlueprintNow,
+    status: blueprintStatus,
+    setStatus: setBlueprintStatus,
+  } = useAutosave<BlueprintIntervention[]>(async (value) => {
+      const payload = value.map((item) => ({
+        id: item.id,
+        client_id: snapshot.client.id,
+        intervention_name: item.interventionName,
+        diagnosis: item.diagnosis,
+        fix: item.fix,
+        projected_lift: item.projectedLift,
+        effort_score: item.effortScore,
+        roi_index: item.roiIndex,
+        blueprint_url: item.blueprintUrl ?? null,
+      }))
+
+      const { data, error } = await supabase
+        .from('interventions')
+        .upsert(payload, { onConflict: 'id' })
+        .select()
+
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setInterventions((current) =>
+          current.map((intervention) => {
+            const updated = data.find((row) => row.intervention_name === intervention.interventionName)
+            if (!updated) return intervention
+            return {
+              ...intervention,
+              id: updated.id,
+              blueprintUrl: updated.blueprint_url ?? intervention.blueprintUrl ?? null,
+            }
+          }),
+        )
+      }
+    })
+
+  const {
+    scheduleSave: scheduleMetricSave,
+    saveImmediately: saveMetricNow,
+    status: metricStatus,
+    setStatus: setMetricStatus,
+  } = useAutosave<RevboardMetric[]>(
+    async (value) => {
+      const payload = value.map((metric) => ({
+        id: metric.id,
+        client_id: snapshot.client.id,
+        kpi_name: metric.kpiName,
+        baseline_value: metric.baselineValue,
+        current_value: metric.currentValue,
+        delta: metric.delta,
+        intervention_id: metric.interventionId ?? null,
+        date: metric.date,
+      }))
+      const { data, error } = await supabase
+        .from('revboard_metrics')
+        .upsert(payload, { onConflict: 'id' })
+        .select()
+
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setMetrics((current) =>
+          current.map((metric) => {
+            const updated = data.find((row) => row.id === metric.id)
+            return updated
+              ? {
+                  ...metric,
+                  id: updated.id,
+                  delta: updated.delta ?? metric.delta,
+                }
+              : metric
+          }),
+        )
+      }
+    },
+  )
+
+  const {
+    scheduleSave: scheduleTaskSave,
+    saveImmediately: saveTaskNow,
+    status: executionStatus,
+    setStatus: setExecutionStatus,
+  } = useAutosave<{
+    tasks: ExecutionTask[]
+    weekly: ExecutionWeeklySummary | null
+  }>(async (value) => {
+    const taskPayload = value.tasks.map((task) => ({
+      id: task.id,
+      client_id: snapshot.client.id,
+      task_name: task.taskName,
+      status: task.status,
+      assigned_to: task.assignedTo,
+      start_date: task.startDate,
+      end_date: task.endDate,
+      progress_notes: task.progressNotes,
+    }))
+
+    const { data: taskData, error: taskError } = await supabase.from('tasks').upsert(taskPayload, { onConflict: 'id' }).select()
+
+    if (taskError) {
+      throw taskError
+    }
+
+    if (taskData) {
+      setTasks((current) =>
+        current.map((task) => {
+          const updated = taskData.find((row) => row.task_name === task.taskName && row.assigned_to === task.assignedTo)
+          if (!updated) return task
+          return {
+            ...task,
+            id: updated.id,
+          }
+        }),
+      )
+    }
+
+    if (value.weekly) {
+      const { data: weeklyData, error: weeklyError } = await supabase
+        .from('execution_weekly_reports')
+        .upsert(
+          {
+            client_id: snapshot.client.id,
+            notes: value.weekly.notes,
+            advisor_summary: value.weekly.advisorSummary ?? null,
+          },
+          { onConflict: 'client_id' },
+        )
+        .select()
+        .maybeSingle()
+
+      if (weeklyError) {
+        throw weeklyError
+      }
+
+      if (weeklyData) {
+        setWeeklySummary({
+          notes: weeklyData.notes ?? value.weekly.notes,
+          advisorSummary: weeklyData.advisor_summary ?? value.weekly.advisorSummary ?? null,
+        })
+      }
+    }
+  })
+
+  const {
+    scheduleSave: scheduleResultsSave,
+    saveImmediately: saveResultsNow,
+    status: resultsStatus,
+    setStatus: setResultsStatus,
+  } = useAutosave<RevenueClearResult>(
+    async (value) => {
+      const { data, error } = await supabase
+        .from('results')
+        .upsert(
+          {
+            id: value.id,
+            client_id: snapshot.client.id,
+            before_mrr: value.beforeMRR,
+            after_mrr: value.afterMRR,
+            before_profit: value.beforeProfit,
+            after_profit: value.afterProfit,
+            total_gain: value.totalGain,
+            payback_period: value.paybackPeriod,
+            report_url: value.reportUrl ?? null,
+          },
+          { onConflict: 'client_id' },
+        )
+        .select()
+        .maybeSingle()
+
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setResults({
+          ...value,
+          id: data.id,
+          reportUrl: data.report_url ?? value.reportUrl ?? null,
+        })
+      }
+    },
+  )
+
+  const {
+    scheduleSave: scheduleNextStepsSave,
+    saveImmediately: saveNextStepsNow,
+    status: nextStepsStatus,
+    setStatus: setNextStepsStatus,
+  } = useAutosave<NextStepPlan>(
+    async (value) => {
+      const { data, error } = await supabase
+        .from('next_steps')
+        .upsert(
+          {
+            id: value.id,
+            client_id: snapshot.client.id,
+            next_offer: value.nextOffer,
+            rationale: value.rationale,
+            projected_outcome: value.projectedOutcome,
+            proposal_doc: value.proposalDoc,
+            proposal_url: value.proposalUrl ?? null,
+          },
+          { onConflict: 'client_id' },
+        )
+        .select()
+        .maybeSingle()
+
+      if (error) {
+        throw error
+      }
+
+      if (data) {
+        setNextStep({
+          ...value,
+          id: data.id,
+          proposalUrl: data.proposal_url ?? value.proposalUrl ?? null,
+        })
+      }
+    },
+  )
+
+  const handleIntakeChange = useCallback(
+    (value: RevenueClearIntake) => {
+      setIntake(value)
+      scheduleIntakeSave(value)
+    },
+    [scheduleIntakeSave],
+  )
+
+  const handleAuditChange = useCallback(
+    (value: AuditLeak[]) => {
+      setAudits(value)
+      scheduleAuditSave(value)
+    },
+    [scheduleAuditSave],
+  )
+
+  const handleBlueprintChange = useCallback(
+    (value: BlueprintIntervention[]) => {
+      setInterventions(value)
+      scheduleBlueprintSave(value)
+    },
+    [scheduleBlueprintSave],
+  )
+
+  const handleMetricChange = useCallback(
+    (value: RevboardMetric[]) => {
+      setMetrics(value)
+      scheduleMetricSave(value)
+    },
+    [scheduleMetricSave],
+  )
+
+  const handleTaskChange = useCallback(
+    (value: ExecutionTask[]) => {
+      const next = { tasks: value, weekly: weeklySummary }
+      setTasks(value)
+      scheduleTaskSave(next)
+    },
+    [scheduleTaskSave, weeklySummary],
+  )
+
+  const handleWeeklySummaryChange = useCallback(
+    (value: ExecutionWeeklySummary) => {
+      const nextPayload = { tasks, weekly: value }
+      setWeeklySummary(value)
+      scheduleTaskSave(nextPayload)
+    },
+    [scheduleTaskSave, tasks],
+  )
+
+  const handleResultsChange = useCallback(
+    (value: RevenueClearResult) => {
+      setResults(value)
+      scheduleResultsSave(value)
+    },
+    [scheduleResultsSave],
+  )
+
+  const handleNextStepsChange = useCallback(
+    (value: NextStepPlan) => {
+      setNextStep(value)
+      scheduleNextStepsSave(value)
+    },
+    [scheduleNextStepsSave],
+  )
+
+  const handleRunIntakeSummary = useCallback(async () => {
+    setIntakeStatus('running')
+    const response = await runIntakeSummary({
+      clientId: snapshot.client.id,
+      intake,
+    })
+
+    if (response.fileUrl) {
+      const updated: RevenueClearIntake = {
+        ...intake,
+        claritySummaryUrl: response.fileUrl,
+      }
+      setIntake(updated)
+      await saveIntakeNow(updated)
+    }
+    setIntakeStatus(response.data ? 'saved' : 'error')
+  }, [intake, saveIntakeNow, setIntakeStatus, snapshot.client.id])
+
+  const handleRunLeakScan = useCallback(async () => {
+    setAuditStatus('running')
+    const response = await runLeakScan({
+      clientId: snapshot.client.id,
+      audits,
+    })
+
+    let nextAudits = audits
+    if (response.fileUrl) {
+      nextAudits = audits.map((audit) => ({
+        ...audit,
+        leakMapUrl: response.fileUrl ?? audit.leakMapUrl ?? null,
+      }))
+      setAudits(nextAudits)
+    }
+    await saveAuditNow(nextAudits)
+    setAuditStatus(response.data ? 'saved' : 'error')
+  }, [audits, saveAuditNow, setAuditStatus, snapshot.client.id])
+
+  const handleGenerateBlueprint = useCallback(async () => {
+    setBlueprintStatus('running')
+    const response = await runBlueprintGeneration({
+      clientId: snapshot.client.id,
+      audits,
+      intake,
+    })
+
+    let nextBlueprints = interventions
+    if (response.data && Array.isArray((response.data as any).interventions)) {
+      nextBlueprints = ((response.data as any).interventions as any[]).slice(0, 3).map((item, index) => ({
+        interventionName: item.intervention_name ?? item.interventionName ?? `Intervention ${index + 1}`,
+        diagnosis: item.diagnosis ?? '',
+        fix: item.fix ?? '',
+        projectedLift: Number(item.projected_lift ?? 0),
+        effortScore: Number(item.effort_score ?? 0),
+        roiIndex: Number(item.roi_index ?? 0),
+      }))
+    }
+
+    if (response.fileUrl) {
+      nextBlueprints = nextBlueprints.map((item) => ({
+        ...item,
+        blueprintUrl: response.fileUrl ?? item.blueprintUrl ?? null,
+      }))
+    }
+
+    setInterventions(nextBlueprints)
+    await saveBlueprintNow(nextBlueprints)
+    setBlueprintStatus(response.data ? 'saved' : 'error')
+  }, [audits, intake, interventions, saveBlueprintNow, setBlueprintStatus, snapshot.client.id])
+
+  const handleCompleteReview = useCallback(async () => {
+    setExecutionStatus('running')
+    const response = await runAdvisorSummary({
+      clientId: snapshot.client.id,
+      weeklySummary,
+      tasks,
+    })
+
+    if (response.data && (response.data as any).advisorSummary) {
+      const advisorSummary = (response.data as any).advisorSummary as string
+      const nextSummary = {
+        notes: weeklySummary?.notes ?? '',
+        advisorSummary,
+      }
+      setWeeklySummary(nextSummary)
+      await saveTaskNow({ tasks, weekly: nextSummary })
+    }
+
+    setExecutionStatus(response.data ? 'saved' : 'error')
+  }, [saveTaskNow, setExecutionStatus, snapshot.client.id, tasks, weeklySummary])
+
+  const handleGenerateReport = useCallback(async () => {
+    setResultsStatus('running')
+    const response = await runResultsReport({
+      clientId: snapshot.client.id,
+      results,
+    })
+
+    if (response.data && (response.data as any).reportUrl) {
+      const nextResult = {
+        ...results,
+        reportUrl: (response.data as any).reportUrl as string,
+      }
+      setResults(nextResult)
+      await saveResultsNow(nextResult)
+    }
+
+    setResultsStatus(response.data ? 'saved' : 'error')
+  }, [results, saveResultsNow, setResultsStatus, snapshot.client.id])
+
+  const handleSendProposal = useCallback(async () => {
+    setNextStepsStatus('running')
+    const response = await runProposal({
+      clientId: snapshot.client.id,
+      plan: nextStep,
+    })
+
+    if (response.data && (response.data as any).proposalUrl) {
+      const nextPlan = {
+        ...nextStep,
+        proposalUrl: (response.data as any).proposalUrl as string,
+      }
+      setNextStep(nextPlan)
+      await saveNextStepsNow(nextPlan)
+    }
+
+    setNextStepsStatus(response.data ? 'saved' : 'error')
+  }, [nextStep, saveNextStepsNow, setNextStepsStatus, snapshot.client.id])
+
+  const trsScore = useMemo(() => computeTrsScore(audits), [audits])
+
+  const stepperItems = TAB_CONFIG.map((tab) => ({
+    ...tab,
+    status: (() => {
+      switch (tab.key) {
+        case 'intake':
+          return intakeStatus
+        case 'audit':
+          return auditStatus
+        case 'blueprint':
+          return blueprintStatus
+        case 'revboard':
+          return metricStatus
+        case 'execution':
+          return executionStatus
+        case 'results':
+          return resultsStatus
+        case 'nextSteps':
+          return nextStepsStatus
+        default:
+          return 'idle' satisfies StageStatus
+      }
+    })(),
+  }))
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-gradient-to-b from-[#0e1018] via-[#121526] to-[#0b0d16] px-6 py-10 text-white">
+      <ProgressStepper
+        items={stepperItems}
+        active={activeTab}
+        onSelect={(key) => setActiveTab(key)}
+      />
+
+      <Tabs defaultValue="intake" value={activeTab} onValueChange={(value) => setActiveTab(value as RevenueClearStageKey)}>
+        <TabsList className="bg-white/5">
+          {TAB_CONFIG.map((tab) => (
+            <TabsTrigger key={tab.key} value={tab.key} className="data-[state=active]:bg-white/20">
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="intake" className="bg-white/5">
+          <IntakeTab
+            client={snapshot.client}
+            value={intake}
+            status={intakeStatus}
+            onChange={handleIntakeChange}
+            onSummarize={handleRunIntakeSummary}
+          />
+        </TabsContent>
+
+        <TabsContent value="audit" className="bg-white/5">
+          <AuditTab
+            audits={audits}
+            trsScore={trsScore}
+            status={auditStatus}
+            onChange={handleAuditChange}
+            onRunLeakScan={handleRunLeakScan}
+          />
+        </TabsContent>
+
+        <TabsContent value="blueprint" className="bg-white/5">
+          <BlueprintTab
+            interventions={interventions}
+            status={blueprintStatus}
+            onChange={handleBlueprintChange}
+            onGenerate={handleGenerateBlueprint}
+            baselineRevenue={snapshot.client.monthlyRevenue ?? 0}
+          />
+        </TabsContent>
+
+        <TabsContent value="revboard" className="bg-white/5">
+          <RevboardTab
+            metrics={metrics}
+            status={metricStatus}
+            trsScore={trsScore}
+            interventions={interventions}
+            onChange={handleMetricChange}
+          />
+        </TabsContent>
+
+        <TabsContent value="execution" className="bg-white/5">
+          <ExecutionTab
+            tasks={tasks}
+            status={executionStatus}
+            weeklySummary={weeklySummary}
+            onChange={handleTaskChange}
+            onWeeklySummaryChange={handleWeeklySummaryChange}
+            onCompleteReview={handleCompleteReview}
+          />
+        </TabsContent>
+
+        <TabsContent value="results" className="bg-white/5">
+          <ResultsTab
+            value={results}
+            status={resultsStatus}
+            onChange={handleResultsChange}
+            onGenerateReport={handleGenerateReport}
+          />
+        </TabsContent>
+
+        <TabsContent value="nextSteps" className="bg-white/5">
+          <NextStepsTab
+            value={nextStep}
+            status={nextStepsStatus}
+            onChange={handleNextStepsChange}
+            onSendProposal={handleSendProposal}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/AuditTab.tsx
+++ b/modules/revenue-clear/components/tabs/AuditTab.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Textarea } from '@/ui/textarea'
+
+import { AuditLeak, StageStatus } from '../../lib/types'
+
+const PILLARS: { key: AuditLeak['pillar']; label: string; description: string }[] = [
+  {
+    key: 'pricing',
+    label: 'Pricing',
+    description: 'Packaging, monetization, and yield discipline.',
+  },
+  {
+    key: 'demand',
+    label: 'Demand',
+    description: 'Pipeline velocity and conversion through the funnel.',
+  },
+  {
+    key: 'retention',
+    label: 'Retention',
+    description: 'Churn, expansion, and customer success execution.',
+  },
+  {
+    key: 'forecasting',
+    label: 'Forecasting',
+    description: 'RevOps accuracy, cadence, and forward visibility.',
+  },
+]
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Scanning…',
+  error: 'Needs attention',
+}
+
+type AuditTabProps = {
+  audits: AuditLeak[]
+  trsScore: number
+  status: StageStatus
+  onChange: (value: AuditLeak[]) => void
+  onRunLeakScan: () => Promise<void>
+}
+
+function FieldLabel({ label, description }: { label: string; description: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-sm font-semibold text-white">{label}</span>
+      <span className="text-xs uppercase tracking-wide text-white/60">{description}</span>
+    </div>
+  )
+}
+
+export default function AuditTab({ audits, trsScore, status, onChange, onRunLeakScan }: AuditTabProps) {
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const aggregateLoss = useMemo(
+    () =>
+      audits.reduce((total, audit) => {
+        return total + Number(audit.estimatedLoss ?? 0)
+      }, 0),
+    [audits],
+  )
+
+  const handleSeverityChange = (pillar: AuditLeak['pillar'], nextSeverity: number) => {
+    const next = audits.map((audit) =>
+      audit.pillar === pillar
+        ? {
+            ...audit,
+            leakSeverity: nextSeverity,
+            score: Math.max(0, 100 - nextSeverity * 10),
+          }
+        : audit,
+    )
+    onChange(next)
+  }
+
+  const handleDescriptionChange = (pillar: AuditLeak['pillar'], value: string) => {
+    const next = audits.map((audit) =>
+      audit.pillar === pillar
+        ? {
+            ...audit,
+            leakDescription: value,
+          }
+        : audit,
+    )
+    onChange(next)
+  }
+
+  const handleLossChange = (pillar: AuditLeak['pillar'], value: number) => {
+    const next = audits.map((audit) =>
+      audit.pillar === pillar
+        ? {
+            ...audit,
+            estimatedLoss: value,
+          }
+        : audit,
+    )
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Revenue Leak Audit</h3>
+          <p className="text-sm text-white/60">
+            Map the severity of leaks by growth pillar. Use the leak scan automation to produce a leak map for executive review.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-center">
+            <div className="text-xs uppercase tracking-wide text-white/60">TRS Score</div>
+            <div className="text-2xl font-semibold text-white">{trsScore}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-center">
+            <div className="text-xs uppercase tracking-wide text-white/60">Total Est. Loss</div>
+            <div className="text-lg font-semibold text-white">${aggregateLoss.toLocaleString()}</div>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+        </div>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {PILLARS.map((pillar) => {
+          const audit = audits.find((item) => item.pillar === pillar.key) ?? {
+            pillar: pillar.key,
+            leakSeverity: 0,
+            leakDescription: '',
+            estimatedLoss: 0,
+            score: 0,
+          }
+
+          return (
+            <div key={pillar.key} className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-5">
+              <FieldLabel label={pillar.label} description={pillar.description} />
+              <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-white/60">
+                <span>Leak Severity ({audit.leakSeverity}/10)</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  step={1}
+                  value={audit.leakSeverity}
+                  onChange={(event) => handleSeverityChange(pillar.key, Number(event.target.value))}
+                  className="accent-[color:var(--color-accent)]"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-white/60">
+                <span>Leak Description</span>
+                <Textarea
+                  value={audit.leakDescription}
+                  rows={3}
+                  onChange={(event) => handleDescriptionChange(pillar.key, event.target.value)}
+                  placeholder="Describe the leak dynamics and root cause"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-white/60">
+                <span>Estimated Loss ($)</span>
+                <Input
+                  type="number"
+                  value={audit.estimatedLoss ?? 0}
+                  onChange={(event) => handleLossChange(pillar.key, Number(event.target.value))}
+                />
+              </label>
+            </div>
+          )
+        })}
+      </div>
+
+      <footer className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-4">
+        <div className="text-sm text-white/70">
+          {status === 'running'
+            ? 'RevenueClarityAI is generating the leak map…'
+            : 'Trigger RevenueClarityAI to produce leak map JSON and executive summary.'}
+        </div>
+        <Button onClick={onRunLeakScan} disabled={status === 'running'}>
+          Run Leak Scan
+        </Button>
+      </footer>
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/BlueprintTab.tsx
+++ b/modules/revenue-clear/components/tabs/BlueprintTab.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Textarea } from '@/ui/textarea'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+
+import { BlueprintIntervention, StageStatus } from '../../lib/types'
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Generating…',
+  error: 'Needs attention',
+}
+
+type BlueprintTabProps = {
+  interventions: BlueprintIntervention[]
+  status: StageStatus
+  baselineRevenue: number
+  onChange: (value: BlueprintIntervention[]) => void
+  onGenerate: () => Promise<void>
+}
+
+export default function BlueprintTab({ interventions, status, baselineRevenue, onChange, onGenerate }: BlueprintTabProps) {
+  const [simulatedLift, setSimulatedLift] = useState(12)
+
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const projectedRevenue = useMemo(() => {
+    const liftMultiplier = 1 + simulatedLift / 100
+    return baselineRevenue > 0 ? baselineRevenue * liftMultiplier : 0
+  }, [baselineRevenue, simulatedLift])
+
+  const handleInterventionChange = <Key extends keyof BlueprintIntervention>(
+    index: number,
+    key: Key,
+    value: BlueprintIntervention[Key],
+  ) => {
+    const next = interventions.map((intervention, idx) => (idx === index ? { ...intervention, [key]: value } : intervention))
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Blueprint & ROI Model</h3>
+          <p className="text-sm text-white/60">
+            Prioritize interventions and pressure test uplift. BlueprintAI returns the top levers and attaches the playbook PDF.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right">
+            <p className="text-xs uppercase tracking-wide text-white/60">Projected MRR</p>
+            <p className="text-lg font-semibold text-white">${projectedRevenue.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
+            <p className="text-xs text-white/50">Lift {simulatedLift}% on ${baselineRevenue.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+        </div>
+      </header>
+
+      <section className="grid gap-4 rounded-xl border border-white/10 bg-white/5 p-5">
+        <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-white/60">
+          <span>ROI Simulator — Expected Lift (%)</span>
+          <input
+            type="range"
+            min={0}
+            max={50}
+            step={1}
+            value={simulatedLift}
+            onChange={(event) => setSimulatedLift(Number(event.target.value))}
+            className="accent-[color:var(--color-accent)]"
+          />
+        </label>
+      </section>
+
+      <section className="overflow-hidden rounded-xl border border-white/10 bg-white/5">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-white/10 bg-white/10 text-left text-xs uppercase tracking-wide text-white/60">
+              <TableHead className="text-white/70">Intervention</TableHead>
+              <TableHead className="text-white/70">Diagnosis</TableHead>
+              <TableHead className="text-white/70">Prescribed Fix</TableHead>
+              <TableHead className="text-white/70">Lift %</TableHead>
+              <TableHead className="text-white/70">Effort</TableHead>
+              <TableHead className="text-white/70">ROI Index</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {interventions.map((intervention, index) => (
+              <TableRow key={index} className="border-white/10">
+                <TableCell className="align-top">
+                  <Input
+                    value={intervention.interventionName}
+                    placeholder={`Intervention ${index + 1}`}
+                    onChange={(event) => handleInterventionChange(index, 'interventionName', event.target.value)}
+                  />
+                  {intervention.blueprintUrl ? (
+                    <a
+                      href={intervention.blueprintUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-2 block text-xs text-white underline"
+                    >
+                      Download Blueprint
+                    </a>
+                  ) : null}
+                </TableCell>
+                <TableCell className="align-top">
+                  <Textarea
+                    value={intervention.diagnosis}
+                    rows={3}
+                    onChange={(event) => handleInterventionChange(index, 'diagnosis', event.target.value)}
+                    placeholder="What is broken?"
+                  />
+                </TableCell>
+                <TableCell className="align-top">
+                  <Textarea
+                    value={intervention.fix}
+                    rows={3}
+                    onChange={(event) => handleInterventionChange(index, 'fix', event.target.value)}
+                    placeholder="How will we fix it?"
+                  />
+                </TableCell>
+                <TableCell className="align-top">
+                  <Input
+                    type="number"
+                    value={intervention.projectedLift ?? 0}
+                    onChange={(event) => handleInterventionChange(index, 'projectedLift', Number(event.target.value))}
+                  />
+                </TableCell>
+                <TableCell className="align-top">
+                  <Input
+                    type="number"
+                    value={intervention.effortScore ?? 0}
+                    onChange={(event) => handleInterventionChange(index, 'effortScore', Number(event.target.value))}
+                  />
+                </TableCell>
+                <TableCell className="align-top">
+                  <Input
+                    type="number"
+                    value={intervention.roiIndex ?? 0}
+                    onChange={(event) => handleInterventionChange(index, 'roiIndex', Number(event.target.value))}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <footer className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-4">
+        <div className="text-sm text-white/70">
+          {status === 'running'
+            ? 'BlueprintAI is composing the intervention plan…'
+            : 'Generate BlueprintAI recommendations to refresh interventions and ROI files.'}
+        </div>
+        <Button onClick={onGenerate} disabled={status === 'running'}>
+          Generate Blueprint
+        </Button>
+      </footer>
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/ExecutionTab.tsx
+++ b/modules/revenue-clear/components/tabs/ExecutionTab.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Select } from '@/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+import { Textarea } from '@/ui/textarea'
+
+import { ExecutionTask, ExecutionWeeklySummary, StageStatus } from '../../lib/types'
+
+const STATUS_OPTIONS: Array<{ value: ExecutionTask['status']; label: string }> = [
+  { value: 'todo', label: 'To Do' },
+  { value: 'in-progress', label: 'In Progress' },
+  { value: 'done', label: 'Complete' },
+]
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Advisor drafting…',
+  error: 'Needs attention',
+}
+
+type ExecutionTabProps = {
+  tasks: ExecutionTask[]
+  status: StageStatus
+  weeklySummary: ExecutionWeeklySummary | null
+  onChange: (tasks: ExecutionTask[]) => void
+  onWeeklySummaryChange: (summary: ExecutionWeeklySummary) => void
+  onCompleteReview: () => Promise<void>
+}
+
+export default function ExecutionTab({
+  tasks,
+  status,
+  weeklySummary,
+  onChange,
+  onWeeklySummaryChange,
+  onCompleteReview,
+}: ExecutionTabProps) {
+  const [filter, setFilter] = useState<'all' | ExecutionTask['status']>('all')
+
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const filteredTasks = useMemo(() => {
+    if (filter === 'all') return tasks
+    return tasks.filter((task) => task.status === filter)
+  }, [filter, tasks])
+
+  const handleTaskChange = <Key extends keyof ExecutionTask>(id: string | undefined, key: Key, value: ExecutionTask[Key]) => {
+    const next = tasks.map((task) => (task.id === id ? { ...task, [key]: value } : task))
+    onChange(next)
+  }
+
+  const handleAddTask = () => {
+    const next = [
+      ...tasks,
+      {
+        id: undefined,
+        taskName: 'New Task',
+        status: 'todo',
+        assignedTo: '',
+        startDate: new Date().toISOString().slice(0, 10),
+        endDate: new Date().toISOString().slice(0, 10),
+        progressNotes: '',
+      } satisfies ExecutionTask,
+    ]
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Execution Tracker</h3>
+          <p className="text-sm text-white/60">
+            Align the operating rhythm across owners, due dates, and advisor recaps. Filters and autosave keep everyone in sync.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right">
+            <p className="text-xs uppercase tracking-wide text-white/60">Tasks</p>
+            <p className="text-lg font-semibold text-white">{tasks.length}</p>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+          <Button variant="secondary" onClick={handleAddTask}>
+            Add Task
+          </Button>
+        </div>
+      </header>
+
+      <section className="flex flex-wrap items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm text-white/70">
+        <span>Filter</span>
+        <div className="flex gap-2">
+          {['all', ...STATUS_OPTIONS.map((option) => option.value)].map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setFilter(value as 'all' | ExecutionTask['status'])}
+              className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
+                filter === value ? 'bg-white text-black' : 'border border-white/30 text-white/70'
+              }`}
+            >
+              {value === 'all'
+                ? 'All'
+                : STATUS_OPTIONS.find((option) => option.value === value)?.label ?? value}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-xl border border-white/10 bg-white/5">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-white/10 bg-white/10 text-left text-xs uppercase tracking-wide text-white/60">
+              <TableHead className="text-white/70">Task</TableHead>
+              <TableHead className="text-white/70">Owner</TableHead>
+              <TableHead className="text-white/70">Status</TableHead>
+              <TableHead className="text-white/70">Start</TableHead>
+              <TableHead className="text-white/70">Due</TableHead>
+              <TableHead className="text-white/70">Notes</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredTasks.map((task) => (
+              <TableRow key={task.id ?? task.taskName}>
+                <TableCell>
+                  <Input value={task.taskName} onChange={(event) => handleTaskChange(task.id, 'taskName', event.target.value)} />
+                </TableCell>
+                <TableCell>
+                  <Input value={task.assignedTo} onChange={(event) => handleTaskChange(task.id, 'assignedTo', event.target.value)} />
+                </TableCell>
+                <TableCell>
+                  <Select
+                    value={task.status}
+                    onChange={(event) => handleTaskChange(task.id, 'status', event.target.value as ExecutionTask['status'])}
+                  >
+                    {STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="date"
+                    value={task.startDate?.slice(0, 10)}
+                    onChange={(event) => handleTaskChange(task.id, 'startDate', event.target.value)}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="date"
+                    value={task.endDate?.slice(0, 10)}
+                    onChange={(event) => handleTaskChange(task.id, 'endDate', event.target.value)}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Textarea
+                    value={task.progressNotes}
+                    rows={2}
+                    onChange={(event) => handleTaskChange(task.id, 'progressNotes', event.target.value)}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section className="grid gap-3 rounded-xl border border-white/10 bg-white/5 p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-white/60">Weekly Summary</h4>
+            <p className="text-xs text-white/50">AdvisorAI crafts a recap when you complete the review.</p>
+          </div>
+          <Button onClick={onCompleteReview} disabled={status === 'running'}>
+            Complete Review
+          </Button>
+        </div>
+        <Textarea
+          rows={5}
+          value={weeklySummary?.notes ?? ''}
+          onChange={(event) => onWeeklySummaryChange({ notes: event.target.value, advisorSummary: weeklySummary?.advisorSummary })}
+          placeholder="Wins, blockers, leading indicators"
+        />
+        {weeklySummary?.advisorSummary ? (
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 text-sm text-white/80">
+            <p className="mb-2 text-xs uppercase tracking-wide text-white/60">Advisor Summary</p>
+            <p>{weeklySummary.advisorSummary}</p>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/IntakeTab.tsx
+++ b/modules/revenue-clear/components/tabs/IntakeTab.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Textarea } from '@/ui/textarea'
+
+import { RevenueClearClient, RevenueClearIntake, StageStatus } from '../../lib/types'
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Running automation…',
+  error: 'Needs attention',
+}
+
+type IntakeTabProps = {
+  client: RevenueClearClient
+  value: RevenueClearIntake
+  status: StageStatus
+  onChange: (value: RevenueClearIntake) => void
+  onSummarize: () => Promise<void>
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-white/60">
+      <span>{label}</span>
+      {children}
+    </label>
+  )
+}
+
+export default function IntakeTab({ client, value, status, onChange, onSummarize }: IntakeTabProps) {
+  const profile = value.companyProfile
+  const financials = value.financials
+  const goals = value.goals
+
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-xl font-semibold">Intake & Baseline</h3>
+          <p className="text-sm text-white/60">
+            Capture the client narrative, revenue picture, and growth objectives. Updates autosave into Supabase in real time.
+          </p>
+        </div>
+        <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">Stage Status: {statusLabel}</span>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-5">
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">Company Profile</h4>
+          <Field label="Company Name">
+            <Input
+              value={profile.name}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  companyProfile: { ...profile, name: event.target.value },
+                })
+              }
+              placeholder="Acme Labs"
+            />
+          </Field>
+          <Field label="Industry">
+            <Input
+              value={profile.industry}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  companyProfile: { ...profile, industry: event.target.value },
+                })
+              }
+              placeholder={client.industry ?? 'SaaS, Services, etc.'}
+            />
+          </Field>
+          <Field label="Revenue Model">
+            <Input
+              value={profile.revenueModel}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  companyProfile: { ...profile, revenueModel: event.target.value },
+                })
+              }
+              placeholder={client.revenueModel ?? 'Subscription, Hybrid, Usage…'}
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-5">
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">Financials</h4>
+          <Field label="Monthly Revenue ($)">
+            <Input
+              type="number"
+              value={financials.monthlyRevenue ?? 0}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  financials: { ...financials, monthlyRevenue: Number(event.target.value) },
+                })
+              }
+            />
+          </Field>
+          <Field label="Profit Margin (%)">
+            <Input
+              type="number"
+              value={financials.profitMargin ?? 0}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  financials: { ...financials, profitMargin: Number(event.target.value) },
+                })
+              }
+            />
+          </Field>
+          <Field label="Target Growth (%)">
+            <Input
+              type="number"
+              value={financials.targetGrowth ?? 0}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  financials: { ...financials, targetGrowth: Number(event.target.value) },
+                })
+              }
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-5">
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">Goals</h4>
+          <Field label="Primary Goal">
+            <Input
+              value={goals.primaryGoal}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  goals: { ...goals, primaryGoal: event.target.value },
+                })
+              }
+              placeholder={client.primaryGoal ?? 'Scale MRR, Improve profit…'}
+            />
+          </Field>
+          <Field label="Secondary Goal">
+            <Input
+              value={goals.secondaryGoal ?? ''}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  goals: { ...goals, secondaryGoal: event.target.value },
+                })
+              }
+              placeholder="Efficiency, hiring, retention…"
+            />
+          </Field>
+          <Field label="Notes">
+            <Textarea
+              value={goals.notes ?? ''}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  goals: { ...goals, notes: event.target.value },
+                })
+              }
+              placeholder="Context, KPIs, constraints"
+              rows={5}
+            />
+          </Field>
+        </div>
+      </section>
+
+      <footer className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-4">
+        <div className="text-sm text-white/70">
+          {value.claritySummaryUrl ? (
+            <a
+              href={value.claritySummaryUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-white underline"
+            >
+              Download the latest clarity summary
+            </a>
+          ) : (
+            <span>Summaries will appear here after RevenueClarityAI completes its run.</span>
+          )}
+        </div>
+        <Button onClick={onSummarize} disabled={status === 'running'}>
+          Save &amp; Continue with RevenueClarityAI
+        </Button>
+      </footer>
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/NextStepsTab.tsx
+++ b/modules/revenue-clear/components/tabs/NextStepsTab.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Select } from '@/ui/select'
+import { Textarea } from '@/ui/textarea'
+
+import { NextStepPlan, StageStatus } from '../../lib/types'
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Sending proposal…',
+  error: 'Needs attention',
+}
+
+const OFFER_OPTIONS: Array<{ value: NextStepPlan['nextOffer']; label: string; template: string }> = [
+  {
+    value: 'Advisory',
+    label: 'Advisory Retainer',
+    template:
+      'Advisory Retainer — Weekly exec standups, RevBoard stewardship, and live diagnostics. Includes TRS growth lab support and quarterly board-readouts.',
+  },
+  {
+    value: 'ProfitOS',
+    label: 'ProfitOS Deployment',
+    template:
+      'ProfitOS Implementation — Deploy the ProfitOS stack across RevOps, finance, and GTM with embedded enablement and 90-day activation sprint.',
+  },
+  {
+    value: 'Equity',
+    label: 'Equity Partnership',
+    template:
+      'Equity Partnership — Structured revenue lab with capital infusion, operational oversight, and shared upside on defined growth milestones.',
+  },
+  {
+    value: 'Other',
+    label: 'Custom Engagement',
+    template: 'Custom engagement — Detail the bespoke delivery model, pricing, and success criteria.',
+  },
+]
+
+type NextStepsTabProps = {
+  value: NextStepPlan
+  status: StageStatus
+  onChange: (value: NextStepPlan) => void
+  onSendProposal: () => Promise<void>
+}
+
+export default function NextStepsTab({ value, status, onChange, onSendProposal }: NextStepsTabProps) {
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const handleOfferChange = (offer: NextStepPlan['nextOffer']) => {
+    const template = OFFER_OPTIONS.find((option) => option.value === offer)?.template ?? value.proposalDoc
+    onChange({
+      ...value,
+      nextOffer: offer,
+      proposalDoc: template,
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Next Steps & Proposal</h3>
+          <p className="text-sm text-white/60">
+            Package the right engagement, align on rationale, and send proposal artifacts with one click.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right">
+            <p className="text-xs uppercase tracking-wide text-white/60">Projected Outcome</p>
+            <p className="text-lg font-semibold text-white">${value.projectedOutcome.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+          <Button onClick={onSendProposal} disabled={status === 'running'}>
+            Send Proposal
+          </Button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 rounded-xl border border-white/10 bg-white/5 p-5">
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+          <span>Recommended Offer</span>
+          <Select value={value.nextOffer} onChange={(event) => handleOfferChange(event.target.value as NextStepPlan['nextOffer'])}>
+            {OFFER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+          <span>Rationale</span>
+          <Textarea
+            rows={4}
+            value={value.rationale}
+            onChange={(event) => onChange({ ...value, rationale: event.target.value })}
+            placeholder="Why this path? Decision criteria, success plan, economics"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+          <span>Projected Outcome ($)</span>
+          <Input
+            type="number"
+            value={value.projectedOutcome ?? 0}
+            onChange={(event) => onChange({ ...value, projectedOutcome: Number(event.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-white/60">
+          <span>Proposal Outline</span>
+          <Textarea
+            rows={6}
+            value={value.proposalDoc}
+            onChange={(event) => onChange({ ...value, proposalDoc: event.target.value })}
+          />
+        </label>
+      </section>
+
+      {value.proposalUrl ? (
+        <div className="rounded-xl border border-sky-500/40 bg-sky-500/10 px-5 py-4 text-sm text-sky-200">
+          Proposal ready: <a href={value.proposalUrl} target="_blank" rel="noreferrer" className="underline">Download</a>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/ResultsTab.tsx
+++ b/modules/revenue-clear/components/tabs/ResultsTab.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+
+import { RevenueClearResult, StageStatus } from '../../lib/types'
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Saved',
+  running: 'Generating report…',
+  error: 'Needs attention',
+}
+
+type ResultsTabProps = {
+  value: RevenueClearResult
+  status: StageStatus
+  onChange: (value: RevenueClearResult) => void
+  onGenerateReport: () => Promise<void>
+}
+
+export default function ResultsTab({ value, status, onChange, onGenerateReport }: ResultsTabProps) {
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const roiPercent = useMemo(() => {
+    if (!value.beforeProfit) return 0
+    return Number((((value.afterProfit - value.beforeProfit) / value.beforeProfit) * 100).toFixed(1))
+  }, [value.afterProfit, value.beforeProfit])
+
+  const chartData = useMemo(
+    () => [
+      {
+        name: 'MRR',
+        before: value.beforeMRR,
+        after: value.afterMRR,
+      },
+      {
+        name: 'Profit',
+        before: value.beforeProfit,
+        after: value.afterProfit,
+      },
+    ],
+    [value.afterMRR, value.afterProfit, value.beforeMRR, value.beforeProfit],
+  )
+
+  const handleChange = <Key extends keyof RevenueClearResult>(key: Key, data: RevenueClearResult[Key]) => {
+    onChange({
+      ...value,
+      [key]: data,
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Results & ROI</h3>
+          <p className="text-sm text-white/60">Finalize the impact narrative with before/after analytics and ROI calculations.</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right">
+            <p className="text-xs uppercase tracking-wide text-white/60">ROI Lift</p>
+            <p className="text-lg font-semibold text-white">{roiPercent}%</p>
+            <p className="text-xs text-white/50">Payback {value.paybackPeriod} months</p>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+          <Button onClick={onGenerateReport} disabled={status === 'running'}>
+            Generate Report
+          </Button>
+        </div>
+      </header>
+
+      <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+        <div className="h-64 w-full">
+          <ResponsiveContainer>
+            <BarChart data={chartData} margin={{ left: -10 }}>
+              <CartesianGrid stroke="rgba(255,255,255,0.08)" strokeDasharray="3 3" />
+              <XAxis dataKey="name" stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+              <YAxis stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+              <Tooltip
+                contentStyle={{ background: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                labelStyle={{ color: '#fff' }}
+              />
+              <Legend />
+              <Bar dataKey="before" name="Before" fill="#94a3b8" radius={[6, 6, 0, 0]} />
+              <Bar dataKey="after" name="After" fill="#34d399" radius={[6, 6, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-xl border border-white/10 bg-white/5">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-white/10 bg-white/10 text-left text-xs uppercase tracking-wide text-white/60">
+              <TableHead className="text-white/70">Metric</TableHead>
+              <TableHead className="text-white/70">Before</TableHead>
+              <TableHead className="text-white/70">After</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Monthly Recurring Revenue</TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={value.beforeMRR ?? 0}
+                  onChange={(event) => handleChange('beforeMRR', Number(event.target.value))}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={value.afterMRR ?? 0}
+                  onChange={(event) => handleChange('afterMRR', Number(event.target.value))}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Monthly Profit</TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={value.beforeProfit ?? 0}
+                  onChange={(event) => handleChange('beforeProfit', Number(event.target.value))}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={value.afterProfit ?? 0}
+                  onChange={(event) => handleChange('afterProfit', Number(event.target.value))}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Total Gain</TableCell>
+              <TableCell colSpan={2}>
+                <Input
+                  type="number"
+                  value={value.totalGain ?? value.afterMRR - value.beforeMRR}
+                  onChange={(event) => handleChange('totalGain', Number(event.target.value))}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Payback Period (months)</TableCell>
+              <TableCell colSpan={2}>
+                <Input
+                  type="number"
+                  value={value.paybackPeriod ?? 0}
+                  onChange={(event) => handleChange('paybackPeriod', Number(event.target.value))}
+                />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </section>
+
+      {value.reportUrl ? (
+        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-5 py-4 text-sm text-emerald-200">
+          Report ready: <a href={value.reportUrl} className="underline" target="_blank" rel="noreferrer">Download ROI Report</a>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/modules/revenue-clear/components/tabs/RevboardTab.tsx
+++ b/modules/revenue-clear/components/tabs/RevboardTab.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Input } from '@/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
+import { Bar, BarChart, CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+
+import { BlueprintIntervention, RevboardMetric, StageStatus } from '../../lib/types'
+
+const STATUS_LABELS: Record<StageStatus, string> = {
+  idle: 'Idle',
+  saving: 'Saving…',
+  saved: 'Live',
+  running: 'Syncing…',
+  error: 'Needs attention',
+}
+
+const KPI_ORDER = ['MRR', 'Churn', 'ARPU', 'CAC']
+
+type RevboardTabProps = {
+  metrics: RevboardMetric[]
+  status: StageStatus
+  trsScore: number
+  interventions: BlueprintIntervention[]
+  onChange: (metrics: RevboardMetric[]) => void
+}
+
+function formatCurrency(value: number) {
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+}
+
+export default function RevboardTab({ metrics, status, trsScore, interventions, onChange }: RevboardTabProps) {
+  const statusLabel = useMemo(() => STATUS_LABELS[status], [status])
+
+  const metricCards = useMemo(() => {
+    return KPI_ORDER.map((name) => {
+      const metric = metrics.find((item) => item.kpiName.toLowerCase() === name.toLowerCase())
+      return {
+        name,
+        baseline: metric?.baselineValue ?? 0,
+        current: metric?.currentValue ?? 0,
+        delta: metric?.delta ?? (metric ? metric.currentValue - metric.baselineValue : 0),
+      }
+    })
+  }, [metrics])
+
+  const timelineData = useMemo(() => {
+    const grouped = new Map<string, { date: string; baseline: number; current: number; count: number }>()
+    metrics.forEach((metric) => {
+      const key = new Date(metric.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      const entry = grouped.get(key) ?? { date: key, baseline: 0, current: 0, count: 0 }
+      entry.baseline += metric.baselineValue
+      entry.current += metric.currentValue
+      entry.count += 1
+      grouped.set(key, entry)
+    })
+    return Array.from(grouped.values()).map((entry) => ({
+      date: entry.date,
+      baseline: entry.count ? Number((entry.baseline / entry.count).toFixed(1)) : 0,
+      current: entry.count ? Number((entry.current / entry.count).toFixed(1)) : 0,
+    }))
+  }, [metrics])
+
+  const barData = useMemo(
+    () =>
+      metrics.map((metric) => ({
+        name: metric.kpiName,
+        baseline: metric.baselineValue,
+        current: metric.currentValue,
+      })),
+    [metrics],
+  )
+
+  const handleMetricChange = (id: string | undefined, key: keyof RevboardMetric, value: number | string) => {
+    const next = metrics.map((metric) => {
+      if (metric.id !== id) return metric
+      const updated: RevboardMetric = {
+        ...metric,
+        [key]: typeof value === 'number' ? value : value,
+      }
+      if (key === 'baselineValue' || key === 'currentValue') {
+        updated.delta = Number((updated.currentValue - updated.baselineValue).toFixed(2))
+      }
+      return updated
+    })
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">RevBoard Metrics</h3>
+          <p className="text-sm text-white/60">
+            Track KPI performance against baseline and surface the TRS Score across the operating rhythm.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-center">
+            <p className="text-xs uppercase tracking-wide text-white/60">TRS Score</p>
+            <p className="text-2xl font-semibold text-white">{trsScore}</p>
+          </div>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">{statusLabel}</span>
+        </div>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        {metricCards.map((metric) => (
+          <div key={metric.name} className="space-y-1 rounded-xl border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/60">{metric.name}</p>
+            <p className="text-lg font-semibold text-white">{formatCurrency(metric.current)}</p>
+            <p className="text-xs text-white/50">
+              Baseline {formatCurrency(metric.baseline)} • Δ {metric.delta >= 0 ? '+' : ''}
+              {metric.delta.toFixed(2)}
+            </p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <h4 className="mb-4 text-sm font-semibold uppercase tracking-wide text-white/60">Momentum vs Baseline</h4>
+          <div className="h-60 w-full">
+            <ResponsiveContainer>
+              <LineChart data={timelineData} margin={{ left: -10 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.08)" strokeDasharray="3 3" />
+                <XAxis dataKey="date" stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+                <YAxis stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+                <Tooltip
+                  contentStyle={{ background: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                  labelStyle={{ color: '#fff' }}
+                />
+                <Legend />
+                <Line type="monotone" dataKey="baseline" stroke="#94a3b8" strokeWidth={2} dot={false} name="Baseline" />
+                <Line type="monotone" dataKey="current" stroke="#38bdf8" strokeWidth={3} dot name="Current" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <h4 className="mb-4 text-sm font-semibold uppercase tracking-wide text-white/60">Baseline vs Current by KPI</h4>
+          <div className="h-60 w-full">
+            <ResponsiveContainer>
+              <BarChart data={barData} margin={{ left: -10 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.08)" strokeDasharray="3 3" />
+                <XAxis dataKey="name" stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+                <YAxis stroke="#A3A7C9" tick={{ fontSize: 12 }} />
+                <Tooltip
+                  contentStyle={{ background: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                  labelStyle={{ color: '#fff' }}
+                />
+                <Legend />
+                <Bar dataKey="baseline" fill="#94a3b8" name="Baseline" radius={[6, 6, 0, 0]} />
+                <Bar dataKey="current" fill="#22d3ee" name="Current" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-xl border border-white/10 bg-white/5">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-white/10 bg-white/10 text-left text-xs uppercase tracking-wide text-white/60">
+              <TableHead className="text-white/70">KPI</TableHead>
+              <TableHead className="text-white/70">Baseline</TableHead>
+              <TableHead className="text-white/70">Current</TableHead>
+              <TableHead className="text-white/70">Delta</TableHead>
+              <TableHead className="text-white/70">Intervention</TableHead>
+              <TableHead className="text-white/70">Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {metrics.map((metric) => (
+              <TableRow key={metric.id ?? `${metric.kpiName}-${metric.date}`}> 
+                <TableCell>
+                  <Input
+                    value={metric.kpiName}
+                    onChange={(event) => handleMetricChange(metric.id, 'kpiName', event.target.value)}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="number"
+                    value={metric.baselineValue ?? 0}
+                    onChange={(event) => handleMetricChange(metric.id, 'baselineValue', Number(event.target.value))}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="number"
+                    value={metric.currentValue ?? 0}
+                    onChange={(event) => handleMetricChange(metric.id, 'currentValue', Number(event.target.value))}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="number"
+                    value={Number(metric.delta ?? metric.currentValue - metric.baselineValue).toFixed(2)}
+                    onChange={(event) => handleMetricChange(metric.id, 'delta', Number(event.target.value))}
+                  />
+                </TableCell>
+                <TableCell>{interventions.find((item) => item.id === metric.interventionId)?.interventionName ?? '—'}</TableCell>
+                <TableCell>
+                  <Input
+                    value={metric.date?.slice(0, 10)}
+                    type="date"
+                    onChange={(event) => handleMetricChange(metric.id, 'date', event.target.value)}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+    </div>
+  )
+}

--- a/modules/revenue-clear/hooks/useAutosave.ts
+++ b/modules/revenue-clear/hooks/useAutosave.ts
@@ -1,0 +1,56 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+import { StageStatus } from '../lib/types'
+
+type SaveFn<T> = (value: T) => Promise<void>
+
+export function useAutosave<T>(saveFn: SaveFn<T>, delay = 800) {
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const [status, setStatus] = useState<StageStatus>('idle')
+
+  const scheduleSave = useCallback(
+    (value: T) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+
+      timerRef.current = setTimeout(async () => {
+        setStatus('saving')
+        try {
+          await saveFn(value)
+          setStatus('saved')
+        } catch (error) {
+          console.error('Autosave failed', error)
+          setStatus('error')
+        }
+      }, delay)
+    },
+    [delay, saveFn],
+  )
+
+  const saveImmediately = useCallback(
+    async (value: T) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+      setStatus('saving')
+      try {
+        await saveFn(value)
+        setStatus('saved')
+      } catch (error) {
+        console.error('Autosave flush failed', error)
+        setStatus('error')
+      }
+    },
+    [saveFn],
+  )
+
+  return {
+    scheduleSave,
+    saveImmediately,
+    status,
+    setStatus,
+  }
+}

--- a/modules/revenue-clear/lib/automations.ts
+++ b/modules/revenue-clear/lib/automations.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+
+const REVENUE_CLARITY_FUNCTION = 'revenue-clarity-ai'
+const BLUEPRINT_FUNCTION = 'revenue-clear-blueprint'
+const ADVISOR_FUNCTION = 'revenue-clear-advisor'
+const REPORT_FUNCTION = 'revenue-clear-report'
+const PROPOSAL_FUNCTION = 'revenue-clear-proposal'
+
+type AutomationResponse<T = Record<string, unknown>> = {
+  data: T | null
+  fileUrl: string | null
+  message: string
+}
+
+async function invokeAutomation<T>(name: string, body: Record<string, unknown>): Promise<AutomationResponse<T>> {
+  const supabase = createClient()
+
+  try {
+    const { data, error } = await supabase.functions.invoke<T>(name, { body })
+    if (error) {
+      console.error(`Automation ${name} failed`, error)
+      return {
+        data: null,
+        fileUrl: null,
+        message: 'Automation unavailable. Manual review required.',
+      }
+    }
+
+    if (!data) {
+      return {
+        data: null,
+        fileUrl: null,
+        message: 'Automation returned no data.',
+      }
+    }
+
+    return {
+      data,
+      fileUrl: (data as any).fileUrl ?? null,
+      message: 'Automation completed',
+    }
+  } catch (error) {
+    console.error(`Automation ${name} threw`, error)
+    return {
+      data: null,
+      fileUrl: null,
+      message: 'Automation unavailable. Manual review required.',
+    }
+  }
+}
+
+export async function runIntakeSummary(payload: Record<string, unknown>) {
+  return invokeAutomation<{ summary: string; fileUrl?: string }>(REVENUE_CLARITY_FUNCTION, {
+    stage: 'intake',
+    ...payload,
+  })
+}
+
+export async function runLeakScan(payload: Record<string, unknown>) {
+  return invokeAutomation<{ leakMap: Record<string, unknown>; fileUrl?: string }>(REVENUE_CLARITY_FUNCTION, {
+    stage: 'audit',
+    ...payload,
+  })
+}
+
+export async function runBlueprintGeneration(payload: Record<string, unknown>) {
+  return invokeAutomation<{ interventions: unknown[]; fileUrl?: string }>(BLUEPRINT_FUNCTION, payload)
+}
+
+export async function runAdvisorSummary(payload: Record<string, unknown>) {
+  return invokeAutomation<{ advisorSummary: string; fileUrl?: string }>(ADVISOR_FUNCTION, payload)
+}
+
+export async function runResultsReport(payload: Record<string, unknown>) {
+  return invokeAutomation<{ reportUrl: string }>(REPORT_FUNCTION, payload)
+}
+
+export async function runProposal(payload: Record<string, unknown>) {
+  return invokeAutomation<{ proposalUrl: string }>(PROPOSAL_FUNCTION, payload)
+}

--- a/modules/revenue-clear/lib/queries.ts
+++ b/modules/revenue-clear/lib/queries.ts
@@ -1,0 +1,218 @@
+import { notFound } from 'next/navigation'
+
+import { createClient } from '@/lib/supabase/server'
+
+import {
+  AuditLeak,
+  BlueprintIntervention,
+  ExecutionTask,
+  ExecutionWeeklySummary,
+  NextStepPlan,
+  RevenueClearClient,
+  RevenueClearIntake,
+  RevenueClearResult,
+  RevenueClearSnapshot,
+  RevboardMetric,
+} from './types'
+
+function toClient(row: any): RevenueClearClient {
+  return {
+    id: row.id,
+    name: row.name,
+    industry: row.industry ?? null,
+    revenueModel: row.revenue_model ?? row.revenueModel ?? null,
+    monthlyRevenue: row.monthly_recurring_revenue ?? row.monthlyRevenue ?? null,
+    profitMargin: row.profit_margin ?? row.profitMargin ?? null,
+    targetGrowth: row.target_growth ?? row.targetGrowth ?? null,
+    primaryGoal: row.primary_goal ?? row.primaryGoal ?? null,
+  }
+}
+
+function toIntake(row: any | null): RevenueClearIntake | null {
+  if (!row) return null
+  return {
+    id: row.id,
+    companyProfile: row.company_profile ?? row.companyProfile ?? {
+      name: '',
+      industry: '',
+      revenueModel: '',
+    },
+    financials: row.financials ?? {
+      monthlyRevenue: 0,
+      profitMargin: 0,
+      targetGrowth: 0,
+    },
+    goals: row.goals ?? {
+      primaryGoal: '',
+      secondaryGoal: '',
+      notes: '',
+    },
+    claritySummaryUrl: row.clarity_summary_url ?? row.claritySummaryUrl ?? null,
+  }
+}
+
+function toAudit(row: any): AuditLeak {
+  return {
+    id: row.id,
+    pillar: row.pillar,
+    leakSeverity: Number(row.leak_severity ?? row.leakSeverity ?? 0),
+    leakDescription: row.leak_description ?? row.leakDescription ?? '',
+    estimatedLoss: Number(row.estimated_loss ?? row.estimatedLoss ?? 0),
+    score: Number(row.score ?? 0),
+    leakMapUrl: row.leak_map_url ?? row.leakMapUrl ?? null,
+  }
+}
+
+function toIntervention(row: any): BlueprintIntervention {
+  return {
+    id: row.id,
+    interventionName: row.intervention_name ?? row.interventionName ?? '',
+    diagnosis: row.diagnosis ?? '',
+    fix: row.fix ?? '',
+    projectedLift: Number(row.projected_lift ?? row.projectedLift ?? 0),
+    effortScore: Number(row.effort_score ?? row.effortScore ?? 0),
+    roiIndex: Number(row.roi_index ?? row.roiIndex ?? 0),
+    blueprintUrl: row.blueprint_url ?? row.blueprintUrl ?? null,
+  }
+}
+
+function toMetric(row: any): RevboardMetric {
+  return {
+    id: row.id,
+    kpiName: row.kpi_name ?? row.kpiName ?? '',
+    baselineValue: Number(row.baseline_value ?? row.baselineValue ?? 0),
+    currentValue: Number(row.current_value ?? row.currentValue ?? 0),
+    delta: Number(row.delta ?? 0),
+    interventionId: row.intervention_id ?? row.interventionId ?? null,
+    date: row.date ?? new Date().toISOString(),
+  }
+}
+
+function toTask(row: any): ExecutionTask {
+  return {
+    id: row.id,
+    taskName: row.task_name ?? row.taskName ?? '',
+    status: (row.status ?? 'todo').toLowerCase(),
+    assignedTo: row.assigned_to ?? row.assignedTo ?? '',
+    startDate: row.start_date ?? row.startDate ?? new Date().toISOString(),
+    endDate: row.end_date ?? row.endDate ?? new Date().toISOString(),
+    progressNotes: row.progress_notes ?? row.progressNotes ?? '',
+  }
+}
+
+function toWeeklySummary(row: any | null): ExecutionWeeklySummary | null {
+  if (!row) return null
+  return {
+    notes: row.notes ?? row.summary ?? '',
+    advisorSummary: row.advisor_summary ?? row.advisorSummary ?? null,
+  }
+}
+
+function toResult(row: any | null): RevenueClearResult | null {
+  if (!row) return null
+  return {
+    id: row.id,
+    beforeMRR: Number(row.before_mrr ?? row.beforeMRR ?? 0),
+    afterMRR: Number(row.after_mrr ?? row.afterMRR ?? 0),
+    beforeProfit: Number(row.before_profit ?? row.beforeProfit ?? 0),
+    afterProfit: Number(row.after_profit ?? row.afterProfit ?? 0),
+    totalGain: Number(row.total_gain ?? row.totalGain ?? 0),
+    paybackPeriod: Number(row.payback_period ?? row.paybackPeriod ?? 0),
+    reportUrl: row.report_url ?? row.reportUrl ?? null,
+  }
+}
+
+function toNextStep(row: any | null): NextStepPlan | null {
+  if (!row) return null
+  return {
+    id: row.id,
+    nextOffer: row.next_offer ?? row.nextOffer ?? 'Advisory',
+    rationale: row.rationale ?? '',
+    projectedOutcome: Number(row.projected_outcome ?? row.projectedOutcome ?? 0),
+    proposalDoc: row.proposal_doc ?? row.proposalDoc ?? '',
+    proposalUrl: row.proposal_url ?? row.proposalUrl ?? null,
+  }
+}
+
+export async function getRevenueClearSnapshot(clientId: string): Promise<RevenueClearSnapshot> {
+  const supabase = await createClient()
+
+  const { data: clientRow, error: clientError } = await supabase
+    .from('clients')
+    .select(
+      `id, name, industry, revenue_model, monthly_recurring_revenue, profit_margin, target_growth, primary_goal`,
+    )
+    .eq('id', clientId)
+    .maybeSingle()
+
+  if (clientError) {
+    console.error('Failed to load client for Revenue Clear:', clientError)
+    notFound()
+  }
+
+  if (!clientRow) {
+    notFound()
+  }
+
+  const client = toClient(clientRow)
+
+  const [intakeRes, auditsRes, interventionsRes, metricsRes, tasksRes, weeklyRes, resultsRes, nextStepsRes] =
+    await Promise.all([
+      supabase.from('intakes').select('*').eq('client_id', clientId).maybeSingle(),
+      supabase.from('audits').select('*').eq('client_id', clientId),
+      supabase.from('interventions').select('*').eq('client_id', clientId).order('roi_index', { ascending: false }),
+      supabase
+        .from('revboard_metrics')
+        .select('*')
+        .eq('client_id', clientId)
+        .order('date', { ascending: true }),
+      supabase.from('tasks').select('*').eq('client_id', clientId).order('start_date', { ascending: true }),
+      supabase.from('execution_weekly_reports').select('*').eq('client_id', clientId).order('created_at', { ascending: false }).maybeSingle(),
+      supabase.from('results').select('*').eq('client_id', clientId).maybeSingle(),
+      supabase.from('next_steps').select('*').eq('client_id', clientId).maybeSingle(),
+    ])
+
+  if (intakeRes.error) {
+    console.warn('Failed to load intake snapshot', intakeRes.error)
+  }
+
+  if (auditsRes.error) {
+    console.warn('Failed to load audits snapshot', auditsRes.error)
+  }
+
+  if (interventionsRes.error) {
+    console.warn('Failed to load interventions snapshot', interventionsRes.error)
+  }
+
+  if (metricsRes.error) {
+    console.warn('Failed to load metrics snapshot', metricsRes.error)
+  }
+
+  if (tasksRes.error) {
+    console.warn('Failed to load tasks snapshot', tasksRes.error)
+  }
+
+  if (weeklyRes.error) {
+    console.warn('Failed to load weekly summary snapshot', weeklyRes.error)
+  }
+
+  if (resultsRes.error) {
+    console.warn('Failed to load results snapshot', resultsRes.error)
+  }
+
+  if (nextStepsRes.error) {
+    console.warn('Failed to load next steps snapshot', nextStepsRes.error)
+  }
+
+  return {
+    client,
+    intake: toIntake(intakeRes.data ?? null),
+    audits: (auditsRes.data ?? []).map(toAudit),
+    interventions: (interventionsRes.data ?? []).map(toIntervention),
+    metrics: (metricsRes.data ?? []).map(toMetric),
+    tasks: (tasksRes.data ?? []).map(toTask),
+    weeklySummary: toWeeklySummary(weeklyRes.data ?? null),
+    results: toResult(resultsRes.data ?? null),
+    nextStep: toNextStep(nextStepsRes.data ?? null),
+  }
+}

--- a/modules/revenue-clear/lib/types.ts
+++ b/modules/revenue-clear/lib/types.ts
@@ -1,0 +1,125 @@
+export type RevenueClearStageKey =
+  | 'intake'
+  | 'audit'
+  | 'blueprint'
+  | 'revboard'
+  | 'execution'
+  | 'results'
+  | 'nextSteps'
+
+export type StageStatus = 'idle' | 'saving' | 'saved' | 'error' | 'running'
+
+export type RevenueClearClient = {
+  id: string
+  name: string
+  industry: string | null
+  revenueModel: string | null
+  monthlyRevenue: number | null
+  profitMargin: number | null
+  targetGrowth: number | null
+  primaryGoal: string | null
+}
+
+export type IntakeCompanyProfile = {
+  name: string
+  industry: string
+  revenueModel: string
+}
+
+export type IntakeFinancials = {
+  monthlyRevenue: number
+  profitMargin: number
+  targetGrowth: number
+}
+
+export type IntakeGoals = {
+  primaryGoal: string
+  secondaryGoal?: string
+  notes?: string
+}
+
+export type RevenueClearIntake = {
+  id?: string
+  companyProfile: IntakeCompanyProfile
+  financials: IntakeFinancials
+  goals: IntakeGoals
+  claritySummaryUrl?: string | null
+}
+
+export type AuditLeak = {
+  id?: string
+  pillar: 'pricing' | 'demand' | 'retention' | 'forecasting'
+  leakSeverity: number
+  leakDescription: string
+  estimatedLoss: number
+  score: number
+  leakMapUrl?: string | null
+}
+
+export type BlueprintIntervention = {
+  id?: string
+  interventionName: string
+  diagnosis: string
+  fix: string
+  projectedLift: number
+  effortScore: number
+  roiIndex: number
+  blueprintUrl?: string | null
+}
+
+export type RevboardMetric = {
+  id?: string
+  kpiName: string
+  baselineValue: number
+  currentValue: number
+  delta: number
+  interventionId?: string | null
+  date: string
+}
+
+export type ExecutionTask = {
+  id?: string
+  taskName: string
+  status: 'todo' | 'in-progress' | 'done'
+  assignedTo: string
+  startDate: string
+  endDate: string
+  progressNotes: string
+}
+
+export type ExecutionWeeklySummary = {
+  notes: string
+  advisorSummary?: string | null
+}
+
+export type RevenueClearResult = {
+  id?: string
+  beforeMRR: number
+  afterMRR: number
+  beforeProfit: number
+  afterProfit: number
+  totalGain: number
+  paybackPeriod: number
+  reportUrl?: string | null
+}
+
+export type NextStepPlan = {
+  id?: string
+  nextOffer: 'Advisory' | 'ProfitOS' | 'Equity' | 'Other'
+  rationale: string
+  projectedOutcome: number
+  proposalDoc: string
+  proposalUrl?: string | null
+}
+
+export type RevenueClearSnapshot = {
+  client: RevenueClearClient
+  intake: RevenueClearIntake | null
+  audits: AuditLeak[]
+  interventions: BlueprintIntervention[]
+  metrics: RevboardMetric[]
+  tasks: ExecutionTask[]
+  weeklySummary: ExecutionWeeklySummary | null
+  results: RevenueClearResult | null
+  nextStep: NextStepPlan | null
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "next": "14.2.6",
     "openai": "^6.2.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@types/node": "20.14.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      recharts:
+        specifier: ^3.2.1
+        version: 3.2.1(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1)
     devDependencies:
       '@types/node':
         specifier: 20.14.10
@@ -575,6 +578,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.9.0':
+    resolution: {integrity: sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -600,6 +614,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.75.0':
     resolution: {integrity: sha512-J8TkeqCOMCV4KwGKVoxmEBuDdHRwoInML2vJilthOo7awVCro2SM+tOcpljORwuBQ1vHUtV62Leit+5wlxrNtw==}
@@ -637,6 +657,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -659,6 +706,9 @@ packages:
 
   '@types/react@18.3.5':
     resolution: {integrity: sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -984,6 +1034,10 @@ packages:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1013,6 +1067,50 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1049,6 +1147,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1136,6 +1237,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.40.0:
+    resolution: {integrity: sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1252,6 +1356,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1462,6 +1569,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1480,6 +1590,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1980,6 +2094,18 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -1997,6 +2123,22 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts@3.2.1:
+    resolution: {integrity: sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2004,6 +2146,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2207,6 +2352,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2284,8 +2432,16 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -2794,6 +2950,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.9.0(react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 10.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.13.0': {}
@@ -2817,6 +2985,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-fast-compare: 3.2.2
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.75.0':
     dependencies:
@@ -2877,6 +3049,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/node@20.14.10':
@@ -2899,6 +3095,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3219,6 +3417,8 @@ snapshots:
 
   clsx@2.0.0: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3240,6 +3440,44 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -3270,6 +3508,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -3426,6 +3666,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.40.0: {}
 
   escalade@3.2.0: {}
 
@@ -3625,6 +3867,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.1: {}
 
   extend@3.0.2: {}
 
@@ -3882,6 +4126,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.1.3: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3901,6 +4147,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4381,6 +4629,15 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.5
+      redux: 5.0.1
+
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.4
@@ -4402,6 +4659,32 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  recharts@3.2.1(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.9.0(react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.40.0
+      eventemitter3: 5.0.1
+      immer: 10.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -4421,6 +4704,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4680,6 +4965,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4792,7 +5079,28 @@ snapshots:
 
   url-template@2.0.8: {}
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary
- add Supabase snapshot assembly and typed models for the Revenue Clear engagement
- build a client-side Revenue Clear shell with autosaving stages, automation triggers, and workflow stepper
- implement seven guided tabs with forms, charts, and proposal tooling plus add the Recharts dependency

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ef7f98bc78832481506e3a1691907b