### PR TITLE
Fix Prisma client export to satisfy type checking

### DIFF
--- a/scripts/seed-sequence.ts
+++ b/scripts/seed-sequence.ts
@@ -1,10 +1,4 @@
-import { getPrismaClient } from '../src/lib/prisma';
-
-const prisma = getPrismaClient();
-
-if (!prisma) {
-  throw new Error('DATABASE_URL is not set');
-}
+import { prisma } from '../src/lib/prisma';
 
 async function main() {
   const sequence = await prisma.sequence.upsert({

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -23,4 +23,12 @@ export function getPrismaClient(): PrismaClient | undefined {
   return prismaClient;
 }
 
-export const prisma = getPrismaClient();
+export const prisma = (() => {
+  const client = getPrismaClient();
+
+  if (!client) {
+    throw new Error('DATABASE_URL is not set');
+  }
+
+  return client;
+})();


### PR DESCRIPTION
## Summary
- ensure the Prisma singleton export throws when DATABASE_URL is missing so the client type is always defined
- update the seed script to rely on the guaranteed Prisma client and avoid nullable handling

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_69013e6c7cec8324ba93b5380d909248