### PR TITLE
feat: add onboarding flow for Revenue Clear clients

### DIFF
--- a/app/revenue-clear/page.tsx
+++ b/app/revenue-clear/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next'
 
 import { ClientSwitcher } from '@/modules/revenue-clear/components/ClientSwitcher'
+import RevenueClearOnboarding from '@/modules/revenue-clear/components/RevenueClearOnboarding'
 import RevenueClearShell from '@/modules/revenue-clear/components/RevenueClearShell'
 import {
   getRevenueClearSnapshot,
   listRevenueClearClients,
+  listRevenuePipelineOptions,
 } from '@/modules/revenue-clear/lib/queries'
 
 const STAGES = [
@@ -97,16 +99,8 @@ export default async function RevenueClearPage({ searchParams }: RevenueClearPag
   const clients = await listRevenueClearClients()
 
   if (!clients.length) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#0e1018] via-[#121526] to-[#0b0d16] px-6 py-10 text-center text-white">
-        <div className="max-w-xl space-y-4">
-          <h1 className="text-3xl font-semibold">Revenue Clear</h1>
-          <p className="text-sm text-white/70">
-            Add at least one client record in Supabase to activate the guided Revenue Clear workspace.
-          </p>
-        </div>
-      </div>
-    )
+    const pipelineOptions = await listRevenuePipelineOptions()
+    return <RevenueClearOnboarding pipelineOptions={pipelineOptions} />
   }
 
   const requestedClientIdRaw = searchParams?.clientId

--- a/modules/revenue-clear/components/RevenueClearOnboarding.tsx
+++ b/modules/revenue-clear/components/RevenueClearOnboarding.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useEffect, type ReactNode } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+import { useRouter } from 'next/navigation'
+
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Select } from '@/ui/select'
+
+import {
+  convertPipelineOpportunityAction,
+  createRevenueClearClientAction,
+  INITIAL_ACTION_STATE,
+  type ActionState,
+} from '../lib/actions'
+import type { RevenuePipelineOption } from '../lib/queries'
+
+const PIPELINE_STAGE_OPTIONS = ['Prospect', 'Qualify', 'Proposal', 'Negotiation', 'ClosedWon'] as const
+
+function formatCurrency(value: number | null | undefined) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return ''
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+type RevenueClearOnboardingProps = {
+  pipelineOptions: RevenuePipelineOption[]
+}
+
+type SubmitButtonProps = {
+  children: ReactNode
+  className?: string
+  disabled?: boolean
+}
+
+function SubmitButton({ children, className, disabled = false }: SubmitButtonProps) {
+  const { pending } = useFormStatus()
+  const isDisabled = pending || disabled
+
+  return (
+    <Button type="submit" disabled={isDisabled} className={className}>
+      {pending ? 'Working…' : children}
+    </Button>
+  )
+}
+
+export default function RevenueClearOnboarding({ pipelineOptions }: RevenueClearOnboardingProps) {
+  const router = useRouter()
+  const [convertState, convertAction] = useFormState<ActionState, FormData>(
+    convertPipelineOpportunityAction,
+    INITIAL_ACTION_STATE,
+  )
+  const [createState, createAction] = useFormState<ActionState, FormData>(
+    createRevenueClearClientAction,
+    INITIAL_ACTION_STATE,
+  )
+
+  useEffect(() => {
+    if (convertState.status === 'success' && convertState.redirectUrl) {
+      router.replace(convertState.redirectUrl)
+    }
+  }, [convertState, router])
+
+  useEffect(() => {
+    if (createState.status === 'success' && createState.redirectUrl) {
+      router.replace(createState.redirectUrl)
+    }
+  }, [createState, router])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#0e1018] via-[#121526] to-[#0b0d16] px-6 py-12 text-white">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
+        <header className="space-y-3 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">Revenue Clear</p>
+          <h1 className="text-3xl font-semibold">Choose how you want to start</h1>
+          <p className="mx-auto max-w-3xl text-sm text-white/70">
+            Load an existing company from your revenue pipeline or create a new client. We will handle the Supabase records and
+            attach them to the pipeline automatically so you can move straight into the workflow.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <form
+            action={convertAction}
+            className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_0_60px_-25px_rgba(59,130,246,0.65)]"
+          >
+            <div>
+              <h2 className="text-lg font-semibold text-white">Use a pipeline company</h2>
+              <p className="mt-1 text-xs text-white/70">
+                Promote an existing opportunity into Revenue Clear. Selecting one will link or create the client record for you.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="opportunityId" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                Pipeline opportunity
+              </label>
+              <Select
+                id="opportunityId"
+                name="opportunityId"
+                defaultValue={pipelineOptions.length ? pipelineOptions[0]?.id : ''}
+                disabled={!pipelineOptions.length}
+                className="bg-[#0b1120] text-white"
+              >
+                {pipelineOptions.length ? (
+                  pipelineOptions.map((option) => {
+                    const formattedAmount = formatCurrency(option.amount)
+                    return (
+                      <option key={option.id} value={option.id} className="bg-[#0b1120] text-white">
+                        {option.label}
+                        {option.stage ? ` · ${option.stage}` : ''}
+                        {formattedAmount ? ` · ${formattedAmount}` : ''}
+                      </option>
+                    )
+                  })
+                ) : (
+                  <option value="" disabled>
+                    No active opportunities available
+                  </option>
+                )}
+              </Select>
+            </div>
+
+            {convertState.status === 'error' ? (
+              <p className="rounded-md border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-100">
+                {convertState.error}
+              </p>
+            ) : null}
+
+            <SubmitButton className="mt-auto" disabled={!pipelineOptions.length}>
+              {pipelineOptions.length ? 'Load from pipeline' : 'Pipeline empty'}
+            </SubmitButton>
+          </form>
+
+          <form
+            action={createAction}
+            className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-[#090b14] p-6 shadow-[0_0_60px_-25px_rgba(59,130,246,0.35)]"
+          >
+            <div>
+              <h2 className="text-lg font-semibold text-white">Start with a new client</h2>
+              <p className="mt-1 text-xs text-white/70">
+                Create a fresh client record and add it to your pipeline with the stage and value you expect.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="name" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                Client name
+              </label>
+              <Input id="name" name="name" placeholder="Acme Corp" required className="bg-white/90 text-black" />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="industry" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                Industry (optional)
+              </label>
+              <Input id="industry" name="industry" placeholder="B2B SaaS" className="bg-white/90 text-black" />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="stage" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                  Pipeline stage
+                </label>
+                <Select id="stage" name="stage" defaultValue="Prospect" className="bg-white/90 text-black">
+                  {PIPELINE_STAGE_OPTIONS.map((option) => (
+                    <option key={option} value={option} className="text-black">
+                      {option}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label htmlFor="dealValue" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                  Deal value ($)
+                </label>
+                <Input
+                  id="dealValue"
+                  name="dealValue"
+                  type="number"
+                  step="1000"
+                  min="0"
+                  placeholder="25000"
+                  className="bg-white/90 text-black"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="nextStep" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
+                Next step (optional)
+              </label>
+              <Input
+                id="nextStep"
+                name="nextStep"
+                placeholder="Book Revenue Clear kickoff"
+                className="bg-white/90 text-black"
+              />
+            </div>
+
+            {createState.status === 'error' ? (
+              <p className="rounded-md border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-100">
+                {createState.error}
+              </p>
+            ) : null}
+
+            <SubmitButton className="mt-auto">Create client &amp; continue</SubmitButton>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/modules/revenue-clear/lib/actions.ts
+++ b/modules/revenue-clear/lib/actions.ts
@@ -1,0 +1,177 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { requireAuth } from '@/lib/server/auth'
+
+const STAGE_PROBABILITIES: Record<string, number> = {
+  Prospect: 10,
+  Qualify: 25,
+  Proposal: 50,
+  Negotiation: 75,
+  ClosedWon: 100,
+  ClosedLost: 0,
+}
+
+export type ActionState = {
+  status: 'idle' | 'success' | 'error'
+  error?: string
+  redirectUrl?: string
+}
+
+export const INITIAL_ACTION_STATE: ActionState = { status: 'idle' }
+
+function parseAmount(raw: FormDataEntryValue | null): number {
+  if (!raw) return 0
+  if (typeof raw !== 'string') return 0
+  const normalized = raw.replace(/[$,\s]/g, '')
+  const parsed = Number.parseFloat(normalized)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function resolveProbability(stage: string | null | undefined, fallback?: number | null): number {
+  if (!stage) return fallback ?? 10
+  return STAGE_PROBABILITIES[stage] ?? fallback ?? 10
+}
+
+export async function convertPipelineOpportunityAction(
+  _prev: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const opportunityId = formData.get('opportunityId')
+
+  if (!opportunityId || typeof opportunityId !== 'string') {
+    return { status: 'error', error: 'Select a pipeline opportunity to continue.' }
+  }
+
+  const { supabase, user } = await requireAuth({ redirectTo: `/revenue-clear` })
+
+  const { data: opportunity, error: loadError } = await supabase
+    .from('opportunities')
+    .select('id, name, client_id, stage, amount, probability, owner_id')
+    .eq('id', opportunityId)
+    .maybeSingle()
+
+  if (loadError) {
+    console.error('revenue-clear:onboarding.load-opportunity', loadError)
+    return { status: 'error', error: 'Failed to load the pipeline record. Try again.' }
+  }
+
+  if (!opportunity) {
+    return { status: 'error', error: 'The selected pipeline record no longer exists.' }
+  }
+
+  let clientId = opportunity.client_id as string | null
+
+  if (!clientId) {
+    const { data: insertedClient, error: insertError } = await supabase
+      .from('clients')
+      .insert({
+        name: opportunity.name,
+        owner_id: user.id,
+        phase: 'Discovery',
+        status: 'active',
+      })
+      .select('id')
+      .single()
+
+    if (insertError || !insertedClient) {
+      console.error('revenue-clear:onboarding.create-client', insertError)
+      return { status: 'error', error: 'Unable to promote the pipeline record into a client.' }
+    }
+
+    clientId = insertedClient.id
+
+    const probability = resolveProbability(opportunity.stage, opportunity.probability)
+
+    const { error: updateOpportunityError } = await supabase
+      .from('opportunities')
+      .update({
+        client_id: clientId,
+        probability,
+        owner_id: opportunity.owner_id ?? user.id,
+      })
+      .eq('id', opportunity.id)
+
+    if (updateOpportunityError) {
+      console.error('revenue-clear:onboarding.update-opportunity', updateOpportunityError)
+      return {
+        status: 'error',
+        error: 'Client created, but the pipeline record could not be updated. Refresh and try again.',
+      }
+    }
+  }
+
+  await Promise.all([
+    revalidatePath('/pipeline'),
+    revalidatePath('/clients'),
+    revalidatePath('/revenue-clear'),
+  ])
+
+  return { status: 'success', redirectUrl: `/revenue-clear?clientId=${clientId}` }
+}
+
+export async function createRevenueClearClientAction(
+  _prev: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const name = formData.get('name')
+  const industryRaw = formData.get('industry')
+  const stageRaw = formData.get('stage')
+  const dealValue = parseAmount(formData.get('dealValue'))
+  const nextStep = formData.get('nextStep')
+
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return { status: 'error', error: 'Enter a client name to begin.' }
+  }
+
+  const stage = typeof stageRaw === 'string' && stageRaw ? stageRaw : 'Prospect'
+  const probability = resolveProbability(stage, null)
+
+  const { supabase, user } = await requireAuth({ redirectTo: `/revenue-clear` })
+
+  const { data: client, error: clientError } = await supabase
+    .from('clients')
+    .insert({
+      name: name.trim(),
+      owner_id: user.id,
+      phase: 'Discovery',
+      status: 'active',
+      industry: typeof industryRaw === 'string' && industryRaw.trim() ? industryRaw.trim() : null,
+    })
+    .select('id')
+    .single()
+
+  if (clientError || !client) {
+    console.error('revenue-clear:onboarding.insert-client', clientError)
+    return { status: 'error', error: 'Unable to create the client. Try again in a moment.' }
+  }
+
+  const opportunityName = `${name.toString().trim()} • Revenue Clear`
+
+  const { error: opportunityError } = await supabase.from('opportunities').insert({
+    client_id: client.id,
+    name: opportunityName,
+    amount: dealValue,
+    stage,
+    probability,
+    owner_id: user.id,
+    next_step: typeof nextStep === 'string' && nextStep.trim() ? nextStep.trim() : 'Launch Revenue Clear intake',
+  })
+
+  if (opportunityError) {
+    console.error('revenue-clear:onboarding.insert-opportunity', opportunityError)
+    return {
+      status: 'error',
+      error: 'Client created, but adding them to the pipeline failed. Refresh and try again.',
+    }
+  }
+
+  await Promise.all([
+    revalidatePath('/pipeline'),
+    revalidatePath('/clients'),
+    revalidatePath('/revenue-clear'),
+  ])
+
+  return { status: 'success', redirectUrl: `/revenue-clear?clientId=${client.id}` }
+}


### PR DESCRIPTION
## Summary
- replace the empty-state block with a Revenue Clear onboarding experience
- add server actions to promote pipeline opportunities or create new clients and attach them to the pipeline
- load pipeline opportunity options for selection when no Revenue Clear client exists

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efe6affaf083249bd768789d125085