### PR TITLE
fix: restore safe area padding utility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -226,4 +226,10 @@ body {
   .ring-ring {
     --tw-ring-color: rgb(var(--color-ring));
   }
+
+  /* Safe area utilities */
+  .safe-area-bottom {
+    padding-bottom: 1rem;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
 }


### PR DESCRIPTION
## Summary
- add a safe-area-bottom utility in the global stylesheet so mobile navigation respects device insets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f95f12febc83249ebd77ee6413bd2b