### PR TITLE
Refactor agents and calculators layout to match clients page

### DIFF
--- a/app/agents/AgentsPageClient.tsx
+++ b/app/agents/AgentsPageClient.tsx
@@ -63,288 +63,301 @@ export default function AgentsPageClient() {
     ['agent-clarity-bot', 'agent-blueprint-engine', 'agent-offer-desk', 'agent-data-gate', 'agent-qra-forecaster', 'agent-revos-orchestrator'].includes(agentId)
 
   return (
-    <div className="space-y-8">
-      <section className="grid gap-4 lg:grid-cols-3">
-        <Card className="lg:col-span-2">
-          <CardHeader className="pb-4">
-            <CardTitle className="text-lg font-semibold">Automation Agents</CardTitle>
-            <CardDescription>Reusable playbooks that orchestrate revenue science tasks.</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4 pt-4 md:grid-cols-2">
-            {agents.map((agent) => {
-              const state = formState[agent.id] ?? { projectId: projects[0]?.id, notes: '', client_name: '', industry: '', monthly_revenue: '', team_size: '' }
-              const isClarity = isClarityBot(agent.id)
-              const isSpecialized = isSpecializedAgent(agent.id)
+    <div className="min-h-screen bg-white text-black">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold text-black">Agents</h1>
+          <p className="text-sm text-gray-600">
+            Reusable playbooks that orchestrate revenue science tasks across every client.
+          </p>
+        </header>
 
-              return (
-                <div
-                  key={agent.id}
-                  className={`flex flex-col rounded-lg border-2 border-[#fd8216] p-4 shadow-sm ${
-                    isSpecialized
-                      ? 'bg-[#004d28]'
-                      : 'bg-[#004d28]'
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-foreground">{agent.name}</p>
-                      <p className="mt-1 text-xs uppercase tracking-widest text-muted-foreground">{agent.category}</p>
-                    </div>
-                    <Badge
-                      variant="outline"
-                      className={isSpecialized ? "border-blue-500 text-blue-700" : "border-emerald-500 text-emerald-600"}
+        <div className="space-y-8">
+          <section className="grid gap-4 lg:grid-cols-3">
+            <Card className="lg:col-span-2">
+              <CardHeader className="pb-4">
+                <CardTitle className="text-lg font-semibold">Automation Agents</CardTitle>
+                <CardDescription>
+                  Launch orchestrated workflows, review inputs, and capture the context agents need to run.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 pt-4 md:grid-cols-2">
+                {agents.map((agent) => {
+                  const state = formState[agent.id] ?? { projectId: projects[0]?.id, notes: '', client_name: '', industry: '', monthly_revenue: '', team_size: '' }
+                  const isClarity = isClarityBot(agent.id)
+                  const isSpecialized = isSpecializedAgent(agent.id)
+
+                  return (
+                    <div
+                      key={agent.id}
+                      className={`flex flex-col rounded-lg border-2 border-[#fd8216] p-4 shadow-sm ${
+                        isSpecialized
+                          ? 'bg-[#004d28]'
+                          : 'bg-[#004d28]'
+                      }`}
                     >
-                      {agent.defaultOutputType}
-                    </Badge>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">{agent.description}</p>
-
-                  <div className="mt-4 space-y-3 text-sm">
-                    {isClarity ? (
-                      // ClarityBot specialized inputs
-                      <>
-                        <div className="space-y-2">
-                          <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Select Project / Client*</label>
-                          <Select
-                            value={state.projectId || projects[0]?.id || ''}
-                            onChange={(event) => {
-                              const selectedProject = projects.find(p => p.id === event.target.value)
-                              setFormState((current) => ({
-                                ...current,
-                                [agent.id]: {
-                                  ...state,
-                                  projectId: event.target.value,
-                                  client_name: selectedProject?.client || '',
-                                  monthly_revenue: selectedProject?.revenueTarget?.toString() || '',
-                                  team_size: selectedProject?.team?.length?.toString() || '',
-                                },
-                              }))
-                            }}
-                            className="border-blue-300 focus:border-blue-500 focus:ring-blue-500"
-                          >
-                            <option value="">Select a project...</option>
-                            {projects.map((project) => (
-                              <option key={project.id} value={project.id}>
-                                {project.name} ({project.client})
-                              </option>
-                            ))}
-                          </Select>
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold text-foreground">{agent.name}</p>
+                          <p className="mt-1 text-xs uppercase tracking-widest text-muted-foreground">{agent.category}</p>
                         </div>
+                        <Badge
+                          variant="outline"
+                          className={isSpecialized ? "border-blue-500 text-blue-700" : "border-emerald-500 text-emerald-600"}
+                        >
+                          {agent.defaultOutputType}
+                        </Badge>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{agent.description}</p>
 
-                        {state.projectId && (() => {
-                          const selectedProject = projects.find(p => p.id === state.projectId)
-                          return selectedProject ? (
-                            <div className="rounded-lg border-2 border-[#fd8216] bg-[#015e32] p-3 text-xs">
-                              <p className="font-semibold text-white">Project Context:</p>
-                              <div className="mt-2 grid grid-cols-2 gap-2 text-white/80">
-                                <div>
-                                  <span className="font-medium">Client:</span> {selectedProject.client}
+                      <div className="mt-4 space-y-3 text-sm">
+                        {isClarity ? (
+                          // ClarityBot specialized inputs
+                          <>
+                            <div className="space-y-2">
+                              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Select Project / Client*</label>
+                              <Select
+                                value={state.projectId || projects[0]?.id || ''}
+                                onChange={(event) => {
+                                  const selectedProject = projects.find(p => p.id === event.target.value)
+                                  setFormState((current) => ({
+                                    ...current,
+                                    [agent.id]: {
+                                      ...state,
+                                      projectId: event.target.value,
+                                      client_name: selectedProject?.client || '',
+                                      monthly_revenue: selectedProject?.revenueTarget?.toString() || '',
+                                      team_size: selectedProject?.team?.length?.toString() || '',
+                                    },
+                                  }))
+                                }}
+                                className="border-blue-300 focus:border-blue-500 focus:ring-blue-500"
+                              >
+                                <option value="">Select a project...</option>
+                                {projects.map((project) => (
+                                  <option key={project.id} value={project.id}>
+                                    {project.name} ({project.client})
+                                  </option>
+                                ))}
+                              </Select>
+                            </div>
+
+                            {state.projectId && (() => {
+                              const selectedProject = projects.find(p => p.id === state.projectId)
+                              return selectedProject ? (
+                                <div className="rounded-lg border-2 border-[#fd8216] bg-[#015e32] p-3 text-xs">
+                                  <p className="font-semibold text-white">Project Context:</p>
+                                  <div className="mt-2 grid grid-cols-2 gap-2 text-white/80">
+                                    <div>
+                                      <span className="font-medium">Client:</span> {selectedProject.client}
+                                    </div>
+                                    <div>
+                                      <span className="font-medium">Type:</span> {selectedProject.type}
+                                    </div>
+                                    <div>
+                                      <span className="font-medium">Revenue:</span> ${(selectedProject.revenueTarget / 1000).toFixed(0)}k
+                                    </div>
+                                    <div>
+                                      <span className="font-medium">Team:</span> {selectedProject.team.length} members
+                                    </div>
+                                  </div>
                                 </div>
-                                <div>
-                                  <span className="font-medium">Type:</span> {selectedProject.type}
-                                </div>
-                                <div>
-                                  <span className="font-medium">Revenue:</span> ${(selectedProject.revenueTarget / 1000).toFixed(0)}k
-                                </div>
-                                <div>
-                                  <span className="font-medium">Team:</span> {selectedProject.team.length} members
-                                </div>
+                              ) : null
+                            })()}
+
+                            <div className="grid grid-cols-2 gap-3">
+                              <div className="space-y-2">
+                                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Industry</label>
+                                <input
+                                  type="text"
+                                  value={state.industry || ''}
+                                  onChange={(event) =>
+                                    setFormState((current) => ({
+                                      ...current,
+                                      [agent.id]: { ...state, industry: event.target.value },
+                                    }))
+                                  }
+                                  placeholder="B2B SaaS"
+                                  className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                  Monthly Revenue
+                                  <span className="ml-1 text-[10px] text-slate-400">(override)</span>
+                                </label>
+                                <input
+                                  type="number"
+                                  value={state.monthly_revenue || ''}
+                                  onChange={(event) =>
+                                    setFormState((current) => ({
+                                      ...current,
+                                      [agent.id]: { ...state, monthly_revenue: event.target.value },
+                                    }))
+                                  }
+                                  placeholder="Auto from project"
+                                  className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                />
                               </div>
                             </div>
-                          ) : null
-                        })()}
 
-                        <div className="grid grid-cols-2 gap-3">
-                          <div className="space-y-2">
-                            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Industry</label>
-                            <input
-                              type="text"
-                              value={state.industry || ''}
-                              onChange={(event) =>
-                                setFormState((current) => ({
-                                  ...current,
-                                  [agent.id]: { ...state, industry: event.target.value },
-                                }))
-                              }
-                              placeholder="B2B SaaS"
-                              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                            />
-                          </div>
-                          <div className="space-y-2">
-                            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                              Monthly Revenue
-                              <span className="ml-1 text-[10px] text-slate-400">(override)</span>
-                            </label>
-                            <input
-                              type="number"
-                              value={state.monthly_revenue || ''}
-                              onChange={(event) =>
-                                setFormState((current) => ({
-                                  ...current,
-                                  [agent.id]: { ...state, monthly_revenue: event.target.value },
-                                }))
-                              }
-                              placeholder="Auto from project"
-                              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                            />
-                          </div>
-                        </div>
-
-                        <div className="space-y-2">
-                          <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Files & Context</label>
-                          <Textarea
-                            value={state.notes}
-                            onChange={(event) =>
-                              setFormState((current) => ({
-                                ...current,
-                                [agent.id]: { ...state, notes: event.target.value },
-                              }))
-                            }
-                            placeholder="Paste data, add context, describe files uploaded..."
-                            rows={3}
-                          />
-                          <p className="text-[10px] text-muted-foreground">Tip: Upload CSV/XLSX exports, CRM data, or paste relevant context</p>
-                        </div>
-                      </>
-                    ) : (
-                      // Standard agent inputs
-                      <>
-                        <div className="space-y-2">
-                          <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Project Context</label>
-                          <Select
-                            value={state.projectId || projects[0]?.id || ''}
-                            onChange={(event) =>
-                              setFormState((current) => ({
-                                ...current,
-                                [agent.id]: { ...state, projectId: event.target.value },
-                              }))
-                            }
-                          >
-                            <option value="">Unassigned</option>
-                            {projects.map((project) => (
-                              <option key={project.id} value={project.id}>
-                                {project.name}
-                              </option>
-                            ))}
-                          </Select>
-                        </div>
-                        <div className="space-y-2">
-                          <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</label>
-                          <Textarea
-                            value={state.notes}
-                            onChange={(event) =>
-                              setFormState((current) => ({
-                                ...current,
-                                [agent.id]: { ...state, notes: event.target.value },
-                              }))
-                            }
-                            placeholder="Add context or desired outcome"
-                            rows={3}
-                          />
-                        </div>
-                      </>
-                    )}
-
-                    <Button
-                      type="button"
-                      onClick={() => handleRun(agent.id)}
-                      className={isSpecialized ? "bg-blue-600 hover:bg-blue-700" : ""}
-                    >
-                      {isClarity ? 'Run Clarity Audit' : isSpecialized ? 'Run Agent' : 'Run Agent'}
-                    </Button>
-                  </div>
-
-                  <details className="mt-4 rounded-lg border-2 border-dashed border-[#fd8216] bg-[#015e32] p-3 text-xs text-white/80">
-                    <summary className="cursor-pointer text-white font-medium">Prompt Blueprint</summary>
-                    <p className="mt-2 whitespace-pre-wrap text-white/70">{agent.prompt}</p>
-                  </details>
-                </div>
-              )
-            })}
-          </CardContent>
-        </Card>
-        <Card className="border-border">
-          <CardHeader className="pb-4">
-            <CardTitle className="text-lg font-semibold">Category Snapshot</CardTitle>
-            <CardDescription>Ensure balanced automation coverage.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3 pt-4 text-sm text-muted-foreground">
-            {Object.entries(categoryBreakdown).map(([category, count]) => (
-              <div key={category} className="flex items-center justify-between rounded-lg border border-border bg-card p-3 shadow-sm">
-                <span className="font-medium text-muted-foreground">{category}</span>
-                <Badge variant="outline" className="border-border text-muted-foreground">
-                  {count}
-                </Badge>
-              </div>
-            ))}
-            <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
-              <p className="text-xs uppercase tracking-widest text-muted-foreground">Total Runs</p>
-              <p className="mt-1 text-2xl font-semibold text-foreground">{automationLogs.length}</p>
-            </div>
-            <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
-              <p className="text-xs uppercase tracking-widest text-muted-foreground">Hours Saved</p>
-              <p className="mt-1 text-2xl font-semibold text-foreground">{(automationLogs.length * 1.5).toFixed(1)}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </section>
-
-      <Card className="border-border">
-        <CardHeader className="pb-4">
-          <CardTitle className="text-lg font-semibold">Automation Activity</CardTitle>
-          <CardDescription>Latest agent executions and outcomes.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-4">
-          {automationLogs.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No automation runs recorded yet.</p>
-          ) : (
-            automationLogs
-              .slice()
-              .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
-              .map((log) => {
-                const agent = agents.find((item) => item.id === log.agentId)
-                const project = log.projectId
-                  ? projects.find((item) => item.id === log.projectId)?.name
-                  : 'Standalone run'
-                const isClarity = agent?.id === 'agent-clarity-bot'
-                const isSpecialized = agent?.id && isSpecializedAgent(agent.id)
-
-                return (
-                  <div
-                    key={log.id}
-                    className="rounded-lg border-2 border-[#fd8216] bg-[#004d28] p-4 shadow-sm"
-                  >
-                    <div className="flex items-center justify-between text-sm font-medium text-foreground">
-                      <div className="flex items-center gap-2">
-                        <span>{agent?.name ?? log.agentId}</span>
-                        {isClarity && (
-                          <Badge variant="outline" className="border-blue-500 text-blue-700 text-[10px]">
-                            AUDIT
-                          </Badge>
+                            <div className="space-y-2">
+                              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Files & Context</label>
+                              <Textarea
+                                value={state.notes}
+                                onChange={(event) =>
+                                  setFormState((current) => ({
+                                    ...current,
+                                    [agent.id]: { ...state, notes: event.target.value },
+                                  }))
+                                }
+                                placeholder="Paste data, add context, describe files uploaded..."
+                                rows={3}
+                              />
+                              <p className="text-[10px] text-muted-foreground">Tip: Upload CSV/XLSX exports, CRM data, or paste relevant context</p>
+                            </div>
+                          </>
+                        ) : (
+                          // Standard agent inputs
+                          <>
+                            <div className="space-y-2">
+                              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Project Context</label>
+                              <Select
+                                value={state.projectId || projects[0]?.id || ''}
+                                onChange={(event) =>
+                                  setFormState((current) => ({
+                                    ...current,
+                                    [agent.id]: { ...state, projectId: event.target.value },
+                                  }))
+                                }
+                              >
+                                <option value="">Unassigned</option>
+                                {projects.map((project) => (
+                                  <option key={project.id} value={project.id}>
+                                    {project.name}
+                                  </option>
+                                ))}
+                              </Select>
+                            </div>
+                            <div className="space-y-2">
+                              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</label>
+                              <Textarea
+                                value={state.notes}
+                                onChange={(event) =>
+                                  setFormState((current) => ({
+                                    ...current,
+                                    [agent.id]: { ...state, notes: event.target.value },
+                                  }))
+                                }
+                                placeholder="Add context or desired outcome"
+                                rows={3}
+                              />
+                            </div>
+                          </>
                         )}
+
+                        <Button
+                          type="button"
+                          onClick={() => handleRun(agent.id)}
+                          className={isSpecialized ? "bg-blue-600 hover:bg-blue-700" : ""}
+                        >
+                          {isClarity ? 'Run Clarity Audit' : isSpecialized ? 'Run Agent' : 'Run Agent'}
+                        </Button>
                       </div>
-                      <span className="text-xs text-muted-foreground suppress-hydration-warning">
-                        {new Date(log.createdAt).toLocaleString()}
-                      </span>
+
+                      <details className="mt-4 rounded-lg border-2 border-dashed border-[#fd8216] bg-[#015e32] p-3 text-xs text-white/80">
+                        <summary className="cursor-pointer text-white font-medium">Prompt Blueprint</summary>
+                        <p className="mt-2 whitespace-pre-wrap text-white/70">{agent.prompt}</p>
+                      </details>
                     </div>
-                    <p className="mt-2 text-sm text-muted-foreground">{log.summary}</p>
-                    <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                      <Badge variant="outline" className="border-border text-muted-foreground">
-                        {project ?? 'Unassigned'}
-                      </Badge>
-                      <Badge
-                        variant="outline"
-                        className={isSpecialized ? 'border-blue-500 text-blue-600' : 'border-emerald-500 text-emerald-600'}
-                      >
-                        {log.outputType}
-                      </Badge>
-                    </div>
+                  )
+                })}
+              </CardContent>
+            </Card>
+            <Card className="border-border">
+              <CardHeader className="pb-4">
+                <CardTitle className="text-lg font-semibold">Category Snapshot</CardTitle>
+                <CardDescription>Ensure balanced automation coverage.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 pt-4 text-sm text-muted-foreground">
+                {Object.entries(categoryBreakdown).map(([category, count]) => (
+                  <div key={category} className="flex items-center justify-between rounded-lg border border-border bg-card p-3 shadow-sm">
+                    <span className="font-medium text-muted-foreground">{category}</span>
+                    <Badge variant="outline" className="border-border text-muted-foreground">
+                      {count}
+                    </Badge>
                   </div>
-                )
-              })
-          )}
-        </CardContent>
-      </Card>
+                ))}
+                <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
+                  <p className="text-xs uppercase tracking-widest text-muted-foreground">Total Runs</p>
+                  <p className="mt-1 text-2xl font-semibold text-foreground">{automationLogs.length}</p>
+                </div>
+                <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
+                  <p className="text-xs uppercase tracking-widest text-muted-foreground">Hours Saved</p>
+                  <p className="mt-1 text-2xl font-semibold text-foreground">{(automationLogs.length * 1.5).toFixed(1)}</p>
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+
+          <Card className="border-border">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-lg font-semibold">Automation Activity</CardTitle>
+              <CardDescription>Latest agent executions and outcomes.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-4">
+              {automationLogs.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No automation runs recorded yet.</p>
+              ) : (
+                automationLogs
+                  .slice()
+                  .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
+                  .map((log) => {
+                    const agent = agents.find((item) => item.id === log.agentId)
+                    const project = log.projectId
+                      ? projects.find((item) => item.id === log.projectId)?.name
+                      : 'Standalone run'
+                    const isClarity = agent?.id === 'agent-clarity-bot'
+                    const isSpecialized = agent?.id && isSpecializedAgent(agent.id)
+
+                    return (
+                      <div
+                        key={log.id}
+                        className="rounded-lg border-2 border-[#fd8216] bg-[#004d28] p-4 shadow-sm"
+                      >
+                        <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                          <div className="flex items-center gap-2">
+                            <span>{agent?.name ?? log.agentId}</span>
+                            {isClarity && (
+                              <Badge variant="outline" className="border-blue-500 text-blue-700 text-[10px]">
+                                AUDIT
+                              </Badge>
+                            )}
+                          </div>
+                          <span className="text-xs text-muted-foreground suppress-hydration-warning">
+                            {new Date(log.createdAt).toLocaleString()}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm text-muted-foreground">{log.summary}</p>
+                        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                          <Badge variant="outline" className="border-border text-muted-foreground">
+                            {project ?? 'Unassigned'}
+                          </Badge>
+                          <Badge
+                            variant="outline"
+                            className={isSpecialized ? 'border-blue-500 text-blue-600' : 'border-emerald-500 text-emerald-600'}
+                          >
+                            {log.outputType}
+                          </Badge>
+                        </div>
+                      </div>
+                    )
+                  })
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/calculators/CalculatorsPageClient.tsx
+++ b/app/calculators/CalculatorsPageClient.tsx
@@ -199,157 +199,168 @@ export default function CalculatorsPageClient() {
   )
 
   return (
-    <div className="space-y-8">
-      {!activeCalculator ? (
-        <section className="grid gap-4 lg:grid-cols-3">
-          <Card className="lg:col-span-2">
-            <CardHeader className="pb-4">
-              <CardTitle className="text-lg font-semibold">Revenue Calculators</CardTitle>
-              <CardDescription>Client-facing and internal calculators for revenue science</CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-4 pt-4 md:grid-cols-2">
-              {filteredCalculators.map((calc) => {
-                const isForm = calc.category === 'forms'
-                const formUrl = isForm ? `/forms/${calc.id.replace('-form', '')}` : null
+    <div className="min-h-screen bg-white text-black">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold text-black">Calculators</h1>
+          <p className="text-sm text-gray-600">
+            Forecast revenue impact, share ROI stories, and prep client forms from one toolkit.
+          </p>
+        </header>
 
-                const cardContent = (
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <p className="text-sm font-semibold text-foreground">{calc.name}</p>
-                        {isForm && <ExternalLink className="h-3 w-3 text-muted-foreground" />}
+        <div className="space-y-8">
+          {!activeCalculator ? (
+            <section className="grid gap-4 lg:grid-cols-3">
+              <Card className="lg:col-span-2">
+                <CardHeader className="pb-4">
+                  <CardTitle className="text-lg font-semibold">Revenue Calculators</CardTitle>
+                  <CardDescription>Client-facing and internal calculators for revenue science</CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4 pt-4 md:grid-cols-2">
+                  {filteredCalculators.map((calc) => {
+                    const isForm = calc.category === 'forms'
+                    const formUrl = isForm ? `/forms/${calc.id.replace('-form', '')}` : null
+
+                    const cardContent = (
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-semibold text-foreground">{calc.name}</p>
+                            {isForm && <ExternalLink className="h-3 w-3 text-muted-foreground" />}
+                          </div>
+                          <p className="mt-1 text-xs uppercase tracking-widest text-muted-foreground">{calc.category}</p>
+                        </div>
+                        <Badge
+                          variant="outline"
+                          className={
+                            calc.category === 'client-facing'
+                              ? 'border-emerald-500 text-emerald-600'
+                              : calc.category === 'forms'
+                              ? 'border-[#fd8216] text-[#fd8216]'
+                              : 'border-blue-500 text-blue-600'
+                          }
+                        >
+                          {calc.category === 'client-facing' ? 'Client' : calc.category === 'forms' ? 'Form' : 'Internal'}
+                        </Badge>
                       </div>
-                      <p className="mt-1 text-xs uppercase tracking-widest text-muted-foreground">{calc.category}</p>
-                    </div>
-                    <Badge
-                      variant="outline"
-                      className={
-                        calc.category === 'client-facing'
-                          ? 'border-emerald-500 text-emerald-600'
-                          : calc.category === 'forms'
-                          ? 'border-[#fd8216] text-[#fd8216]'
-                          : 'border-blue-500 text-blue-600'
-                      }
-                    >
-                      {calc.category === 'client-facing' ? 'Client' : calc.category === 'forms' ? 'Form' : 'Internal'}
-                    </Badge>
-                  </div>
-                )
+                    )
 
-                return isForm && formUrl ? (
-                  <Link
-                    key={calc.id}
-                    href={formUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex cursor-pointer flex-col rounded-lg border border-border bg-card p-4 shadow-sm transition-all hover:border-[#fd8216] hover:shadow-md"
-                  >
-                    {cardContent}
-                    <p className="mt-2 text-sm text-muted-foreground">{calc.description}</p>
-                    <div className="mt-2 text-xs text-muted-foreground">
-                      <span className="font-medium">Used in:</span> {calc.stages}
-                    </div>
-                  </Link>
-                ) : (
+                    return isForm && formUrl ? (
+                      <Link
+                        key={calc.id}
+                        href={formUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex cursor-pointer flex-col rounded-lg border border-border bg-card p-4 shadow-sm transition-all hover:border-[#fd8216] hover:shadow-md"
+                      >
+                        {cardContent}
+                        <p className="mt-2 text-sm text-muted-foreground">{calc.description}</p>
+                        <div className="mt-2 text-xs text-muted-foreground">
+                          <span className="font-medium">Used in:</span> {calc.stages}
+                        </div>
+                      </Link>
+                    ) : (
+                      <div
+                        key={calc.id}
+                        className="flex cursor-pointer flex-col rounded-lg border border-border bg-card p-4 shadow-sm transition-all hover:border-blue-300 hover:shadow-md"
+                        onClick={() => setActiveCalculator(calc.id)}
+                      >
+                        {cardContent}
+                        <p className="mt-2 text-sm text-muted-foreground">{calc.description}</p>
+                        <div className="mt-2 text-xs text-muted-foreground">
+                          <span className="font-medium">Used in:</span> {calc.stages}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </CardContent>
+              </Card>
+
+              <Card className="border-border">
+                <CardHeader className="pb-4">
+                  <CardTitle className="text-lg font-semibold">Category Filter</CardTitle>
+                  <CardDescription>Filter calculators by category</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 pt-4">
                   <div
-                    key={calc.id}
-                    className="flex cursor-pointer flex-col rounded-lg border border-border bg-card p-4 shadow-sm transition-all hover:border-blue-300 hover:shadow-md"
-                    onClick={() => setActiveCalculator(calc.id)}
+                    className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
+                      category === 'all'
+                        ? 'border-[#fd8216] bg-[#015e32] text-white'
+                        : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
+                    }`}
+                    onClick={() => setCategory('all')}
                   >
-                    {cardContent}
-                    <p className="mt-2 text-sm text-muted-foreground">{calc.description}</p>
-                    <div className="mt-2 text-xs text-muted-foreground">
-                      <span className="font-medium">Used in:</span> {calc.stages}
-                    </div>
+                    <p className={`text-sm font-medium ${category === 'all' ? 'text-white' : 'text-white'}`}>All Calculators</p>
+                    <p className={`mt-1 text-xs ${category === 'all' ? 'text-white/80' : 'text-white/70'}`}>{calculators.length} calculators</p>
                   </div>
-                )
-              })}
-            </CardContent>
-          </Card>
 
-          <Card className="border-border">
-            <CardHeader className="pb-4">
-              <CardTitle className="text-lg font-semibold">Category Filter</CardTitle>
-              <CardDescription>Filter calculators by category</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 pt-4">
-              <div
-                className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
-                  category === 'all'
-                    ? 'border-[#fd8216] bg-[#015e32] text-white'
-                    : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
-                }`}
-                onClick={() => setCategory('all')}
-              >
-                <p className={`text-sm font-medium ${category === 'all' ? 'text-white' : 'text-white'}`}>All Calculators</p>
-                <p className={`mt-1 text-xs ${category === 'all' ? 'text-white/80' : 'text-white/70'}`}>{calculators.length} calculators</p>
-              </div>
+                  <div
+                    className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
+                      category === 'client-facing'
+                        ? 'border-[#fd8216] bg-[#015e32] text-white'
+                        : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
+                    }`}
+                    onClick={() => setCategory('client-facing')}
+                  >
+                    <p className={`text-sm font-medium ${category === 'client-facing' ? 'text-white' : 'text-white'}`}>Client-Facing</p>
+                    <p className={`mt-1 text-xs ${category === 'client-facing' ? 'text-white/80' : 'text-white/70'}`}>
+                      {calculators.filter((c) => c.category === 'client-facing').length} calculators
+                    </p>
+                  </div>
 
-              <div
-                className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
-                  category === 'client-facing'
-                    ? 'border-[#fd8216] bg-[#015e32] text-white'
-                    : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
-                }`}
-                onClick={() => setCategory('client-facing')}
-              >
-                <p className={`text-sm font-medium ${category === 'client-facing' ? 'text-white' : 'text-white'}`}>Client-Facing</p>
-                <p className={`mt-1 text-xs ${category === 'client-facing' ? 'text-white/80' : 'text-white/70'}`}>
-                  {calculators.filter((c) => c.category === 'client-facing').length} calculators
-                </p>
-              </div>
+                  <div
+                    className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
+                      category === 'internal'
+                        ? 'border-[#fd8216] bg-[#015e32] text-white'
+                        : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
+                    }`}
+                    onClick={() => setCategory('internal')}
+                  >
+                    <p className={`text-sm font-medium ${category === 'internal' ? 'text-white' : 'text-white'}`}>Internal TRS</p>
+                    <p className={`mt-1 text-xs ${category === 'internal' ? 'text-white/80' : 'text-white/70'}`}>
+                      {calculators.filter((c) => c.category === 'internal').length} calculators
+                    </p>
+                  </div>
 
-              <div
-                className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
-                  category === 'internal'
-                    ? 'border-[#fd8216] bg-[#015e32] text-white'
-                    : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
-                }`}
-                onClick={() => setCategory('internal')}
+                  <div
+                    className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
+                      category === 'forms'
+                        ? 'border-[#fd8216] bg-[#015e32] text-white'
+                        : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
+                    }`}
+                    onClick={() => setCategory('forms')}
+                  >
+                    <p className={`text-sm font-medium ${category === 'forms' ? 'text-white' : 'text-white'}`}>Client Forms</p>
+                    <p className={`mt-1 text-xs ${category === 'forms' ? 'text-white/80' : 'text-white/70'}`}>
+                      {calculators.filter((c) => c.category === 'forms').length} forms
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+          ) : (
+            <div className="space-y-6">
+              <Button
+                variant="outline"
+                onClick={() => setActiveCalculator(null)}
+                className="w-fit"
               >
-                <p className={`text-sm font-medium ${category === 'internal' ? 'text-white' : 'text-white'}`}>Internal TRS</p>
-                <p className={`mt-1 text-xs ${category === 'internal' ? 'text-white/80' : 'text-white/70'}`}>
-                  {calculators.filter((c) => c.category === 'internal').length} calculators
-                </p>
-              </div>
-
-              <div
-                className={`cursor-pointer rounded-lg border-2 p-3 transition-all ${
-                  category === 'forms'
-                    ? 'border-[#fd8216] bg-[#015e32] text-white'
-                    : 'border-[#fd8216] bg-[#004d28] hover:bg-[#015e32]'
-                }`}
-                onClick={() => setCategory('forms')}
-              >
-                <p className={`text-sm font-medium ${category === 'forms' ? 'text-white' : 'text-white'}`}>Client Forms</p>
-                <p className={`mt-1 text-xs ${category === 'forms' ? 'text-white/80' : 'text-white/70'}`}>
-                  {calculators.filter((c) => c.category === 'forms').length} forms
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </section>
-      ) : (
-        <div>
-          <Button
-            variant="outline"
-            onClick={() => setActiveCalculator(null)}
-            className="mb-4"
-          >
-            ← Back to All Calculators
-          </Button>
-          {activeCalculator === 'audit-roi' && <AuditROICalculator />}
-          {activeCalculator === 'pricing-scenario' && <PricingScenarioCalculator />}
-          {activeCalculator === 'activation-funnel' && <ActivationFunnelCalculator />}
-          {activeCalculator === 'retention-ltv' && <RetentionLTVCalculator />}
-          {activeCalculator === 'cac-payback' && <CACPaybackCalculator />}
-          {activeCalculator === 'offer-roi' && <OfferROICalculator />}
-          {activeCalculator === 'revenue-planner' && <RevenuePlannerCalculator />}
-          {activeCalculator === 'volume-targets' && <VolumeTargetsCalculator />}
-          {activeCalculator === 'revenueos-recognition' && <RevenueOSRecognitionCalculator />}
-          {activeCalculator === 'compensation' && <CompensationCalculator />}
+                ← Back to All Calculators
+              </Button>
+              {activeCalculator === 'audit-roi' && <AuditROICalculator />}
+              {activeCalculator === 'pricing-scenario' && <PricingScenarioCalculator />}
+              {activeCalculator === 'activation-funnel' && <ActivationFunnelCalculator />}
+              {activeCalculator === 'retention-ltv' && <RetentionLTVCalculator />}
+              {activeCalculator === 'cac-payback' && <CACPaybackCalculator />}
+              {activeCalculator === 'offer-roi' && <OfferROICalculator />}
+              {activeCalculator === 'revenue-planner' && <RevenuePlannerCalculator />}
+              {activeCalculator === 'volume-targets' && <VolumeTargetsCalculator />}
+              {activeCalculator === 'revenueos-recognition' && <RevenueOSRecognitionCalculator />}
+              {activeCalculator === 'compensation' && <CompensationCalculator />}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the agents and calculators experiences in the same container and header structure used on the clients page
- update the agents overview copy to avoid duplication and clarify the purpose of the orchestration card
- apply the shared layout to calculators, including a consistent back button treatment when viewing individual tools

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f6dced64348324b633e769ac4e78d5