### PR TITLE
fix: add safe area fallback handling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -226,4 +226,10 @@ body {
   .ring-ring {
     --tw-ring-color: rgb(var(--color-ring));
   }
+
+  /* Safe area utilities */
+  .safe-area-bottom {
+    padding-bottom: 1rem;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0));
+  }
 }


### PR DESCRIPTION
## Summary
- include a fallback value in the safe-area-bottom utility so padding remains valid on browsers without the env inset

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f95f12febc83249ebd77ee6413bd2b