### PR TITLE
Add Revenue Clear shortcut to main navigation

### DIFF
--- a/components/nav/Sidebar.tsx
+++ b/components/nav/Sidebar.tsx
@@ -3,16 +3,18 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MAIN_NAV, type NavItem } from '@/lib/navigation'
+import { isActivePath } from '@/lib/utils'
 import { canSee, Role, FLAGS } from '@/core/flags/flags'
 
 export default function Sidebar({ role = 'SuperAdmin' as Role }) {
   const pathname = usePathname()
+  const currentPath = pathname ?? ''
 
   const Item = ({ label, href, flag, roles }: NavItem) => {
     if (!canSee(role, roles)) return null
     if (flag && !FLAGS[flag]) return null
 
-    const active = pathname === href || (href !== '/' && pathname.startsWith(href))
+    const active = isActivePath(currentPath, href)
 
     return (
       <Link

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -86,6 +86,12 @@ export const MAIN_NAV: NavItem[] = [
     roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
   },
   {
+    label: 'Revenue Clear',
+    href: '/resources?tab=Revenue%20Clear',
+    icon: 'Calculator',
+    roles: ['SuperAdmin', 'Admin', 'Director', 'Member', 'Client'],
+  },
+  {
     label: 'Settings',
     href: '/settings',
     icon: 'Settings',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,8 +9,10 @@ export function cn(...c: Array<string | false | null | undefined>) {
  */
 export function isActivePath(current: string, href: string) {
   if (!current || !href) return false
-  if (href === '/') {
-    return current === '/'
+  const currentPath = current.split(/[?#]/)[0]
+  const targetPath = href.split(/[?#]/)[0]
+  if (targetPath === '/') {
+    return currentPath === '/'
   }
-  return current === href || current.startsWith(`${href}/`)
+  return currentPath === targetPath || currentPath.startsWith(`${targetPath}/`)
 }


### PR DESCRIPTION
## Summary
- add a Revenue Clear shortcut to the main navigation so it appears under Resources ahead of Settings
- normalize the active path helper to ignore query strings and reuse it across the legacy sidebar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efdb43fa8883248b1fa51146c77945