### PR TITLE
fix: use uuid identifiers for intake submissions

### DIFF
--- a/app/api/forms/submit/route.ts
+++ b/app/api/forms/submit/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { randomUUID } from 'crypto'
 
 // This API endpoint is PUBLIC - no auth required
 // It creates a document in Supabase from form submissions
@@ -54,8 +55,8 @@ export async function POST(request: NextRequest) {
     } - ${clientName}`
 
     // Generate unique IDs
-    const documentId = `form-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-    const projectId = `project-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    const documentId = randomUUID()
+    const projectId = randomUUID()
 
     // Step 1: Create client in clients table
     const { data: client, error: clientError } = await supabase


### PR DESCRIPTION
## Summary
- generate Supabase document and project identifiers with `crypto.randomUUID`
- ensure intake submissions use UUID-compatible values for revos tables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4804b45bc83249d70cbfaa15dbb2d