### PR TITLE
fix: guard prisma initialization for missing DATABASE_URL

### DIFF
--- a/scripts/seed-sequence.ts
+++ b/scripts/seed-sequence.ts
@@ -1,4 +1,10 @@
-import { prisma } from '../src/lib/prisma';
+import { getPrismaClient } from '../src/lib/prisma';
+
+const prisma = getPrismaClient();
+
+if (!prisma) {
+  throw new Error('DATABASE_URL is not set');
+}
 
 async function main() {
   const sequence = await prisma.sequence.upsert({

--- a/src/app/api/prospecting/booked/route.ts
+++ b/src/app/api/prospecting/booked/route.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/src/lib/prisma';
+import { getPrismaClient } from '@/src/lib/prisma';
 
 type CalendlyPayload = {
   payload?: {
@@ -8,6 +8,12 @@ type CalendlyPayload = {
 };
 
 export async function POST(request: Request) {
+  const prisma = getPrismaClient();
+  if (!prisma) {
+    console.warn('[prospecting] booked webhook received without DATABASE_URL');
+    return new Response('database unavailable', { status: 500 });
+  }
+
   let body: CalendlyPayload | null = null;
   try {
     body = (await request.json()) as CalendlyPayload;

--- a/src/app/api/prospecting/inbound/route.ts
+++ b/src/app/api/prospecting/inbound/route.ts
@@ -1,7 +1,13 @@
-import { prisma } from '@/src/lib/prisma';
+import { getPrismaClient } from '@/src/lib/prisma';
 import { classifyReply } from '@/src/lib/prospecting';
 
 export async function POST(request: Request) {
+  const prisma = getPrismaClient();
+  if (!prisma) {
+    console.warn('[prospecting] inbound reply received without DATABASE_URL');
+    return new Response('database unavailable', { status: 500 });
+  }
+
   const form = await request.formData();
   const fromField = String(form.get('from') || '');
   const emailMatch = (fromField.split('<')[1] || fromField).replace('>', '').trim().toLowerCase();

--- a/src/app/prospecting/server-actions.ts
+++ b/src/app/prospecting/server-actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
 import { startOfDay } from 'date-fns';
-import { prisma } from '@/src/lib/prisma';
+import { getPrismaClient } from '@/src/lib/prisma';
 import {
   generateCopy,
   isWithinSendWindow,
@@ -34,6 +34,12 @@ const rowSchema = z.object({
 });
 
 export async function ingestCsvAction(rows: any[]) {
+  const prisma = getPrismaClient();
+  if (!prisma) {
+    console.warn('[prospecting] ingestCsvAction invoked without DATABASE_URL');
+    return;
+  }
+
   for (const row of rows) {
     const parsed = rowSchema.safeParse(row);
     if (!parsed.success) continue;
@@ -87,6 +93,12 @@ export async function ingestCsvAction(rows: any[]) {
 }
 
 export async function queueResearchAction() {
+  const prisma = getPrismaClient();
+  if (!prisma) {
+    console.warn('[prospecting] queueResearchAction invoked without DATABASE_URL');
+    return;
+  }
+
   const prospects = await prisma.prospect.findMany({
     where: { status: 'new' },
     include: {
@@ -125,6 +137,12 @@ export async function queueResearchAction() {
 }
 
 export async function runDailySendsAction() {
+  const prisma = getPrismaClient();
+  if (!prisma) {
+    console.warn('[prospecting] runDailySendsAction invoked without DATABASE_URL');
+    return;
+  }
+
   const sequence = await prisma.sequence.findFirst({
     orderBy: { createdAt: 'asc' },
   });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -5,8 +5,22 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-export const prisma = globalThis.prisma || new PrismaClient();
+let prismaClient: PrismaClient | undefined;
 
-if (process.env.NODE_ENV !== 'production') {
-  globalThis.prisma = prisma;
+export function getPrismaClient(): PrismaClient | undefined {
+  if (!process.env.DATABASE_URL) {
+    return undefined;
+  }
+
+  if (!prismaClient) {
+    prismaClient = globalThis.prisma ?? new PrismaClient();
+
+    if (process.env.NODE_ENV !== 'production') {
+      globalThis.prisma = prismaClient;
+    }
+  }
+
+  return prismaClient;
 }
+
+export const prisma = getPrismaClient();


### PR DESCRIPTION
## Summary
- skip Prisma client initialization when DATABASE_URL is absent to avoid Netlify prerender failures
- short-circuit prospecting server actions and webhooks when the database is unavailable
- ensure the seed script fails fast without a configured database URL

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69013bb10bb48324b0f57e8529a10d17