### PR TITLE
fix: adjust revenue clear button props

### DIFF
--- a/components/resources/RevenueClearInteractiveModel.tsx
+++ b/components/resources/RevenueClearInteractiveModel.tsx
@@ -341,7 +341,7 @@ export default function RevenueClearInteractiveModel() {
               <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-500">
                 Launch the module
               </span>
-              <Button asChild size="md" className="w-full">
+              <Button asChild className="w-full">
                 <Link href="/revenue-clear">Open Revenue Clear workspace</Link>
               </Button>
               <p className="text-xs text-gray-500">


### PR DESCRIPTION
## Summary
- rely on the default medium sizing for the Revenue Clear CTA button to avoid invalid props during the Netlify build

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f042b4ea848324ae525f68b0956808