### PR TITLE
style: force white text globally

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -148,6 +148,12 @@ body {
     min-height: 100vh;
   }
 
+  body *,
+  body *::before,
+  body *::after {
+    color: rgb(var(--color-foreground)) !important;
+  }
+
   ::selection {
     background: rgba(var(--color-primary), 0.2);
   }


### PR DESCRIPTION
## Summary
- ensure all rendered text inherits the theme foreground color, forcing a white appearance across the app

## Testing
- pnpm dev *(fails: Supabase URL and key env vars required in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6d978a9048324bac736817a7251c6