### PR TITLE
Handle missing environment credentials in API and Supabase clients

### DIFF
--- a/app/api/brain/chat/route.ts
+++ b/app/api/brain/chat/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
 import OpenAI from 'openai'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+const MISSING_API_KEY_RESPONSE = NextResponse.json(
+  { error: 'OpenAI API key is not configured' },
+  { status: 500 }
+)
 
 const ASSISTANT_ID = 'asst_i5vAHTLNd8ktgpUYPEEzGmDw'
 
 export async function POST(request: NextRequest) {
   try {
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      console.error('OpenAI API key missing during /api/brain/chat invocation')
+      return MISSING_API_KEY_RESPONSE
+    }
+
+    const openai = new OpenAI({
+      apiKey,
+    })
+
     const { message, threadId } = await request.json()
 
     if (!message) {

--- a/app/api/content/generate/route.ts
+++ b/app/api/content/generate/route.ts
@@ -1,12 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import OpenAI from 'openai'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+const MISSING_API_KEY_RESPONSE = NextResponse.json(
+  { error: 'OpenAI API key is not configured' },
+  { status: 500 }
+)
 
 export async function POST(request: NextRequest) {
   try {
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      console.error('OpenAI API key missing during /api/content/generate invocation')
+      return MISSING_API_KEY_RESPONSE
+    }
+
+    const openai = new OpenAI({
+      apiKey,
+    })
+
     const { title, type, instructions, sourceProject } = await request.json()
 
     if (!title || !instructions) {

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -2,6 +2,8 @@ import { getPartners } from "@/core/partners/actions"
 
 import PartnersPageClient from "./PartnersPageClient"
 
+export const dynamic = "force-dynamic"
+
 export default async function PartnersPage() {
   const partners = await getPartners()
 

--- a/hooks/useAgentNotifier.ts
+++ b/hooks/useAgentNotifier.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export type AgentNotification<T = unknown> = {
   message: string;
@@ -34,7 +34,12 @@ export function useAgentNotifier<T = unknown>(options?: UseAgentNotifierOptions<
   }, []);
 
   useEffect(() => {
-    const channel = supabase
+    const client = getSupabaseClient();
+    if (!client) {
+      return;
+    }
+
+    const channel = client
       .channel(`agent-notifier:${userId ?? 'global'}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'agents' }, async (payload) => {
         try {
@@ -83,7 +88,7 @@ export function useAgentNotifier<T = unknown>(options?: UseAgentNotifierOptions<
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      client.removeChannel(channel);
     };
   }, [onNotify, userId]);
 

--- a/hooks/useAnalyticsStream.ts
+++ b/hooks/useAnalyticsStream.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type AsyncState<T> = {
   data: T | null;
@@ -90,7 +90,12 @@ export function useAnalyticsStream<T = unknown>(userId?: string | null): Analyti
 
     fetchAnalytics();
 
-    const channel = supabase
+    const client = getSupabaseClient();
+    if (!client) {
+      return undefined;
+    }
+
+    const channel = client
       .channel(`analytics-stream:${userId}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'analytics_events' }, () => {
         void fetchAnalytics();
@@ -98,7 +103,7 @@ export function useAnalyticsStream<T = unknown>(userId?: string | null): Analyti
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      client.removeChannel(channel);
     };
   }, [fetchAnalytics, userId]);
 

--- a/hooks/useDashboardSync.ts
+++ b/hooks/useDashboardSync.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type AsyncState<T> = {
   data: T | null;
@@ -90,7 +90,12 @@ export function useDashboardSync<T = unknown>(userId?: string | null): Dashboard
 
     refresh();
 
-    const channel = supabase
+    const client = getSupabaseClient();
+    if (!client) {
+      return undefined;
+    }
+
+    const channel = client
       .channel(`dashboard-sync:${userId}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'finance' }, () => {
         void refresh();
@@ -101,7 +106,7 @@ export function useDashboardSync<T = unknown>(userId?: string | null): Dashboard
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      client.removeChannel(channel);
     };
   }, [refresh, userId]);
 

--- a/hooks/useMorningBrief.ts
+++ b/hooks/useMorningBrief.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type AsyncState<T> = {
   data: T | null;
@@ -92,7 +92,12 @@ export function useMorningBrief<T = unknown>(userId?: string | null): MorningBri
 
     fetchBrief();
 
-    const channel = supabase
+    const client = getSupabaseClient();
+    if (!client) {
+      return undefined;
+    }
+
+    const channel = client
       .channel(`morning-brief:${userId}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'finance' }, () => {
         void fetchBrief();
@@ -108,7 +113,7 @@ export function useMorningBrief<T = unknown>(userId?: string | null): MorningBri
 
     return () => {
       window.clearInterval(intervalId);
-      supabase.removeChannel(channel);
+      client.removeChannel(channel);
     };
   }, [fetchBrief, userId]);
 

--- a/lib/server/edgeClient.ts
+++ b/lib/server/edgeClient.ts
@@ -1,20 +1,23 @@
-import { createClient } from '@supabase/supabase-js';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: { persistSession: false }
-});
+function ensureSupabaseEnv() {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase environment variables are not configured')
+  }
+}
 
 async function callEdge<T>(name: string, body?: any): Promise<T> {
+  ensureSupabaseEnv()
+
   const res = await fetch(`${supabaseUrl}/functions/v1/${name}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      apikey: supabaseAnonKey
+      apikey: supabaseAnonKey!,
     },
-    body: body ? JSON.stringify(body) : undefined
-  });
+    body: body ? JSON.stringify(body) : undefined,
+  })
   const data = await res.json();
   if (!res.ok) throw new Error(data.error || `Edge call failed: ${name}`);
   return data;

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,6 +1,21 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+let cachedClient: SupabaseClient | null = null
+
+export const hasSupabaseCredentials = Boolean(supabaseUrl && supabaseAnonKey)
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (cachedClient) {
+    return cachedClient
+  }
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null
+  }
+
+  cachedClient = createClient(supabaseUrl, supabaseAnonKey)
+  return cachedClient
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,8 +5,12 @@ import { cookies, headers } from "next/headers";
 export function getServerSupabase() {
   const cookieStore = cookies();
   const headerStore = headers();
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    throw new Error('Supabase environment variables are not configured');
+  }
   return createServerClient(url, anon, {
     cookies: {
       getAll() {
@@ -23,7 +27,11 @@ export function getServerSupabase() {
 }
 
 export function getBrowserSupabase() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    throw new Error('Supabase environment variables are not configured');
+  }
   return createBrowserClient(url, anon);
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -4,8 +4,12 @@ import { cookies, headers } from 'next/headers'
 export function createServerClient() {
   const cookieStore = cookies()
   const headerStore = headers()
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !anon) {
+    throw new Error('Supabase environment variables are not configured')
+  }
 
   return createSupabaseServerClient(url, anon, {
     cookies: {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,6 +1,1 @@
-import { createClient } from '@supabase/supabase-js';
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+export { getSupabaseClient, hasSupabaseCredentials } from './supabase-client'


### PR DESCRIPTION
## Summary
- guard the OpenAI-backed API routes so they fail fast when `OPENAI_API_KEY` is not configured
- rework Supabase client helpers and consumers to create clients lazily and fall back gracefully when credentials are absent
- force the partners page to render dynamically to avoid prerender failures when cookies are required

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68f5bf9467bc8324b70fdaafcda792db