### PR TITLE
Refactor layout system for consistent page framing

### DIFF
--- a/app/brain/BrainPageClient.tsx
+++ b/app/brain/BrainPageClient.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
 import { Input } from '@/ui/input'
 import { Textarea } from '@/ui/textarea'
+import { PageBody, PageHeader } from '@/components/layout/Page'
 
 type SourceCard = {
   id: string
@@ -185,74 +186,67 @@ export default function BrainPageClient() {
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">TRS Brain</h1>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-          Your knowledge layer. Ask about frameworks, past audits, offers, calculators, and SOPs.
-        </p>
-      </div>
+    <PageBody>
+      <PageHeader
+        title="TRS Brain"
+        description="Your knowledge layer. Ask about frameworks, past audits, offers, calculators, and SOPs."
+      />
 
-      <div className="grid gap-6 lg:grid-cols-3">
+      <div className="grid flex-1 gap-6 lg:grid-cols-3">
         {/* Main Chat Area */}
-        <Card className="border-slate-200 dark:border-slate-800 lg:col-span-2">
+        <Card className="flex min-h-[520px] flex-col border-slate-200 dark:border-slate-800 lg:col-span-2">
           <CardHeader className="border-b border-slate-200/60 dark:border-slate-800/60 pb-4">
             <CardTitle className="text-lg font-semibold">Chat</CardTitle>
             <CardDescription>Ask questions, get answers with citations.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4 pt-4">
+          <CardContent className="flex flex-1 flex-col gap-4 pt-4">
             {/* Messages */}
-            <div className="space-y-4 min-h-[400px] max-h-[500px] overflow-y-auto">
+            <div className="flex-1 space-y-4 overflow-y-auto rounded-xl border border-neutral-200/80 bg-white/70 p-4 dark:border-slate-800/60 dark:bg-slate-900/40">
               {messages.length === 0 ? (
-                <div className="flex items-center justify-center h-[400px] text-sm text-slate-500 dark:text-slate-400">
-                  <div className="text-center space-y-2">
-                    <p className="font-medium">No messages yet</p>
-                    <p className="text-xs">Try asking about TRS frameworks, offers, or past audits</p>
-                  </div>
+                <div className="flex h-full flex-col items-center justify-center text-sm text-neutral-500 dark:text-slate-400">
+                  <p className="font-medium">No messages yet</p>
+                  <p className="mt-2 text-xs text-neutral-400 dark:text-slate-500">
+                    Try asking about TRS frameworks, offers, or past audits.
+                  </p>
                 </div>
               ) : (
                 messages.map((message) => (
                   <div
                     key={message.id}
-                    className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                    className={`flex w-full ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
                   >
                     <div
-                      className={`max-w-[80%] rounded-lg p-4 ${
+                      className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-sm ${
                         message.role === 'user'
-                          ? 'bg-blue-600 dark:bg-blue-700 text-white'
-                          : 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100'
+                          ? 'bg-emerald-600 text-white'
+                          : 'bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100'
                       }`}
                     >
-                      {/* Message content with formatting */}
                       {message.role === 'user' ? (
-                        <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+                        <p className="whitespace-pre-wrap">{message.content}</p>
                       ) : (
                         <FormattedText content={message.content} />
                       )}
 
-                      {/* Sources */}
                       {message.sources && message.sources.length > 0 && (
                         <div className="mt-3 space-y-2">
-                          <p className="text-xs font-semibold text-slate-600 dark:text-slate-300">Sources:</p>
+                          <p className="text-xs font-semibold text-neutral-500 dark:text-slate-300">Sources</p>
                           {message.sources.map((source) => (
                             <div
                               key={source.id}
-                              className="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-2 text-xs"
+                              className="rounded-lg border border-neutral-200/70 bg-white/90 p-3 text-xs dark:border-slate-800/70 dark:bg-slate-900/60"
                             >
-                              <div className="flex items-center justify-between">
+                              <div className="flex items-center justify-between gap-4">
                                 <span className="font-medium text-slate-900 dark:text-slate-100">{source.title}</span>
                                 <Badge variant="outline" className="text-[10px]">
                                   {source.type}
                                 </Badge>
                               </div>
-                              <p className="mt-1 text-slate-600 dark:text-slate-400">{source.excerpt}</p>
-                              <div className="mt-1 flex items-center gap-2">
-                                <span className="text-slate-500 dark:text-slate-400">
-                                  Relevance: {Math.round(source.relevance * 100)}%
-                                </span>
+                              <p className="mt-1 text-neutral-600 dark:text-slate-400">{source.excerpt}</p>
+                              <div className="mt-2 flex items-center gap-3 text-[11px] text-neutral-500 dark:text-slate-400">
+                                <span>Relevance: {Math.round(source.relevance * 100)}%</span>
                                 {source.url && (
-                                  <a href={source.url} className="text-blue-600 dark:text-blue-400 hover:underline">
+                                  <a href={source.url} className="font-medium text-emerald-600 hover:underline dark:text-emerald-400">
                                     View →
                                   </a>
                                 )}
@@ -262,7 +256,6 @@ export default function BrainPageClient() {
                         </div>
                       )}
 
-                      {/* Copy button for assistant messages */}
                       {message.role === 'assistant' && (
                         <div className="mt-3 flex items-center gap-2">
                           <Button
@@ -273,12 +266,12 @@ export default function BrainPageClient() {
                           >
                             {copiedMessageId === message.id ? (
                               <>
-                                <Check className="h-3 w-3 mr-1" />
+                                <Check className="mr-1 h-3 w-3" />
                                 Copied
                               </>
                             ) : (
                               <>
-                                <Copy className="h-3 w-3 mr-1" />
+                                <Copy className="mr-1 h-3 w-3" />
                                 Copy
                               </>
                             )}
@@ -286,7 +279,7 @@ export default function BrainPageClient() {
                         </div>
                       )}
 
-                      <p className="mt-2 text-[10px] opacity-70 suppress-hydration-warning">
+                      <p className="mt-2 text-[10px] text-neutral-400 dark:text-slate-500">
                         {message.timestamp.toLocaleTimeString()}
                       </p>
                     </div>
@@ -294,14 +287,13 @@ export default function BrainPageClient() {
                 ))
               )}
 
-              {/* Loading indicator */}
               {isLoading && (
                 <div className="flex justify-start">
-                  <div className="max-w-[80%] rounded-lg bg-slate-100 dark:bg-slate-800 p-4">
+                  <div className="max-w-[80%] rounded-2xl bg-white/80 p-4 shadow-sm dark:bg-slate-800/80">
                     <div className="flex items-center gap-2">
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-slate-400 dark:bg-slate-500"></div>
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-slate-400 dark:bg-slate-500 delay-100"></div>
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-slate-400 dark:bg-slate-500 delay-200"></div>
+                      <div className="h-2 w-2 animate-bounce rounded-full bg-neutral-400 dark:bg-slate-500"></div>
+                      <div className="h-2 w-2 animate-bounce rounded-full bg-neutral-400 dark:bg-slate-500 delay-100"></div>
+                      <div className="h-2 w-2 animate-bounce rounded-full bg-neutral-400 dark:bg-slate-500 delay-200"></div>
                     </div>
                   </div>
                 </div>
@@ -405,6 +397,6 @@ export default function BrainPageClient() {
           </Card>
         </div>
       </div>
-    </div>
+    </PageBody>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,11 +18,11 @@ type RootLayoutProps = {
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
-    <html lang="en" suppressHydrationWarning style={{ margin: 0, padding: 0, width: '100%' }}>
-      <body className="min-h-screen bg-background text-foreground" style={{ margin: 0, padding: 0, width: '100%' }}>
+    <html lang="en" suppressHydrationWarning className="h-full">
+      <body className="flex min-h-screen flex-col bg-neutral-50 text-slate-900 antialiased">
         <ThemeProvider defaultTheme="system" storageKey="trs-theme">
           <RevosDataProvider>
-            <Suspense fallback={<div className="min-h-screen bg-background" />}>
+            <Suspense fallback={<div className="min-h-screen bg-neutral-50" />}>
               <AppShell>{children}</AppShell>
             </Suspense>
           </RevosDataProvider>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import * as Icons from 'lucide-react'
@@ -8,21 +8,20 @@ import * as Icons from 'lucide-react'
 import { useRevosData } from '@/app/providers/RevosDataProvider'
 import { MAIN_NAV } from '@/lib/navigation'
 import { cn } from '@/lib/utils'
-import { Badge } from '@/ui/badge'
 import { Button } from '@/ui/button'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import GlobalSearch from '@/components/search/GlobalSearch'
 import MobileBottomNav from '@/components/layout/MobileBottomNav'
+import { PageContainer } from '@/components/layout/Page'
+
+const containerClass = 'mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8'
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? '/'
   const router = useRouter()
-  const [mobileOpen, setMobileOpen] = useState(false)
   const { projects, documents, automationLogs } = useRevosData()
 
   const handleLogout = async () => {
-    // Clear any auth tokens/session data
-    // For now, just redirect to login
     router.push('/login')
   }
 
@@ -38,7 +37,6 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     }
   }, [projects, documents, automationLogs])
 
-  // Don't show sidebar/header on login page or public forms
   const isLoginPage = pathname === '/login'
   const isPublicFormPage = pathname.startsWith('/forms/')
 
@@ -47,88 +45,110 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-screen bg-[#015e32] dark:bg-[#004d28] text-white" style={{ width: '100vw', margin: 0, padding: 0 }}>
-      {/* Desktop Sidebar - hidden on mobile */}
-      <aside
-        className={cn(
-          'hidden md:block fixed inset-y-0 z-40 w-64 border-r border-gray-700 dark:border-gray-700 bg-[#004d28] dark:bg-[#003320] px-4 py-6 shadow-lg md:static',
-        )}
-        style={{ left: 0, margin: 0 }}
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-[#fd8216]">TRS</p>
-            <p className="text-lg font-semibold text-white">RevOS</p>
+    <div className="flex min-h-screen flex-col bg-neutral-50 text-slate-900">
+      <div className="flex flex-1">
+        <aside className="relative hidden w-64 flex-col border-r border-neutral-200 bg-white/80 backdrop-blur md:flex">
+          <div className="flex h-16 items-center border-b border-neutral-200 px-6">
+            <Link href="/" className="flex flex-col">
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">TRS</span>
+              <span className="text-lg font-semibold text-slate-900">RevOS</span>
+            </Link>
           </div>
-        </div>
-        <nav className="mt-6 space-y-1 text-sm">
-          {MAIN_NAV.map((item) => {
-            const Icon = (Icons[item.icon as keyof typeof Icons] ?? Icons.Circle) as Icons.LucideIcon
-            const active = pathname === item.href
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(
-                  'flex items-center gap-3 rounded-lg px-3 py-2 font-medium transition-colors',
-                  active ? 'bg-[#fd8216] text-white shadow-lg shadow-[#fd8216]/30' : 'text-white/80 hover:bg-[#015e32] hover:text-white',
-                )}
-              >
-                <Icon className="h-4 w-4" aria-hidden="true" />
-                <span>{item.label}</span>
-              </Link>
-            )
-          })}
-        </nav>
-      </aside>
 
-      <div className="flex w-full flex-1 flex-col">
-        {/* Desktop Header - hidden on mobile */}
-        <header className="hidden md:flex sticky top-0 z-30 items-center justify-between border-b border-gray-700 bg-[#004d28]/95 backdrop-blur px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div>
-              <p className="text-xs uppercase tracking-widest text-[#fd8216]">Execution Layer</p>
-              <p className="text-base font-semibold text-white">TRS-RevOS</p>
+          <nav className="flex-1 overflow-y-auto px-4 py-6">
+            <ul className="space-y-1 text-sm">
+              {MAIN_NAV.map((item) => {
+                const Icon = (Icons[item.icon as keyof typeof Icons] ?? Icons.Circle) as Icons.LucideIcon
+                const active = pathname === item.href
+
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={cn(
+                        'flex items-center gap-3 rounded-lg px-3 py-2 font-medium transition-colors',
+                        active
+                          ? 'bg-emerald-600 text-white shadow-md shadow-emerald-200/60'
+                          : 'text-neutral-600 hover:bg-neutral-100 hover:text-slate-900',
+                      )}
+                    >
+                      <Icon className="h-4 w-4" aria-hidden="true" />
+                      <span>{item.label}</span>
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+
+          <div className="border-t border-neutral-200 px-6 py-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">Snapshot</p>
+            <dl className="mt-4 space-y-4 text-sm text-neutral-600">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-400">Active projects</dt>
+                <dd className="mt-1 text-lg font-semibold text-slate-900">{kpis.activeProjects}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-400">In-flight deliverables</dt>
+                <dd className="mt-1 text-lg font-semibold text-slate-900">{kpis.deliverablesInProgress}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-400">Automation hours</dt>
+                <dd className="mt-1 text-lg font-semibold text-slate-900">{kpis.automationHours}</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+
+        <div className="flex flex-1 flex-col">
+          <header className="sticky top-0 z-40 border-b border-neutral-200 bg-white/80 backdrop-blur">
+            <div className={cn('flex h-16 items-center justify-between gap-4', containerClass)}>
+              <div className="flex items-center gap-3">
+                <Link href="/" className="flex flex-col">
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">TRS</span>
+                  <span className="text-base font-semibold text-slate-900">RevOS</span>
+                </Link>
+                <span className="hidden text-sm font-medium text-neutral-400 md:inline-flex">Execution Layer</span>
+              </div>
+              <div className="flex items-center gap-2 md:gap-3">
+                <div className="hidden md:flex">
+                  <GlobalSearch />
+                </div>
+                <ThemeToggle />
+                <Button
+                  onClick={handleLogout}
+                  variant="outline"
+                  size="sm"
+                  className="hidden border-neutral-200 text-slate-600 hover:bg-neutral-100 md:inline-flex"
+                >
+                  <Icons.LogOut className="mr-2 h-4 w-4" />
+                  Logout
+                </Button>
+              </div>
             </div>
-          </div>
-          <div className="flex items-center gap-3 text-xs">
-            <GlobalSearch />
-            <Button
-              onClick={handleLogout}
-              variant="outline"
-              size="sm"
-              className="border-[#fd8216] text-white hover:bg-[#fd8216] hover:text-white"
-            >
-              <Icons.LogOut className="h-4 w-4 mr-2" />
-              Logout
-            </Button>
-          </div>
-        </header>
+            <div className={cn('flex items-center justify-between gap-3 border-t border-neutral-200 py-3 md:hidden', containerClass)}>
+              <GlobalSearch />
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+                <Button
+                  onClick={handleLogout}
+                  variant="ghost"
+                  size="icon"
+                  className="text-slate-500 hover:text-slate-900"
+                >
+                  <Icons.LogOut className="h-5 w-5" />
+                  <span className="sr-only">Logout</span>
+                </Button>
+              </div>
+            </div>
+          </header>
 
-        {/* Mobile Header - only shown on mobile */}
-        <header className="md:hidden sticky top-0 z-30 flex items-center justify-between border-b-2 border-[#fd8216] bg-[#004d28] backdrop-blur px-4 py-3">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-[#fd8216]">TRS</p>
-            <p className="text-base font-semibold text-white">RevOS</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <GlobalSearch />
-            <Button
-              onClick={handleLogout}
-              variant="ghost"
-              size="sm"
-              className="text-white hover:bg-[#fd8216] hover:text-white p-2"
-            >
-              <Icons.LogOut className="h-4 w-4" />
-            </Button>
-          </div>
-        </header>
+          <main className="flex-1">
+            <PageContainer className="pb-32 md:pb-12">{children}</PageContainer>
+          </main>
 
-        {/* Main Content - extra padding on mobile for bottom nav */}
-        <main className="flex-1 px-3 sm:px-4 md:px-6 pb-20 md:pb-8 pt-4 md:pt-8">{children}</main>
-
-        {/* Mobile Bottom Navigation */}
-        <MobileBottomNav />
+          <MobileBottomNav />
+        </div>
       </div>
     </div>
   )

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -37,8 +37,8 @@ export default function MobileBottomNav() {
   const pathname = usePathname() ?? '/'
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-[#004d28] border-t-2 border-[#fd8216] md:hidden safe-area-bottom">
-      <div className="grid grid-cols-5 h-16">
+    <nav className="safe-area-bottom fixed bottom-0 left-0 right-0 z-50 border-t border-neutral-200 bg-white/90 backdrop-blur md:hidden">
+      <div className="grid h-16 grid-cols-5">
         {mobileNavItems.map((item) => {
           const Icon = item.icon
           const isActive = pathname === item.href || pathname.startsWith(item.href + '/')
@@ -48,14 +48,14 @@ export default function MobileBottomNav() {
               key={item.href}
               href={item.href}
               className={cn(
-                'flex flex-col items-center justify-center gap-1 transition-all',
+                'flex flex-col items-center justify-center gap-1 text-xs font-medium transition-colors',
                 isActive
-                  ? 'bg-[#015e32] text-[#fd8216]'
-                  : 'text-white/70 hover:text-white hover:bg-[#015e32]/50'
+                  ? 'text-emerald-600'
+                  : 'text-neutral-500 hover:text-slate-900'
               )}
             >
-              <Icon className={cn('h-5 w-5', isActive && 'scale-110')} />
-              <span className="text-[10px] font-medium">{item.label}</span>
+              <Icon className={cn('h-5 w-5', isActive ? 'text-emerald-600' : 'text-neutral-400')} />
+              <span className="text-[10px]">{item.label}</span>
             </Link>
           )
         })}

--- a/components/layout/Page.tsx
+++ b/components/layout/Page.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type PageContainerProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function PageContainer({ children, className }: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        'mx-auto flex h-full w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-12 sm:px-6 lg:px-8',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+type PageBodyProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function PageBody({ children, className }: PageBodyProps) {
+  return <div className={cn('flex flex-1 flex-col gap-6', className)}>{children}</div>
+}
+
+type PageHeaderProps = {
+  title: string
+  description?: string
+  actions?: React.ReactNode
+  className?: string
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn('flex flex-wrap items-end justify-between gap-6 border-b border-neutral-200 pb-6', className)}>
+      <div className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-[0.3em] text-neutral-400">ReggieAI</p>
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{title}</h1>
+        {description ? <p className="text-base text-neutral-500">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex items-center gap-3">{actions}</div> : null}
+    </div>
+  )
+}
+

--- a/components/revos/dashboard/DashboardScreen.tsx
+++ b/components/revos/dashboard/DashboardScreen.tsx
@@ -4,11 +4,13 @@ import Link from 'next/link'
 import { useMemo, useEffect, useState } from 'react'
 
 import { useRevosData } from '@/app/providers/RevosDataProvider'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/ui/badge'
 import { Button } from '@/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table'
 import { FileText, Users, Plus, TrendingUp, ArrowUp, ArrowDown, Filter } from 'lucide-react'
+import { PageBody, PageHeader } from '@/components/layout/Page'
 
 type TimePeriod = '7d' | '30d' | '90d' | 'year'
 
@@ -19,6 +21,13 @@ type NewsArticle = {
   publishedAt: string
   source: string
 }
+
+const timePeriodOptions: { label: string; value: TimePeriod }[] = [
+  { label: 'Last 7 Days', value: '7d' },
+  { label: 'Last 30 Days', value: '30d' },
+  { label: 'Last 90 Days', value: '90d' },
+  { label: 'This Year', value: 'year' },
+]
 
 export default function DashboardScreen() {
   const { projects, documents, content } = useRevosData()
@@ -172,35 +181,35 @@ export default function DashboardScreen() {
   }, [projects, documents, content])
 
   return (
-    <div className="space-y-8">
-      {/* Time Period Filter */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Dashboard Overview</h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400">Track your revenue operations metrics</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Filter className="h-4 w-4 text-slate-500" />
-          <div className="flex gap-2">
-            {(['7d', '30d', '90d', 'year'] as TimePeriod[]).map((period) => (
-              <button
-                key={period}
-                onClick={() => setTimePeriod(period)}
-                className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                  timePeriod === period
-                    ? 'bg-[#015e32] text-white'
-                    : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'
-                }`}
-              >
-                {period === '7d' ? 'Last 7 Days' : period === '30d' ? 'Last 30 Days' : period === '90d' ? 'Last 90 Days' : 'This Year'}
-              </button>
-            ))}
+    <PageBody>
+      <PageHeader
+        title="Dashboard overview"
+        description="Track your revenue operations metrics."
+        actions={
+          <div className="flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-4 py-2 shadow-sm">
+            <Filter className="h-4 w-4 text-neutral-400" />
+            <div className="flex items-center gap-1">
+              {timePeriodOptions.map(({ label, value }) => (
+                <button
+                  key={value}
+                  onClick={() => setTimePeriod(value)}
+                  className={cn(
+                    'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                    timePeriod === value
+                      ? 'bg-emerald-600 text-white shadow-sm shadow-emerald-200/60'
+                      : 'text-neutral-500 hover:text-slate-900',
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
-      </div>
+        }
+      />
 
       {/* 6 Enhanced KPI Cards */}
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         <MetricCard
           label="Annual Revenue"
           value={`$${metrics.totalAnnualRevenue.toLocaleString()}`}
@@ -680,7 +689,7 @@ export default function DashboardScreen() {
           </CardContent>
         </Card>
       </section>
-    </div>
+    </PageBody>
   )
 }
 

--- a/ui/card.tsx
+++ b/ui/card.tsx
@@ -7,7 +7,7 @@ export function Card({ className, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        'rounded-xl border border-border bg-card text-card-foreground shadow-sm',
+        'rounded-xl border border-border bg-card text-card-foreground shadow-md shadow-neutral-200/50',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- introduce a shared Page layout utility and update the root shell to center content inside a max width container
- refresh dashboard and brain chat pages to use the new layout primitives with consistent spacing and typography
- soften card styling and mobile navigation to match the neutral visual language across screens

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68f6bc27ac78832482ad49857fabcbfd