### PR TITLE
feat: allow revenue clear to start without onboarding

### DIFF
--- a/app/revenue-clear/new-client/page.tsx
+++ b/app/revenue-clear/new-client/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+import RevenueClearOnboarding from '@/modules/revenue-clear/components/RevenueClearOnboarding'
+import { listRevenuePipelineOptions } from '@/modules/revenue-clear/lib/queries'
+
+export const metadata: Metadata = {
+  title: 'Create Revenue Clear Client | TRS RevOS',
+  description: 'Promote a pipeline opportunity or add a new client to launch the Revenue Clear workflow.',
+}
+
+export default async function RevenueClearNewClientPage() {
+  const pipelineOptions = await listRevenuePipelineOptions()
+
+  return <RevenueClearOnboarding pipelineOptions={pipelineOptions} />
+}

--- a/app/revenue-clear/page.tsx
+++ b/app/revenue-clear/page.tsx
@@ -1,14 +1,16 @@
 import type { Metadata } from 'next'
 
+import Link from 'next/link'
+
 import { ClientSwitcher } from '@/modules/revenue-clear/components/ClientSwitcher'
-import RevenueClearOnboarding from '@/modules/revenue-clear/components/RevenueClearOnboarding'
 import RevenueClearShell from '@/modules/revenue-clear/components/RevenueClearShell'
 import {
   getRevenueClearSnapshot,
+  createRevenueClearDemoClient,
   listRevenueClearClients,
-  listRevenuePipelineOptions,
 } from '@/modules/revenue-clear/lib/queries'
 import { PageTemplate } from '@/components/layout/PageTemplate'
+import { Button } from '@/ui/button'
 import { Badge } from '@/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
 
@@ -99,11 +101,45 @@ function formatPercent(value: number | null | undefined) {
 }
 
 export default async function RevenueClearPage({ searchParams }: RevenueClearPageProps) {
-  const clients = await listRevenueClearClients()
+  let clients = await listRevenueClearClients()
 
   if (!clients.length) {
-    const pipelineOptions = await listRevenuePipelineOptions()
-    return <RevenueClearOnboarding pipelineOptions={pipelineOptions} />
+    const demoClient = await createRevenueClearDemoClient()
+
+    if (demoClient) {
+      clients = [demoClient]
+    } else {
+      clients = await listRevenueClearClients()
+    }
+  }
+
+  if (!clients.length) {
+    return (
+      <PageTemplate
+        title="Revenue Clear"
+        description="Guide revenue clarity engagements with autosave, Supabase persistence, and AI co-pilots."
+        actions={
+          <Button asChild variant="outline">
+            <Link href="/revenue-clear/new-client">+ New client</Link>
+          </Button>
+        }
+        badges={[{ label: 'Supabase workflow' }, { label: 'AI automations' }]}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Set up your first client</CardTitle>
+            <CardDescription>
+              We couldn’t create the demo client automatically. Use the new client flow to get started.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-[color:var(--color-text-muted)]">
+              Launch the workflow by adding a client. You can return here anytime to manage Revenue Clear engagements.
+            </p>
+          </CardContent>
+        </Card>
+      </PageTemplate>
+    )
   }
 
   const requestedClientIdRaw = searchParams?.clientId

--- a/modules/revenue-clear/components/ClientSwitcher.tsx
+++ b/modules/revenue-clear/components/ClientSwitcher.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import Link from 'next/link'
 import { useTransition, type ChangeEvent } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
+import { Button } from '@/ui/button'
 import { Select } from '@/ui/select'
 
 export type ClientSwitcherOption = {
@@ -34,16 +36,23 @@ export function ClientSwitcher({ clients, activeClientId }: ClientSwitcherProps)
   }
 
   return (
-    <div className="flex w-full flex-col gap-2 rounded-lg border border-[color:var(--color-border)] bg-white p-4 shadow-sm lg:w-auto">
-      <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-muted)]">
-          Active client
-        </span>
-        {isPending ? (
-          <span className="text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">
-            Updating…
+    <div className="flex w-full flex-col gap-3 rounded-lg border border-[color:var(--color-border)] bg-white p-4 shadow-sm lg:w-auto">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-muted)]">
+            Active client
           </span>
-        ) : null}
+          {isPending ? (
+            <span className="text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]">
+              Updating…
+            </span>
+          ) : null}
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/revenue-clear/new-client" className="no-underline">
+            + New client
+          </Link>
+        </Button>
       </div>
       <Select
         value={activeClientId}

--- a/modules/revenue-clear/lib/queries.ts
+++ b/modules/revenue-clear/lib/queries.ts
@@ -160,6 +160,39 @@ export async function listRevenueClearClients(): Promise<RevenueClearClient[]> {
   return (data ?? []).map(toClient)
 }
 
+export async function createRevenueClearDemoClient(): Promise<RevenueClearClient | null> {
+  const supabase = await createClient()
+
+  const demoPayload = {
+    name: 'Revenue Clear Demo Co.',
+    industry: 'B2B SaaS',
+    revenue_model: 'Subscription',
+    monthly_recurring_revenue: 125_000,
+    profit_margin: 42,
+    target_growth: 18,
+    primary_goal: 'Map revenue leaks and launch interventions.',
+  }
+
+  const { data, error } = await supabase
+    .from('clients')
+    .insert(demoPayload)
+    .select(
+      `id, name, industry, revenue_model, monthly_recurring_revenue, profit_margin, target_growth, primary_goal`,
+    )
+    .single()
+
+  if (error) {
+    console.error('Failed to create Revenue Clear demo client:', error)
+    return null
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return toClient(data)
+}
+
 export async function listRevenuePipelineOptions(): Promise<RevenuePipelineOption[]> {
   const supabase = await createClient()
 


### PR DESCRIPTION
## Summary
- auto-create a demo client when the Revenue Clear workspace has no records so the workflow loads immediately
- add a dedicated optional new-client route and expose it from the client switcher for manual onboarding
- keep users unblocked with a graceful fallback message if demo client creation fails

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f0493f4d3c8324ba251693f1e91b7f