### PR TITLE
fix: harden intake supabase insert

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,3 +7,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Optional: Service role key (keep this secret, never expose to client)
 # SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Optional: Default owner for clients created from public intake submissions
+# SUPABASE_DEFAULT_CLIENT_OWNER_ID=uuid-of-default-owner

--- a/.env.local.example
+++ b/.env.local.example
@@ -2,11 +2,15 @@
 # Get these values from your Supabase project settings:
 # https://supabase.com/dashboard/project/YOUR-PROJECT-REF/settings/api
 
+# Server components and API routes will also read SUPABASE_URL if exposed only to the backend
 NEXT_PUBLIC_SUPABASE_URL=your-project-url.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Optional: Service role key (keep this secret, never expose to client)
 # SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Optional: Server-only URL for environments that do not expose NEXT_PUBLIC_SUPABASE_URL
+# SUPABASE_URL=your-project-url.supabase.co
 
 # Optional: Default owner for clients created from public intake submissions
 # SUPABASE_DEFAULT_CLIENT_OWNER_ID=uuid-of-default-owner


### PR DESCRIPTION
## Summary
- force the public intake submission handler to run in the Node.js runtime and trim the default client owner id
- sanitize currency inputs before calculating annual revenue for Supabase inserts

## Testing
- pnpm test
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f4804b45bc83249d70cbfaa15dbb2d