### PR TITLE
fix: unblock edge middleware auth and prisma generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start -p 3000",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "postinstall": "prisma generate"
   },
   "packageManager": "pnpm@10.18.0",
   "engines": {


### PR DESCRIPTION
## Summary
- replace the Supabase middleware helper with an Edge-compatible token check that relies on the REST API
- ensure Prisma generates the client during installs so type definitions are present at build time

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_6901385f11588324a0a3d7b202b7fa44