### PR TITLE
feat: refine Revenue Clear workflow shell

### DIFF
--- a/modules/revenue-clear/components/ProgressStepper.tsx
+++ b/modules/revenue-clear/components/ProgressStepper.tsx
@@ -23,11 +23,17 @@ type ProgressStepperProps = {
   items: StepperItem[]
   active: RevenueClearStageKey
   onSelect?: (key: RevenueClearStageKey) => void
+  className?: string
 }
 
-export function ProgressStepper({ items, active, onSelect }: ProgressStepperProps) {
+export function ProgressStepper({ items, active, onSelect, className }: ProgressStepperProps) {
   return (
-    <nav className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-border)] bg-white p-4 shadow-sm">
+    <nav
+      className={cn(
+        'flex flex-col gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/95 p-4 shadow-sm supports-[backdrop-filter]:bg-[color:var(--color-surface)]/80',
+        className,
+      )}
+    >
       <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-muted)]">
         Revenue Clear Workflow
       </h2>


### PR DESCRIPTION
## Summary
- pad Blueprint interventions and RevBoard metrics with sensible defaults and stricter autosave sanitization
- pin the Revenue Clear stepper and tabs at the top of the workspace with refreshed surface styling
- allow ProgressStepper styling overrides to integrate with the pinned navigation header

## Testing
- pnpm lint *(warns about the local TypeScript version)*

------
https://chatgpt.com/codex/tasks/task_e_68f0393a458c8324b26e340d3293b366