### PR TITLE
fix: ensure logout clears supabase session

### DIFF
--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+import { createServerClient } from "@/lib/supabase/server"
+
+export async function POST() {
+  const supabase = createServerClient()
+  const { error } = await supabase.auth.signOut()
+
+  if (error) {
+    console.error("Failed to sign out", error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/components/nav/GlobalHeader.tsx
+++ b/components/nav/GlobalHeader.tsx
@@ -1,29 +1,34 @@
 "use client"
 
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Bell, Search } from "lucide-react"
 
-import { createClient } from "@/lib/supabase/client"
-
 export default function GlobalHeader() {
   const router = useRouter()
-  const supabase = useMemo(() => createClient(), [])
   const [isSigningOut, setIsSigningOut] = useState(false)
 
   const handleSignOut = useCallback(async () => {
+    setIsSigningOut(true)
     try {
-      setIsSigningOut(true)
-      const { error } = await supabase.auth.signOut()
-      if (error) {
-        throw error
+      const response = await fetch("/auth/signout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to sign out")
       }
+
       router.replace("/login")
     } catch (error) {
       console.error("Failed to sign out", error)
+    } finally {
       setIsSigningOut(false)
     }
-  }, [router, supabase])
+  }, [router])
 
   return (
     <header className="border-b border-gray-200" style={{ backgroundColor: '#e87b28' }}>


### PR DESCRIPTION
## Summary
- add a dedicated `/auth/signout` route that clears the Supabase session on the server
- update the global header logout button to call the new route and reset its loading state

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f5d0fcf75c8324a74c5f81bcc75413