### PR TITLE
style: refresh project detail color theme

### DIFF
--- a/app/projects/[id]/ProjectWorkspace.tsx
+++ b/app/projects/[id]/ProjectWorkspace.tsx
@@ -109,47 +109,47 @@ export default function ProjectWorkspace({
   const getStatusColor = (status: ProjectStatus) => {
     switch (status) {
       case 'Active':
-        return 'bg-green-100 text-green-800'
+        return 'border border-orange-500 bg-green-700 text-white'
       case 'Pending':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'border border-orange-500 bg-green-800 text-white'
       case 'Delivered':
-        return 'bg-blue-100 text-blue-800'
+        return 'border border-orange-500 bg-green-600 text-white'
       case 'Closed':
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-900 text-white'
       default:
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-800 text-white'
     }
   }
 
   const getTypeColor = (type: ProjectType) => {
     switch (type) {
       case 'Audit':
-        return 'bg-purple-100 text-purple-800'
+        return 'border border-orange-500 bg-green-700 text-white'
       case 'Blueprint':
-        return 'bg-blue-100 text-blue-800'
+        return 'border border-orange-500 bg-green-800 text-white'
       case 'Advisory':
-        return 'bg-orange-100 text-orange-800'
+        return 'border border-orange-500 bg-green-600 text-white'
       case 'Internal':
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-900 text-white'
       default:
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-800 text-white'
     }
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 text-white">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Link
             href="/projects"
-            className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors"
+            className="group flex h-10 w-10 items-center justify-center rounded-lg border border-orange-500 bg-green-800 text-white transition-colors hover:bg-orange-500"
           >
-            <ArrowLeft className="h-5 w-5 text-gray-600" />
+            <ArrowLeft className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
-            <p className="text-sm text-gray-500">Client: {project.client}</p>
+            <h1 className="text-2xl font-bold text-white">{project.name}</h1>
+            <p className="text-sm text-green-200">Client: {project.client}</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -163,8 +163,8 @@ export default function ProjectWorkspace({
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
-        <nav className="-mb-px flex space-x-8">
+      <div className="border-b border-orange-500 pb-2">
+        <nav className="-mb-px flex flex-wrap gap-3">
           {tabs.map((tab) => {
             const Icon = tab.icon
             return (
@@ -172,15 +172,15 @@ export default function ProjectWorkspace({
                 key={tab.key}
                 onClick={() => handleTabChange(tab.key)}
                 className={`
-                  flex items-center gap-2 whitespace-nowrap border-b-2 py-4 px-1 text-sm font-medium transition-colors
+                  group flex items-center gap-2 whitespace-nowrap rounded-lg border border-orange-500 px-4 py-2 text-sm font-medium transition-colors
                   ${
                     activeTab === tab.key
-                      ? 'border-[#fd8216] text-[#fd8216]'
-                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                      ? 'bg-orange-500 text-white'
+                      : 'bg-green-800 text-white hover:bg-orange-500 hover:text-white'
                   }
                 `}
               >
-                <Icon className="h-5 w-5" />
+                <Icon className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
                 {tab.label}
               </button>
             )

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -88,15 +88,17 @@ export default async function ProjectDetailPage({
   const content = contentResult.data || []
 
   return (
-    <div className="min-h-screen bg-white text-black">
+    <div className="min-h-screen bg-green-950 text-white">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-6">
-        <ProjectWorkspace
-          project={project}
-          documents={documents}
-          resources={resources}
-          content={content}
-          initialTab={initialTab}
-        />
+        <div className="rounded-2xl border border-orange-500 bg-green-900 p-6 shadow-xl">
+          <ProjectWorkspace
+            project={project}
+            documents={documents}
+            resources={resources}
+            content={content}
+            initialTab={initialTab}
+          />
+        </div>
       </div>
     </div>
   )

--- a/app/projects/[id]/tabs/ActivityTab.tsx
+++ b/app/projects/[id]/tabs/ActivityTab.tsx
@@ -47,15 +47,15 @@ export default function ActivityTab({ project }: ActivityTabProps) {
   const getActivityColor = (type: string) => {
     switch (type) {
       case 'project_created':
-        return 'bg-green-100 text-green-600'
+        return 'border border-orange-500 bg-green-600 text-white'
       case 'project_updated':
-        return 'bg-blue-100 text-blue-600'
+        return 'border border-orange-500 bg-green-700 text-white'
       case 'document_added':
-        return 'bg-purple-100 text-purple-600'
+        return 'border border-orange-500 bg-green-800 text-white'
       case 'team_updated':
-        return 'bg-orange-100 text-orange-600'
+        return 'border border-orange-500 bg-green-900 text-white'
       default:
-        return 'bg-gray-100 text-gray-600'
+        return 'border border-orange-500 bg-green-800 text-white'
     }
   }
 
@@ -77,26 +77,26 @@ export default function ActivityTab({ project }: ActivityTabProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 text-white">
       {/* Header */}
       <div>
-        <h2 className="text-xl font-semibold text-gray-900">Project Activity</h2>
-        <p className="text-sm text-gray-500 mt-1">Timeline of all project events and updates</p>
+        <h2 className="text-xl font-semibold text-white">Project Activity</h2>
+        <p className="mt-1 text-sm text-green-200">Timeline of all project events and updates</p>
       </div>
 
       {/* Activity Timeline */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
         <div className="space-y-6">
           {mockActivities.length === 0 ? (
-            <div className="text-center py-12">
-              <Activity className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No activity yet</h3>
-              <p className="text-gray-500">Project activity will appear here as events occur</p>
+            <div className="py-12 text-center">
+              <Activity className="mx-auto mb-4 h-12 w-12 text-white" />
+              <h3 className="mb-2 text-lg font-medium text-white">No activity yet</h3>
+              <p className="text-green-200">Project activity will appear here as events occur</p>
             </div>
           ) : (
             <div className="relative">
               {/* Timeline line */}
-              <div className="absolute left-8 top-0 bottom-0 w-0.5 bg-gray-200" />
+              <div className="absolute left-8 top-0 bottom-0 w-0.5 bg-orange-500" />
 
               {/* Activity items */}
               <div className="space-y-6">
@@ -105,20 +105,22 @@ export default function ActivityTab({ project }: ActivityTabProps) {
                   return (
                     <div key={activity.id} className="relative flex gap-4">
                       {/* Icon */}
-                      <div className={`relative z-10 flex h-16 w-16 items-center justify-center rounded-full ${getActivityColor(activity.type)}`}>
-                        <Icon className="h-6 w-6" />
+                      <div
+                        className={`relative z-10 flex h-16 w-16 items-center justify-center rounded-full ${getActivityColor(activity.type)}`}
+                      >
+                        <Icon className="h-6 w-6 text-white" />
                       </div>
 
                       {/* Content */}
                       <div className="flex-1 pt-2">
                         <div className="flex items-start justify-between">
                           <div>
-                            <p className="text-base font-medium text-gray-900">{activity.description}</p>
-                            <p className="text-sm text-gray-500 mt-1">
+                            <p className="text-base font-medium text-white">{activity.description}</p>
+                            <p className="mt-1 text-sm text-green-200">
                               by {activity.user}
                             </p>
                           </div>
-                          <span className="text-sm text-gray-400 whitespace-nowrap ml-4">
+                          <span className="ml-4 whitespace-nowrap text-sm text-green-200">
                             {formatTimestamp(activity.timestamp)}
                           </span>
                         </div>
@@ -133,37 +135,37 @@ export default function ActivityTab({ project }: ActivityTabProps) {
       </div>
 
       {/* Project Milestones */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Key Milestones</h3>
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+        <h3 className="mb-4 text-lg font-semibold text-white">Key Milestones</h3>
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between rounded-lg border border-orange-500 bg-green-900 p-3">
             <div className="flex items-center gap-3">
-              <Calendar className="h-5 w-5 text-gray-400" />
-              <span className="text-sm font-medium text-gray-900">Project Start</span>
+              <Calendar className="h-5 w-5 text-white" />
+              <span className="text-sm font-medium text-white">Project Start</span>
             </div>
-            <span className="text-sm text-gray-500">
+            <span className="text-sm text-green-200">
               {project.start_date ? new Date(project.start_date).toLocaleDateString() : 'Not set'}
             </span>
           </div>
 
           {project.end_date && (
-            <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+            <div className="flex items-center justify-between rounded-lg border border-orange-500 bg-green-900 p-3">
               <div className="flex items-center gap-3">
-                <Calendar className="h-5 w-5 text-gray-400" />
-                <span className="text-sm font-medium text-gray-900">Project End</span>
+                <Calendar className="h-5 w-5 text-white" />
+                <span className="text-sm font-medium text-white">Project End</span>
               </div>
-              <span className="text-sm text-gray-500">
+              <span className="text-sm text-green-200">
                 {new Date(project.end_date).toLocaleDateString()}
               </span>
             </div>
           )}
 
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between rounded-lg border border-orange-500 bg-green-900 p-3">
             <div className="flex items-center gap-3">
-              <Edit className="h-5 w-5 text-gray-400" />
-              <span className="text-sm font-medium text-gray-900">Last Updated</span>
+              <Edit className="h-5 w-5 text-white" />
+              <span className="text-sm font-medium text-white">Last Updated</span>
             </div>
-            <span className="text-sm text-gray-500">
+            <span className="text-sm text-green-200">
               {new Date(project.updated_at).toLocaleDateString()}
             </span>
           </div>
@@ -171,26 +173,26 @@ export default function ActivityTab({ project }: ActivityTabProps) {
       </div>
 
       {/* Activity Summary */}
-      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Total Events</div>
-          <div className="text-2xl font-bold text-gray-900">{mockActivities.length}</div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Total Events</div>
+          <div className="text-2xl font-bold text-white">{mockActivities.length}</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Documents</div>
-          <div className="text-2xl font-bold text-purple-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Documents</div>
+          <div className="text-2xl font-bold text-white">
             {mockActivities.filter((a) => a.type === 'document_added').length}
           </div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Updates</div>
-          <div className="text-2xl font-bold text-blue-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Updates</div>
+          <div className="text-2xl font-bold text-white">
             {mockActivities.filter((a) => a.type === 'project_updated').length}
           </div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Team Changes</div>
-          <div className="text-2xl font-bold text-orange-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Team Changes</div>
+          <div className="text-2xl font-bold text-white">
             {mockActivities.filter((a) => a.type === 'team_updated').length}
           </div>
         </div>

--- a/app/projects/[id]/tabs/ContentTab.tsx
+++ b/app/projects/[id]/tabs/ContentTab.tsx
@@ -30,13 +30,13 @@ export default function ContentTab({ project, content }: ContentTabProps) {
   const getStatusColor = (status: ProjectContent['status']) => {
     switch (status) {
       case 'Draft':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'border border-orange-500 bg-green-700 text-white'
       case 'Review':
-        return 'bg-blue-100 text-blue-800'
+        return 'border border-orange-500 bg-green-800 text-white'
       case 'Published':
-        return 'bg-green-100 text-green-800'
+        return 'border border-orange-500 bg-green-600 text-white'
       default:
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-800 text-white'
     }
   }
 
@@ -46,20 +46,20 @@ export default function ContentTab({ project, content }: ContentTabProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 text-white">
       {/* Header with Actions */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Project Content</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-xl font-semibold text-white">Project Content</h2>
+          <p className="mt-1 text-sm text-green-200">
             {filteredContent.length} of {content.length} content piece{content.length !== 1 ? 's' : ''}
           </p>
         </div>
         <button
           onClick={handleCreateContent}
-          className="flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+          className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
         >
-          <Plus className="h-5 w-5" />
+          <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
           New Content
         </button>
       </div>
@@ -67,14 +67,14 @@ export default function ContentTab({ project, content }: ContentTabProps) {
       {/* Search and Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         {/* Search */}
-        <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-green-200" />
           <input
             type="text"
             placeholder="Search content..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+            className="w-full rounded-lg border border-orange-500 bg-green-950 pl-10 pr-4 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
           />
         </div>
 
@@ -82,7 +82,7 @@ export default function ContentTab({ project, content }: ContentTabProps) {
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value as any)}
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+          className="rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
         >
           <option value="all">All Statuses</option>
           <option value="Draft">Draft</option>
@@ -94,7 +94,7 @@ export default function ContentTab({ project, content }: ContentTabProps) {
         <select
           value={filterType}
           onChange={(e) => setFilterType(e.target.value)}
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+          className="rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
         >
           <option value="all">All Types</option>
           {contentTypes.map((type) => (
@@ -107,10 +107,10 @@ export default function ContentTab({ project, content }: ContentTabProps) {
 
       {/* Content List */}
       {filteredContent.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg border-2 border-dashed border-gray-300">
-          <FolderOpen className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No content found</h3>
-          <p className="text-gray-500 mb-4">
+        <div className="rounded-lg border-2 border-dashed border-orange-500 bg-green-900 py-12 text-center">
+          <FolderOpen className="mx-auto mb-4 h-12 w-12 text-white" />
+          <h3 className="mb-2 text-lg font-medium text-white">No content found</h3>
+          <p className="mb-4 text-green-200">
             {content.length === 0
               ? 'Get started by creating your first content piece'
               : 'Try adjusting your search or filters'}
@@ -118,9 +118,9 @@ export default function ContentTab({ project, content }: ContentTabProps) {
           {content.length === 0 && (
             <button
               onClick={handleCreateContent}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+              className="group inline-flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <Plus className="h-5 w-5" />
+              <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
               Create Content
             </button>
           )}
@@ -130,40 +130,40 @@ export default function ContentTab({ project, content }: ContentTabProps) {
           {filteredContent.map((item) => (
             <div
               key={item.id}
-              className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+              className="rounded-lg border border-orange-500 bg-green-800 p-6 transition-shadow hover:bg-orange-500"
             >
               <div className="flex items-start justify-between">
                 <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-2">
-                    <FileText className="h-5 w-5 text-[#fd8216]" />
-                    <h3 className="text-lg font-semibold text-gray-900">{item.title}</h3>
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(item.status)}`}>
+                  <div className="mb-2 flex items-center gap-3">
+                    <FileText className="h-5 w-5 text-white" />
+                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                    <span className={`rounded-full px-2 py-1 text-xs font-medium ${getStatusColor(item.status)}`}>
                       {item.status}
                     </span>
                   </div>
 
-                  <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500 mb-3">
+                  <div className="mb-3 flex flex-wrap items-center gap-4 text-sm text-green-100">
                     <span className="flex items-center gap-1">
-                      <span className="font-medium">Type:</span> {item.type}
+                      <span className="font-medium text-white">Type:</span> {item.type}
                     </span>
                     <span className="flex items-center gap-1">
-                      <span className="font-medium">Updated:</span>{' '}
+                      <span className="font-medium text-white">Updated:</span>{' '}
                       {new Date(item.updated_at).toLocaleDateString()}
                     </span>
                   </div>
 
                   {/* Content Preview */}
                   {item.final_text && (
-                    <div className="mt-3 p-4 bg-gray-50 rounded-lg">
-                      <div className="text-xs font-medium text-gray-500 mb-2">Published Content Preview</div>
-                      <p className="text-sm text-gray-700 line-clamp-3">{item.final_text}</p>
+                    <div className="mt-3 rounded-lg border border-orange-500 bg-green-900 p-4">
+                      <div className="mb-2 text-xs font-medium text-green-100">Published Content Preview</div>
+                      <p className="text-sm text-green-100 line-clamp-3">{item.final_text}</p>
                     </div>
                   )}
 
                   {!item.final_text && item.draft && (
-                    <div className="mt-3 p-4 bg-yellow-50 rounded-lg">
-                      <div className="text-xs font-medium text-yellow-700 mb-2">Draft Preview</div>
-                      <p className="text-sm text-gray-700 line-clamp-3">{item.draft}</p>
+                    <div className="mt-3 rounded-lg border border-orange-500 bg-green-900 p-4">
+                      <div className="mb-2 text-xs font-medium text-green-100">Draft Preview</div>
+                      <p className="text-sm text-green-100 line-clamp-3">{item.draft}</p>
                     </div>
                   )}
                 </div>
@@ -171,16 +171,16 @@ export default function ContentTab({ project, content }: ContentTabProps) {
                 <div className="flex flex-col gap-2 ml-4">
                   <Link
                     href={`/content/${item.id}`}
-                    className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-[#fd8216] hover:bg-orange-50 rounded-lg transition-colors"
+                    className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
                   >
-                    <Eye className="h-4 w-4" />
+                    <Eye className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
                     View
                   </Link>
                   <Link
                     href={`/content/${item.id}/edit`}
-                    className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+                    className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
                   >
-                    <Edit className="h-4 w-4" />
+                    <Edit className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
                     Edit
                   </Link>
                 </div>
@@ -191,20 +191,20 @@ export default function ContentTab({ project, content }: ContentTabProps) {
       )}
 
       {/* Content Statistics */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Total Content</div>
-          <div className="text-2xl font-bold text-gray-900">{content.length}</div>
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Total Content</div>
+          <div className="text-2xl font-bold text-white">{content.length}</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Published</div>
-          <div className="text-2xl font-bold text-green-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Published</div>
+          <div className="text-2xl font-bold text-white">
             {content.filter((c) => c.status === 'Published').length}
           </div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">In Review</div>
-          <div className="text-2xl font-bold text-blue-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">In Review</div>
+          <div className="text-2xl font-bold text-white">
             {content.filter((c) => c.status === 'Review').length}
           </div>
         </div>

--- a/app/projects/[id]/tabs/DocumentsTab.tsx
+++ b/app/projects/[id]/tabs/DocumentsTab.tsx
@@ -32,13 +32,13 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
   const getStatusColor = (status: ProjectDocument['status']) => {
     switch (status) {
       case 'Draft':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'border border-orange-500 bg-green-700 text-white'
       case 'Review':
-        return 'bg-blue-100 text-blue-800'
+        return 'border border-orange-500 bg-green-800 text-white'
       case 'Approved':
-        return 'bg-green-100 text-green-800'
+        return 'border border-orange-500 bg-green-600 text-white'
       default:
-        return 'bg-gray-100 text-gray-800'
+        return 'border border-orange-500 bg-green-800 text-white'
     }
   }
 
@@ -48,20 +48,20 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 text-white">
       {/* Header with Actions */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Project Documents</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-xl font-semibold text-white">Project Documents</h2>
+          <p className="mt-1 text-sm text-green-200">
             {filteredDocuments.length} of {documents.length} document{documents.length !== 1 ? 's' : ''}
           </p>
         </div>
         <button
           onClick={handleCreateDocument}
-          className="flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+          className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
         >
-          <Plus className="h-5 w-5" />
+          <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
           New Document
         </button>
       </div>
@@ -70,13 +70,13 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
       <div className="flex flex-col sm:flex-row gap-4">
         {/* Search */}
         <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-green-200" />
           <input
             type="text"
             placeholder="Search documents..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+            className="w-full rounded-lg border border-orange-500 bg-green-950 pl-10 pr-4 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
           />
         </div>
 
@@ -84,7 +84,7 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value as any)}
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+          className="rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
         >
           <option value="all">All Statuses</option>
           <option value="Draft">Draft</option>
@@ -96,7 +96,7 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
         <select
           value={filterType}
           onChange={(e) => setFilterType(e.target.value)}
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+          className="rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
         >
           <option value="all">All Types</option>
           {documentTypes.map((type) => (
@@ -109,10 +109,10 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
 
       {/* Documents List */}
       {filteredDocuments.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg border-2 border-dashed border-gray-300">
-          <FileText className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No documents found</h3>
-          <p className="text-gray-500 mb-4">
+        <div className="rounded-lg border-2 border-dashed border-orange-500 bg-green-900 py-12 text-center">
+          <FileText className="mx-auto mb-4 h-12 w-12 text-white" />
+          <h3 className="mb-2 text-lg font-medium text-white">No documents found</h3>
+          <p className="mb-4 text-green-200">
             {documents.length === 0
               ? 'Get started by creating your first document'
               : 'Try adjusting your search or filters'}
@@ -120,9 +120,9 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
           {documents.length === 0 && (
             <button
               onClick={handleCreateDocument}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+              className="group inline-flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <Plus className="h-5 w-5" />
+              <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
               Create Document
             </button>
           )}
@@ -132,39 +132,39 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
           {filteredDocuments.map((doc) => (
             <div
               key={doc.id}
-              className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+              className="rounded-lg border border-orange-500 bg-green-800 p-6 transition-shadow hover:bg-orange-500"
             >
               <div className="flex items-start justify-between">
                 <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-2">
-                    <FileText className="h-5 w-5 text-[#fd8216]" />
-                    <h3 className="text-lg font-semibold text-gray-900">{doc.title}</h3>
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(doc.status)}`}>
+                  <div className="mb-2 flex items-center gap-3">
+                    <FileText className="h-5 w-5 text-white" />
+                    <h3 className="text-lg font-semibold text-white">{doc.title}</h3>
+                    <span className={`rounded-full px-2 py-1 text-xs font-medium ${getStatusColor(doc.status)}`}>
                       {doc.status}
                     </span>
                   </div>
 
-                  <p className="text-gray-600 mb-3">{doc.description}</p>
+                  <p className="mb-3 text-green-100">{doc.description}</p>
 
-                  <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500">
+                  <div className="flex flex-wrap items-center gap-4 text-sm text-green-100">
                     <span className="flex items-center gap-1">
-                      <span className="font-medium">Type:</span> {doc.type}
+                      <span className="font-medium text-white">Type:</span> {doc.type}
                     </span>
                     <span className="flex items-center gap-1">
-                      <span className="font-medium">Version:</span> {doc.version}
+                      <span className="font-medium text-white">Version:</span> {doc.version}
                     </span>
                     <span className="flex items-center gap-1">
-                      <span className="font-medium">Updated:</span>{' '}
+                      <span className="font-medium text-white">Updated:</span>{' '}
                       {new Date(doc.updated_at).toLocaleDateString()}
                     </span>
                   </div>
 
                   {doc.tags && doc.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-2 mt-3">
+                    <div className="mt-3 flex flex-wrap gap-2">
                       {doc.tags.map((tag, idx) => (
                         <span
                           key={idx}
-                          className="px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs"
+                          className="rounded border border-orange-500 bg-green-700 px-2 py-1 text-xs text-white"
                         >
                           {tag}
                         </span>
@@ -173,8 +173,8 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
                   )}
 
                   {doc.summary && (
-                    <div className="mt-3 p-3 bg-gray-50 rounded-lg">
-                      <p className="text-sm text-gray-700">{doc.summary}</p>
+                    <div className="mt-3 rounded-lg border border-orange-500 bg-green-900 p-3">
+                      <p className="text-sm text-green-100">{doc.summary}</p>
                     </div>
                   )}
                 </div>
@@ -182,9 +182,9 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
                 <div className="flex flex-col gap-2 ml-4">
                   <Link
                     href={`/documents/${doc.id}`}
-                    className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-[#fd8216] hover:bg-orange-50 rounded-lg transition-colors"
+                    className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
                   >
-                    <Eye className="h-4 w-4" />
+                    <Eye className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
                     View
                   </Link>
                   {doc.file_url && (
@@ -192,9 +192,9 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
                       href={doc.file_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+                      className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
                     >
-                      <Download className="h-4 w-4" />
+                      <Download className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
                       File
                     </a>
                   )}
@@ -206,20 +206,20 @@ export default function DocumentsTab({ project, documents }: DocumentsTabProps) 
       )}
 
       {/* Document Statistics */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Total Documents</div>
-          <div className="text-2xl font-bold text-gray-900">{documents.length}</div>
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Total Documents</div>
+          <div className="text-2xl font-bold text-white">{documents.length}</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Approved</div>
-          <div className="text-2xl font-bold text-green-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Approved</div>
+          <div className="text-2xl font-bold text-white">
             {documents.filter((d) => d.status === 'Approved').length}
           </div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">In Review</div>
-          <div className="text-2xl font-bold text-blue-600">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">In Review</div>
+          <div className="text-2xl font-bold text-white">
             {documents.filter((d) => d.status === 'Review').length}
           </div>
         </div>

--- a/app/projects/[id]/tabs/FinancialsTab.tsx
+++ b/app/projects/[id]/tabs/FinancialsTab.tsx
@@ -37,35 +37,35 @@ export default function FinancialsTab({ project }: FinancialsTabProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 text-white">
       {/* Header with Edit Toggle */}
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Project Financials</h2>
-          <p className="text-sm text-gray-500 mt-1">Revenue tracking and invoicing</p>
+          <h2 className="text-xl font-semibold text-white">Project Financials</h2>
+          <p className="mt-1 text-sm text-green-200">Revenue tracking and invoicing</p>
         </div>
         {!isEditing ? (
           <button
             onClick={() => setIsEditing(true)}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#fd8216] hover:bg-orange-50 rounded-lg transition-colors"
+            className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
           >
-            <Edit2 className="h-4 w-4" />
+            <Edit2 className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
             Edit Financials
           </button>
         ) : (
           <div className="flex gap-2">
             <button
               onClick={handleSave}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#fd8216] hover:bg-[#e67412] rounded-lg transition-colors"
+              className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <Save className="h-4 w-4" />
+              <Save className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
               Save Changes
             </button>
             <button
               onClick={handleCancel}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-lg transition-colors"
+              className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
               Cancel
             </button>
           </div>
@@ -73,55 +73,55 @@ export default function FinancialsTab({ project }: FinancialsTabProps) {
       </div>
 
       {/* Revenue Target */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <DollarSign className="h-5 w-5 text-[#fd8216]" />
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+        <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+          <DollarSign className="h-5 w-5 text-white" />
           Revenue Target
         </h3>
         {isEditing ? (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Target Amount</label>
+            <label className="mb-2 block text-sm font-medium text-green-200">Target Amount</label>
             <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-green-200">$</span>
               <input
                 type="number"
                 value={revenueTarget}
                 onChange={(e) => setRevenueTarget(parseFloat(e.target.value))}
-                className="w-full pl-7 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                className="w-full rounded-lg border border-orange-500 bg-green-950 pl-7 pr-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
               />
             </div>
           </div>
         ) : (
-          <div className="text-4xl font-bold text-gray-900">
+          <div className="text-4xl font-bold text-white">
             ${revenueTarget.toLocaleString()}
           </div>
         )}
       </div>
 
       {/* Progress Bar */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-2">
-          <h3 className="text-lg font-semibold text-gray-900">Revenue Progress</h3>
-          <span className="text-sm font-medium text-gray-500">{percentageComplete}% Complete</span>
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-white">Revenue Progress</h3>
+          <span className="text-sm font-medium text-green-200">{percentageComplete}% Complete</span>
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-4 mb-4">
+        <div className="mb-4 h-4 w-full rounded-full bg-green-950">
           <div
-            className="bg-[#fd8216] h-4 rounded-full transition-all duration-300"
+            className="h-4 rounded-full bg-orange-500 transition-all duration-300"
             style={{ width: `${Math.min(percentageComplete, 100)}%` }}
           />
         </div>
-        <div className="grid grid-cols-3 gap-4 text-sm">
+        <div className="grid grid-cols-3 gap-4 text-sm text-green-100">
           <div>
-            <span className="text-gray-500">Paid</span>
-            <div className="font-semibold text-green-600">${mockFinancials.paid.toLocaleString()}</div>
+            <span className="text-green-200">Paid</span>
+            <div className="font-semibold text-white">${mockFinancials.paid.toLocaleString()}</div>
           </div>
           <div>
-            <span className="text-gray-500">Outstanding</span>
-            <div className="font-semibold text-yellow-600">${mockFinancials.outstanding.toLocaleString()}</div>
+            <span className="text-green-200">Outstanding</span>
+            <div className="font-semibold text-white">${mockFinancials.outstanding.toLocaleString()}</div>
           </div>
           <div>
-            <span className="text-gray-500">Remaining</span>
-            <div className="font-semibold text-gray-600">
+            <span className="text-green-200">Remaining</span>
+            <div className="font-semibold text-white">
               ${(revenueTarget - mockFinancials.invoiced).toLocaleString()}
             </div>
           </div>
@@ -129,20 +129,20 @@ export default function FinancialsTab({ project }: FinancialsTabProps) {
       </div>
 
       {/* QuickBooks Integration */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <TrendingUp className="h-5 w-5 text-[#fd8216]" />
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+        <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+          <TrendingUp className="h-5 w-5 text-white" />
           QuickBooks Integration
         </h3>
         {isEditing ? (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Invoice URL</label>
+            <label className="mb-2 block text-sm font-medium text-green-200">Invoice URL</label>
             <input
               type="url"
               value={quickbooksUrl}
               onChange={(e) => setQuickbooksUrl(e.target.value)}
               placeholder="https://qbo.intuit.com/..."
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+              className="w-full rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
             />
           </div>
         ) : quickbooksUrl ? (
@@ -150,75 +150,75 @@ export default function FinancialsTab({ project }: FinancialsTabProps) {
             href={quickbooksUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 px-4 py-3 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors w-fit"
+            className="group flex w-fit items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-3 font-medium text-white transition-colors hover:bg-orange-500"
           >
-            <ExternalLink className="h-5 w-5" />
+            <ExternalLink className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
             View Invoice in QuickBooks
           </a>
         ) : (
-          <p className="text-gray-500 text-sm">No QuickBooks invoice URL set</p>
+          <p className="text-sm text-green-200">No QuickBooks invoice URL set</p>
         )}
       </div>
 
       {/* Financial Summary Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
-            <DollarSign className="h-4 w-4" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 flex items-center gap-2 text-sm text-green-200">
+            <DollarSign className="h-4 w-4 text-white" />
             Revenue Target
           </div>
-          <div className="text-2xl font-bold text-gray-900">${revenueTarget.toLocaleString()}</div>
+          <div className="text-2xl font-bold text-white">${revenueTarget.toLocaleString()}</div>
         </div>
 
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
-            <TrendingUp className="h-4 w-4" />
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 flex items-center gap-2 text-sm text-green-200">
+            <TrendingUp className="h-4 w-4 text-white" />
             Total Invoiced
           </div>
-          <div className="text-2xl font-bold text-blue-600">${mockFinancials.invoiced.toLocaleString()}</div>
+          <div className="text-2xl font-bold text-white">${mockFinancials.invoiced.toLocaleString()}</div>
         </div>
 
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
-            <DollarSign className="h-4 w-4" />
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 flex items-center gap-2 text-sm text-green-200">
+            <DollarSign className="h-4 w-4 text-white" />
             Total Paid
           </div>
-          <div className="text-2xl font-bold text-green-600">${mockFinancials.paid.toLocaleString()}</div>
+          <div className="text-2xl font-bold text-white">${mockFinancials.paid.toLocaleString()}</div>
         </div>
 
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
-            <Calendar className="h-4 w-4" />
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 flex items-center gap-2 text-sm text-green-200">
+            <Calendar className="h-4 w-4 text-white" />
             Outstanding
           </div>
-          <div className="text-2xl font-bold text-yellow-600">${mockFinancials.outstanding.toLocaleString()}</div>
+          <div className="text-2xl font-bold text-white">${mockFinancials.outstanding.toLocaleString()}</div>
         </div>
       </div>
 
       {/* Payment Schedule (Mock) */}
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Payment Schedule</h3>
+      <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+        <h3 className="mb-4 text-lg font-semibold text-white">Payment Schedule</h3>
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-green-50 border border-green-200 rounded-lg">
+          <div className="flex items-center justify-between rounded-lg border border-orange-500 bg-green-900 p-3">
             <div>
-              <div className="font-medium text-gray-900">Initial Payment</div>
-              <div className="text-sm text-gray-500">Received on {new Date(project.created_at).toLocaleDateString()}</div>
+              <div className="font-medium text-white">Initial Payment</div>
+              <div className="text-sm text-green-200">Received on {new Date(project.created_at).toLocaleDateString()}</div>
             </div>
             <div className="text-right">
-              <div className="font-semibold text-green-600">${mockFinancials.paid.toLocaleString()}</div>
-              <div className="text-xs text-green-600">Paid</div>
+              <div className="font-semibold text-white">${mockFinancials.paid.toLocaleString()}</div>
+              <div className="text-xs text-green-200">Paid</div>
             </div>
           </div>
 
           {mockFinancials.outstanding > 0 && (
-            <div className="flex items-center justify-between p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <div className="flex items-center justify-between rounded-lg border border-orange-500 bg-green-900 p-3">
               <div>
-                <div className="font-medium text-gray-900">Outstanding Balance</div>
-                <div className="text-sm text-gray-500">Due upon completion</div>
+                <div className="font-medium text-white">Outstanding Balance</div>
+                <div className="text-sm text-green-200">Due upon completion</div>
               </div>
               <div className="text-right">
-                <div className="font-semibold text-yellow-600">${mockFinancials.outstanding.toLocaleString()}</div>
-                <div className="text-xs text-yellow-600">Pending</div>
+                <div className="font-semibold text-white">${mockFinancials.outstanding.toLocaleString()}</div>
+                <div className="text-xs text-green-200">Pending</div>
               </div>
             </div>
           )}

--- a/app/projects/[id]/tabs/OverviewTab.tsx
+++ b/app/projects/[id]/tabs/OverviewTab.tsx
@@ -99,25 +99,25 @@ export default function OverviewTab({ project }: OverviewTabProps) {
         {!isEditing ? (
           <button
             onClick={() => setIsEditing(true)}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#fd8216] hover:bg-orange-50 rounded-lg transition-colors"
+            className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
           >
-            <Edit2 className="h-4 w-4" />
+            <Edit2 className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
             Edit Project
           </button>
         ) : (
           <div className="flex gap-2">
             <button
               onClick={handleSave}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[#fd8216] hover:bg-[#e67412] rounded-lg transition-colors"
+              className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <Save className="h-4 w-4" />
+              <Save className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
               Save Changes
             </button>
             <button
               onClick={handleCancel}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-lg transition-colors"
+              className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
               Cancel
             </button>
           </div>
@@ -128,44 +128,44 @@ export default function OverviewTab({ project }: OverviewTabProps) {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Left Column */}
         <div className="space-y-6">
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Project Information</h3>
+          <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+            <h3 className="mb-4 text-lg font-semibold text-white">Project Information</h3>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Project Name</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">Project Name</label>
                 {isEditing ? (
                   <input
                     type="text"
                     value={formData.name}
                     onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   />
                 ) : (
-                  <p className="text-gray-900">{project.name}</p>
+                  <p className="text-white">{project.name}</p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Client</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">Client</label>
                 {isEditing ? (
                   <input
                     type="text"
                     value={formData.client}
                     onChange={(e) => setFormData({ ...formData, client: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   />
                 ) : (
-                  <p className="text-gray-900">{project.client}</p>
+                  <p className="text-white">{project.client}</p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Project Type</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">Project Type</label>
                 {isEditing ? (
                   <select
                     value={formData.type}
                     onChange={(e) => handleTypeChange(e.target.value as ProjectType)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   >
                     <option value="Audit">Audit</option>
                     <option value="Blueprint">Blueprint</option>
@@ -173,17 +173,17 @@ export default function OverviewTab({ project }: OverviewTabProps) {
                     <option value="Internal">Internal</option>
                   </select>
                 ) : (
-                  <p className="text-gray-900">{project.type}</p>
+                  <p className="text-white">{project.type}</p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">Status</label>
                 {isEditing ? (
                   <select
                     value={formData.status}
                     onChange={(e) => setFormData({ ...formData, status: e.target.value as ProjectStatus })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   >
                     <option value="Pending">Pending</option>
                     <option value="Active">Active</option>
@@ -191,46 +191,46 @@ export default function OverviewTab({ project }: OverviewTabProps) {
                     <option value="Closed">Closed</option>
                   </select>
                 ) : (
-                  <p className="text-gray-900">{project.status}</p>
+                  <p className="text-white">{project.status}</p>
                 )}
               </div>
             </div>
           </div>
 
           {/* Timeline */}
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-              <Calendar className="h-5 w-5 text-[#fd8216]" />
+          <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+            <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+              <Calendar className="h-5 w-5 text-white" />
               Timeline
             </h3>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">Start Date</label>
                 {isEditing ? (
                   <input
                     type="date"
                     value={formData.start_date}
                     onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   />
                 ) : (
-                  <p className="text-gray-900">
+                  <p className="text-white">
                     {project.start_date ? new Date(project.start_date).toLocaleDateString() : 'Not set'}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
+                <label className="mb-1 block text-sm font-medium text-green-200">End Date</label>
                 {isEditing ? (
                   <input
                     type="date"
                     value={formData.end_date}
                     onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                    className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
                   />
                 ) : (
-                  <p className="text-gray-900">
+                  <p className="text-white">
                     {project.end_date ? new Date(project.end_date).toLocaleDateString() : 'Not set'}
                   </p>
                 )}
@@ -242,9 +242,9 @@ export default function OverviewTab({ project }: OverviewTabProps) {
         {/* Right Column */}
         <div className="space-y-6">
           {/* Team */}
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-              <Users className="h-5 w-5 text-[#fd8216]" />
+          <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+            <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+              <Users className="h-5 w-5 text-white" />
               Team
             </h3>
             {isEditing ? (
@@ -253,28 +253,28 @@ export default function OverviewTab({ project }: OverviewTabProps) {
                 value={formData.team}
                 onChange={(e) => setFormData({ ...formData, team: e.target.value })}
                 placeholder="Comma-separated team members"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
               />
             ) : project.team.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {project.team.map((member, idx) => (
                   <span
                     key={idx}
-                    className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm"
+                    className="rounded-full border border-orange-500 bg-green-700 px-3 py-1 text-sm text-white"
                   >
                     {member}
                   </span>
                 ))}
               </div>
             ) : (
-              <p className="text-gray-500 text-sm">No team members assigned</p>
+              <p className="text-sm text-green-200">No team members assigned</p>
             )}
           </div>
 
           {/* Revenue Target */}
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-              <DollarSign className="h-5 w-5 text-[#fd8216]" />
+          <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+            <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+              <DollarSign className="h-5 w-5 text-white" />
               Revenue Target
             </h3>
             {isEditing ? (
@@ -282,19 +282,19 @@ export default function OverviewTab({ project }: OverviewTabProps) {
                 type="number"
                 value={formData.revenue_target}
                 onChange={(e) => setFormData({ ...formData, revenue_target: parseFloat(e.target.value) })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
               />
             ) : (
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-2xl font-bold text-white">
                 ${project.revenue_target?.toLocaleString() || '0'}
               </p>
             )}
           </div>
 
           {/* QuickBooks */}
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-              <Target className="h-5 w-5 text-[#fd8216]" />
+          <div className="rounded-lg border border-orange-500 bg-green-800 p-6">
+            <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+              <Target className="h-5 w-5 text-white" />
               QuickBooks Invoice
             </h3>
             {isEditing ? (
@@ -303,19 +303,19 @@ export default function OverviewTab({ project }: OverviewTabProps) {
                 value={formData.quickbooks_invoice_url}
                 onChange={(e) => setFormData({ ...formData, quickbooks_invoice_url: e.target.value })}
                 placeholder="https://..."
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+                className="w-full rounded-lg border border-orange-500 bg-green-950 px-3 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
               />
             ) : project.quickbooks_invoice_url ? (
               <a
                 href={project.quickbooks_invoice_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#fd8216] hover:text-[#e67412] underline"
+                className="font-medium text-white underline decoration-orange-400 underline-offset-4 hover:text-orange-200"
               >
                 View Invoice
               </a>
             ) : (
-              <p className="text-gray-500 text-sm">No invoice URL set</p>
+              <p className="text-sm text-green-200">No invoice URL set</p>
             )}
           </div>
         </div>
@@ -323,11 +323,11 @@ export default function OverviewTab({ project }: OverviewTabProps) {
 
       {/* Document Templates (shown when type changes in edit mode) */}
       {showTemplates && isEditing && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="rounded-lg border border-orange-500 bg-green-900 p-6">
+          <h3 className="mb-4 text-lg font-semibold text-white">
             Recommended Documents for {selectedType} Projects
           </h3>
-          <p className="text-sm text-gray-600 mb-4">
+          <p className="mb-4 text-sm text-green-100">
             Click any template below to create that document for this project:
           </p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -335,11 +335,11 @@ export default function OverviewTab({ project }: OverviewTabProps) {
               <button
                 key={idx}
                 onClick={() => handleCreateDocument(template)}
-                className="text-left p-4 bg-white border border-gray-200 rounded-lg hover:border-[#fd8216] hover:shadow-sm transition-all"
+                className="group rounded-lg border border-orange-500 bg-green-800 p-4 text-left transition-all hover:bg-orange-500"
               >
-                <div className="font-medium text-gray-900">{template.name}</div>
-                <div className="text-sm text-gray-500 mt-1">{template.description}</div>
-                <div className="text-xs text-gray-400 mt-2">Type: {template.type}</div>
+                <div className="font-medium text-white transition-colors group-hover:text-green-900">{template.name}</div>
+                <div className="mt-1 text-sm text-green-100 transition-colors group-hover:text-white">{template.description}</div>
+                <div className="mt-2 text-xs text-green-200 transition-colors group-hover:text-green-900">Type: {template.type}</div>
               </button>
             ))}
           </div>

--- a/app/projects/[id]/tabs/ResourcesTab.tsx
+++ b/app/projects/[id]/tabs/ResourcesTab.tsx
@@ -34,20 +34,20 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 text-white">
       {/* Header with Actions */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Project Resources</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-xl font-semibold text-white">Project Resources</h2>
+          <p className="mt-1 text-sm text-green-200">
             {filteredResources.length} of {resources.length} resource{resources.length !== 1 ? 's' : ''}
           </p>
         </div>
         <button
           onClick={handleCreateResource}
-          className="flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+          className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
         >
-          <Plus className="h-5 w-5" />
+          <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
           Add Resource
         </button>
       </div>
@@ -55,14 +55,14 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
       {/* Search and Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         {/* Search */}
-        <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-green-200" />
           <input
             type="text"
             placeholder="Search resources..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+            className="w-full rounded-lg border border-orange-500 bg-green-950 pl-10 pr-4 py-2 text-white placeholder:text-green-200 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
           />
         </div>
 
@@ -70,7 +70,7 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
         <select
           value={filterType}
           onChange={(e) => setFilterType(e.target.value)}
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fd8216] focus:border-[#fd8216]"
+          className="rounded-lg border border-orange-500 bg-green-950 px-4 py-2 text-white focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-300"
         >
           <option value="all">All Types</option>
           {resourceTypes.map((type) => (
@@ -83,10 +83,10 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
 
       {/* Resources List */}
       {filteredResources.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg border-2 border-dashed border-gray-300">
-          <Package className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No resources found</h3>
-          <p className="text-gray-500 mb-4">
+        <div className="rounded-lg border-2 border-dashed border-orange-500 bg-green-900 py-12 text-center">
+          <Package className="mx-auto mb-4 h-12 w-12 text-white" />
+          <h3 className="mb-2 text-lg font-medium text-white">No resources found</h3>
+          <p className="mb-4 text-green-200">
             {resources.length === 0
               ? 'Get started by adding your first resource'
               : 'Try adjusting your search or filters'}
@@ -94,48 +94,48 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
           {resources.length === 0 && (
             <button
               onClick={handleCreateResource}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[#fd8216] hover:bg-[#e67412] text-white rounded-lg font-medium transition-colors"
+              className="group inline-flex items-center gap-2 rounded-lg border border-orange-500 bg-green-800 px-4 py-2 font-medium text-white transition-colors hover:bg-orange-500"
             >
-              <Plus className="h-5 w-5" />
+              <Plus className="h-5 w-5 text-white transition-colors group-hover:text-green-900" />
               Add Resource
             </button>
           )}
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {filteredResources.map((resource) => (
             <div
               key={resource.id}
-              className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+              className="rounded-lg border border-orange-500 bg-green-800 p-6 transition-shadow hover:bg-orange-500"
             >
-              <div className="flex items-start justify-between mb-3">
+              <div className="mb-3 flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <Package className="h-5 w-5 text-[#fd8216]" />
-                  <h3 className="text-lg font-semibold text-gray-900">{resource.name}</h3>
+                  <Package className="h-5 w-5 text-white" />
+                  <h3 className="text-lg font-semibold text-white">{resource.name}</h3>
                 </div>
-                <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">
+                <span className="rounded-full border border-orange-500 bg-green-700 px-2 py-1 text-xs font-medium text-white">
                   {resource.type}
                 </span>
               </div>
 
-              <p className="text-gray-600 mb-3">{resource.description}</p>
+              <p className="mb-3 text-green-100">{resource.description}</p>
 
               {resource.tags && resource.tags.length > 0 && (
-                <div className="flex flex-wrap gap-2 mb-3">
+                <div className="mb-3 flex flex-wrap gap-2">
                   {resource.tags.map((tag, idx) => (
                     <span
                       key={idx}
-                      className="flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs"
+                      className="flex items-center gap-1 rounded border border-orange-500 bg-green-700 px-2 py-1 text-xs text-white"
                     >
-                      <Tag className="h-3 w-3" />
+                      <Tag className="h-3 w-3 text-white" />
                       {tag}
                     </span>
                   ))}
                 </div>
               )}
 
-              <div className="flex items-center gap-2 text-sm text-gray-500 mb-3">
-                <span className="font-medium">Updated:</span>{' '}
+              <div className="mb-3 flex items-center gap-2 text-sm text-green-100">
+                <span className="font-medium text-white">Updated:</span>{' '}
                 {new Date(resource.updated_at).toLocaleDateString()}
               </div>
 
@@ -144,9 +144,9 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
                   href={resource.link}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-[#fd8216] hover:bg-orange-50 rounded-lg transition-colors"
+                  className="group flex items-center gap-2 rounded-lg border border-orange-500 bg-green-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-500"
                 >
-                  <ExternalLink className="h-4 w-4" />
+                  <ExternalLink className="h-4 w-4 text-white transition-colors group-hover:text-green-900" />
                   Open Resource
                 </a>
               )}
@@ -156,18 +156,18 @@ export default function ResourcesTab({ project, resources }: ResourcesTabProps) 
       )}
 
       {/* Resource Statistics */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Total Resources</div>
-          <div className="text-2xl font-bold text-gray-900">{resources.length}</div>
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Total Resources</div>
+          <div className="text-2xl font-bold text-white">{resources.length}</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">Resource Types</div>
-          <div className="text-2xl font-bold text-gray-900">{resourceTypes.length}</div>
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">Resource Types</div>
+          <div className="text-2xl font-bold text-white">{resourceTypes.length}</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="text-sm text-gray-500 mb-1">With Links</div>
-          <div className="text-2xl font-bold text-gray-900">
+        <div className="rounded-lg border border-orange-500 bg-green-800 p-4">
+          <div className="mb-1 text-sm text-green-200">With Links</div>
+          <div className="text-2xl font-bold text-white">
             {resources.filter((r) => r.link).length}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rethemed the project detail layout with green backgrounds, orange borders, and white typography
- updated workspace navigation, buttons, and hover interactions to deliver orange hover states with green and white text accents
- aligned all project tab panels with the new palette, including inputs, cards, and status chips

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9d6b8c82c8324872cff1fc4981fb6