### PR TITLE
Fix Supabase middleware cookie updates on Netlify

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -15,7 +15,6 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request,
           })


### PR DESCRIPTION
## Summary
- stop mutating the request cookies when Supabase updates session state so the middleware can run on the edge runtime

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f6944433648324969aa36cff75e391