### PR TITLE
fix: escape apostrophe in public form message

### DIFF
--- a/app/forms/[formId]/PublicFormClient.tsx
+++ b/app/forms/[formId]/PublicFormClient.tsx
@@ -93,7 +93,7 @@ export default function PublicFormClient({ formConfig }: PublicFormClientProps) 
               Your submission has been received.
             </p>
             <p className="text-sm text-gray-400">
-              We'll review your information and get back to you within 24 hours.
+              We&apos;ll review your information and get back to you within 24 hours.
             </p>
             <p className="mt-6 text-xs text-gray-500">
               Check your email for a confirmation and next steps.


### PR DESCRIPTION
## Summary
- escape the apostrophe in the public form confirmation message to satisfy linting during build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2a3011c3883248932b368f030e287